### PR TITLE
Add global header/footer block architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Over time, this is intended to become the canonical source repository all `mu-plugins` on the WordPress.org network. At the moment, it only includes a few.
 
+## Usage
+
+1. Add to a project's `composer.json`, example
+1. run `composer update` to download it
+1. do in env/0-sandbox.php .  on production, it's already defined
+	```php
+	define( 'WPORG_GIT_MUPLUGINS_DIR', dirname( ABSPATH ) . '/vendor/wporg/wporg-mu-plugins' );
+	```
+1. `require_once` the files that you want. e.g., have a themes's `functions.php`
+	```php
+	require_once WPORG_GIT_MUPLUGINS_DIR . '/mu-plugins/blocks/global-header-footer/blocks.php';
+	```
 
 ## Sync/Deploy
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,22 @@ Over time, this is intended to become the canonical source repository all `mu-pl
 
 ## Usage
 
-1. Add to a project's `composer.json`, example
-1. run `composer update` to download it
-1. do in env/0-sandbox.php .  on production, it's already defined
+1. Add entries to the `repositories` and `require-dev` sections of `composer.json`. See `wporg-news-2021` as an example.
+1. Run `composer update` to install it
+1. Add a constant in `env/0-sandbox.php`:
 	```php
 	define( 'WPORG_GIT_MUPLUGINS_DIR', dirname( ABSPATH ) . '/vendor/wporg/wporg-mu-plugins' );
 	```
-1. `require_once` the files that you want. e.g., have a themes's `functions.php`
+1. `require_once` the files that you want. e.g.,
 	```php
 	require_once WPORG_GIT_MUPLUGINS_DIR . '/mu-plugins/blocks/global-header-footer/blocks.php';
 	```
+1. See individual plugin readmes for specific instructions
 
 ## Sync/Deploy
 
 The files here are commited to `dotorg.svn` so they can be deployed. The aren't synced to `meta.svn`, since they're already open.
 
-The other `mu-plugins` in `meta.svn` are not synced here. Eventually they'll be removed from `meta.svn` and added here, but until then they can stay where they are.
+The other `mu-plugins` in `meta.svn` are not synced here. Over time, they can be removed from `meta.svn` and added here.
 
 To sync these to `dotorg.svn`, run `composer exec sync-svn` (WIP) and follow the instructions. Once they're committed, you can deploy like normal.

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,17 @@
 		"sync-svn": {
 			"main-branch": "trunk",
 			"paths": {
-				"mu-plugins/": "https://dotorg.svn.wordpress.org/wordpress/website/wp-content/mu-plugins/git-sync/  -- todo: name this better, but probably want a subfolder in mu-plugins/ so can cleanly sync"
+				"mu-plugins/": "https://dotorg.svn.wordpress.org/wordpress/website/wp-content/mu-plugins/git-sync/  -- todo: come up with name this better, but probably want a subfolder in mu-plugins/ so can cleanly sync"
 			}
 		}
+	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "git@github.com:WordPress/wporg-repo-tools.git"
+		}
+	],
+	"require-dev": {
+		"wporg/wporg-repo-tools": "dev-trunk",
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,12 @@
 	"name": "wporg/wporg-mu-plugins",
 	"description": "`mu-plugins` for the WordPress.org network",
 	"license": "GPL-2.0-or-later",
-	"extra" : {
-		"sync-svn" : {
-			"main-branch" : "trunk",
-			"paths" : {
-				"mu-plugins/" : "https://dotorg.svn.wordpress.org/wordpress/website/wp-content/mu-plugins/git-sync/  -- todo: name this better, but probably want a subfolder in mu-plugins/ so can cleanly sync"
+	"require": {},
+	"extra": {
+		"sync-svn": {
+			"main-branch": "trunk",
+			"paths": {
+				"mu-plugins/": "https://dotorg.svn.wordpress.org/wordpress/website/wp-content/mu-plugins/git-sync/  -- todo: name this better, but probably want a subfolder in mu-plugins/ so can cleanly sync"
 			}
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,7 @@
 {
-    "name": "wordpress/wporg-mu-plugins",
-    "description": "`mu-plugins` for the WordPress.org network",
-    "license": "GPL-2.0-or-later",
-    "require": {},
+	"name": "wporg/wporg-mu-plugins",
+	"description": "`mu-plugins` for the WordPress.org network",
+	"license": "GPL-2.0-or-later",
 	"extra" : {
 		"sync-svn" : {
 			"main-branch" : "trunk",

--- a/mu-plugins/blocks/global-header-footer/README.md
+++ b/mu-plugins/blocks/global-header-footer/README.md
@@ -2,31 +2,18 @@
 
 ## Setup
 
-
-
-
 ## Register as a block (for Full Site Editing themes)
 
-Add as a composer dependency, install, then add this to a theme's `functions.php`:
-
-```php
-require_once WPORG_GIT_MUPLUGINS_DIR . '/mu-plugins/blocks/global-header-footer/blocks.php';
-```
-
+1. Add entries to the `repositories` and `require-dev` sections of `composer.json`
+1. Run `composer update` to install it
+1. `require_once .../global-header-footer/blocks.php` file. See `wporg-news-2021` as an example.
 
 ## Include directly in PHP (for classic themes)
 
-Add as a composer dependency, install, then
+The same as above, but include `universal-header.php` directly. See `{ todo }` as an example.
 
-```php
-require_once WPORG_GIT_MUPLUGINS_DIR . '/mu-plugins/blocks/global-header-footer/universal-header.php';
+## Embed as an iframe (for non-WP software like Trac, Codex, etc)
+
 ```
-
-todo path should be "blocks", or more generic like "components", "template-parts", ?
-
-
-## Embed as an iframe (for Trac, Codex, etc)
-
-<iframe ...>
-
-src=http...?embed_context=codex
+todo add example, maybe w/ something like `src=http...?embed_context=codex`
+```

--- a/mu-plugins/blocks/global-header-footer/README.md
+++ b/mu-plugins/blocks/global-header-footer/README.md
@@ -1,0 +1,32 @@
+# Global Header
+
+## Setup
+
+
+
+
+## Register as a block (for Full Site Editing themes)
+
+Add as a composer dependency, install, then add this to a theme's `functions.php`:
+
+```php
+require_once WPORG_GIT_MUPLUGINS_DIR . '/mu-plugins/blocks/global-header-footer/blocks.php';
+```
+
+
+## Include directly in PHP (for classic themes)
+
+Add as a composer dependency, install, then
+
+```php
+require_once WPORG_GIT_MUPLUGINS_DIR . '/mu-plugins/blocks/global-header-footer/universal-header.php';
+```
+
+todo path should be "blocks", or more generic like "components", "template-parts", ?
+
+
+## Embed as an iframe (for Trac, Codex, etc)
+
+<iframe ...>
+
+src=http...?embed_context=codex

--- a/mu-plugins/blocks/global-header-footer/README.md
+++ b/mu-plugins/blocks/global-header-footer/README.md
@@ -1,11 +1,8 @@
 # Global Header
 
-## Setup
-
 ## Register as a block (for Full Site Editing themes)
 
-1. Add entries to the `repositories` and `require-dev` sections of `composer.json`
-1. Run `composer update` to install it
+1. See `../../../README.md` for installation prerequsites.
 1. `require_once .../global-header-footer/blocks.php` file. See `wporg-news-2021` as an example.
 
 ## Include directly in PHP (for classic themes)

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WordPress_org\MU_Plugins\Global_Header_Footer;
+namespace WordPressdotorg\MU_Plugins\Global_Header_Footer;
 
 defined( 'WPINC' ) || die();
 
@@ -12,12 +12,12 @@ function register_assets() {
 	// don't want this visible in Inserter. need to create ticket for that?
 
 	register_block_type(
-		'wordpress-org/global-header',
+		'wporg/global-header',
 		array( 'render_callback' => __NAMESPACE__ . '\render_global_header' )
 	);
 
 	register_block_type(
-		'wordpress-org/global-footer',
+		'wporg/global-footer',
 		array( 'render_callback' => __NAMESPACE__ . '\render_global_footer' )
 	);
 }

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WordPress_org\MU_Plugins\Global_Header_Footer;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\register_assets', 9 );
+// why 9? if can be 10, then callers could be 9
+
+
+function register_assets() {
+	// don't want this visible in Inserter. need to create ticket for that?
+
+	register_block_type(
+		'wordpress-org/global-header',
+		array( 'render_callback' => __NAMESPACE__ . '\render_global_header' )
+	);
+
+	register_block_type(
+		'wordpress-org/global-footer',
+		array( 'render_callback' => __NAMESPACE__ . '\render_global_footer' )
+	);
+}
+
+/**
+ * Render the global header in a block context.
+ *
+ * @param array $attributes Block attributes.
+ *
+ * @return string
+ */
+function render_global_header( $attributes ) {
+	/*
+	todo
+	meta tags included called automaticaly in FSE themes
+	so the header needs to avoid adding them for FSE, or we need to disable FSE automatically adding them
+	*/
+
+	ob_start();
+	require_once __DIR__ . '/universal-header.php';
+	// cant include inside namespace b/c that messes things up?
+	// if so, is there a way to de-scope it?
+
+	return ob_get_clean();
+}
+
+/**
+ * Render the global footer in a block context.
+ *
+ * @param array $attributes Block attributes.
+ *
+ * @return string
+ */
+function render_global_footer( $attributes ) {
+	ob_start();
+	require_once __DIR__ . '/universal-footer.php';
+	return ob_get_clean();
+}
+
+
+// maybe make an api endpoint to serve this to codex/trac?
+
+ // all universal logic should go inside header.php, so that Trac, the Codex, etc can load it

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -1,16 +1,23 @@
 <?php
 
+/*
+ * This file should only contain logic related to blocks.
+ * Anything that applies to loading the header as raw PHP, iframe'ing, etc, should go in `universal-header.php`.
+ */
+
 namespace WordPressdotorg\MU_Plugins\Global_Header_Footer;
 
 defined( 'WPINC' ) || die();
 
-add_action( 'init', __NAMESPACE__ . '\register_assets', 9 );
-// why 9? if can be 10, then callers could be 9
+add_action( 'init', __NAMESPACE__ . '\register_block_types', 10 );
 
 
-function register_assets() {
-	// don't want this visible in Inserter. need to create ticket for that?
-
+/**
+ * Register block types
+ *
+ * These are intentionally missing arguments like `title`, `category`, `icon`, etc, because we don't want them showing up in the Block Inserter, regardless of which theme is running.
+ */
+function register_block_types() {
 	register_block_type(
 		'wporg/global-header',
 		array( 'render_callback' => __NAMESPACE__ . '\render_global_header' )
@@ -25,39 +32,21 @@ function register_assets() {
 /**
  * Render the global header in a block context.
  *
- * @param array $attributes Block attributes.
- *
  * @return string
  */
-function render_global_header( $attributes ) {
-	/*
-	todo
-	meta tags included called automaticaly in FSE themes
-	so the header needs to avoid adding them for FSE, or we need to disable FSE automatically adding them
-	*/
-
+function render_global_header() {
 	ob_start();
 	require_once __DIR__ . '/universal-header.php';
-	// cant include inside namespace b/c that messes things up?
-	// if so, is there a way to de-scope it?
-
 	return ob_get_clean();
 }
 
 /**
  * Render the global footer in a block context.
  *
- * @param array $attributes Block attributes.
- *
  * @return string
  */
-function render_global_footer( $attributes ) {
+function render_global_footer() {
 	ob_start();
 	require_once __DIR__ . '/universal-footer.php';
 	return ob_get_clean();
 }
-
-
-// maybe make an api endpoint to serve this to codex/trac?
-
- // all universal logic should go inside header.php, so that Trac, the Codex, etc can load it

--- a/mu-plugins/blocks/global-header-footer/universal-footer.php
+++ b/mu-plugins/blocks/global-header-footer/universal-footer.php
@@ -1,0 +1,5 @@
+<?php
+echo 'this is the global footer :)';
+return;
+
+

--- a/mu-plugins/blocks/global-header-footer/universal-header.php
+++ b/mu-plugins/blocks/global-header-footer/universal-header.php
@@ -1,0 +1,4 @@
+<?php
+echo 'this is the global header :)';
+return;
+


### PR DESCRIPTION
refactor of https://github.com/WordPress/wporg-repo-tools/pull/9

interconnected with https://github.com/WordPress/wporg-news-2021/pull/20

see https://github.com/WordPress/wporg-news-2021/issues/6

@coreymckrill , what do you think about this?