### PR TITLE
Add functional search to header

### DIFF
--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -32,40 +32,51 @@ if ( ! $is_fse_theme ) {
 	</figure>
 	<!-- /wp:image -->
 
-	<!-- wp:group {"className":"site-header__search-container"} -->
-	<div class="wp-block-group site-header__search-container">
-		<!-- wp:html -->
-		<button
-			aria-haspopup="true"
-			aria-expanded="false"
-			aria-label="Open search"
-			class="site-header__open-search"
-		>
-			<img
-				src="<?php echo esc_url( plugins_url( '/images/search.svg', __FILE__ ) ); ?>"
-				alt=""
-				width="18"
-				height="17"
-			/>
-		</button>
+	<!--
+		The search block is inside a navigation submenu, because that provides the exact functionality the design
+		calls for. It also provides a consistent experience with the primary navigation menu, with respect to
+		keyboard navigation, ARIA states, etc. It also saves having to write custom code for all the interactions.
+	-->
+	<!-- wp:navigation {"orientation":"vertical","className":"site-header__search","isResponsive":true} -->
+		<!-- wp:navigation-link {"label":"Search","url":"#","kind":"custom","isTopLevelLink":false} -->
+			<!-- wp:html -->
+			<!--
+				This markup is forked from the `wp:search` block. The only reason we're not using that, is because the
+				`action` URL can't be customized.
 
-		<button
-			aria-haspopup="false"
-			aria-expanded="false"
-			aria-label="Open search"
-			class="site-header__close-search"
-		>
-			<img
-				src="<?php echo esc_url( plugins_url( '/images/close.svg', __FILE__ ) ); ?>"
-				alt=""
-				width="21"
-				height="21"
-			/>
-		</button>
-		<!-- /wp:html -->
+				@link https://github.com/WordPress/gutenberg/issues/35572
 
-		<!-- wp:search {"className":"site-header__search-form","label":"Search","placeholder":"Search WordPress.org...","buttonText":"Submit search"} /-->
-	</div> <!-- /wp:group -->
+				The only things that changed were:
+
+				1) The `s` parameter is renamed to `search`, because `do-search.php` requires that.
+				2) The instance ID was changed to `99`, to make it likely to be unique.
+
+				If that issue is ever resolved, we should be able to replace this with the Search block, without having
+				to change any CSS.
+			-->
+			<form
+				role="search"
+				method="get"
+				action="https://wordpress.org/search/do-search.php"
+				class="wp-block-search__button-outside wp-block-search__text-button site-header__search-form wp-block-search"
+			>
+				<label for="wp-block-search__input-99" class="wp-block-search__label">Search</label>
+				<div class="wp-block-search__inside-wrapper">
+					<input
+						type="search"
+						id="wp-block-search__input-99"
+						class="wp-block-search__input"
+						name="search"
+						value=""
+						placeholder="Search WordPress.org..."
+						required=""
+					>
+					<button type="submit" class="wp-block-search__button" aria-label="Submit search"></button>
+				</div>
+			</form>
+			<!-- /wp:html -->
+		<!-- /wp:navigation-link -->
+	<!-- /wp:navigation -->
 
 	<!-- This is the first of two Get WordPress buttons; the other is in the navigation menu.
 		 Two are needed because they have different DOM hierarchies at different breakpoints. -->

--- a/mu-plugins/blocks/global-header-footer/images/close.svg
+++ b/mu-plugins/blocks/global-header-footer/images/close.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M0.203337 14.1297L14.3325 0.000504091L15.5386 1.20654L1.40938 15.3357L0.203337 14.1297Z" fill="white"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M14.3325 15.3352L0.203263 1.20604L1.4093 0L15.5385 14.1292L14.3325 15.3352Z" fill="white"/>
-</svg>

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -11,7 +11,7 @@
 /* Breakpoints should be synced with `wporg-parent-2021` (or `wporg-news-2021` until parent exists). */
 @custom-media --tablet (min-width: 890px);
 @custom-media --desktop (min-width: 1152px);
-@custom-media --desktop-wide (min-width: 1430px);
+@custom-media --desktop-wide (min-width: 1440px);
 
 /*
  * Shared styles
@@ -28,6 +28,12 @@
 	}
 }
 
+.wp-block-group.site-header {
+	& .wp-block-navigation__responsive-container-open[aria-expanded=true] {
+		visibility: hidden; /* Not needed when expanded, and behaves unintuitively. */
+	}
+}
+
 .wp-block-group.site-header,
 .wp-block-group.site-footer,
 .wp-block-group.site-header .wp-block-navigation:not(.has-background) .wp-block-navigation__responsive-container,
@@ -39,6 +45,25 @@
 
 	& .wp-block-image {
 		margin: 0;
+	}
+}
+
+.wp-block-group.site-header .site-header__navigation,
+.wp-block-group.site-header .site-header__search {
+	& .wp-block-navigation__responsive-container:not(.is-menu-open) {
+		display: none; /* Gutenberg has the menu hardcoded to open at 600px, but we need it to wait until `--tablet`. */
+
+		@media (--tablet) {
+			display: flex;
+		}
+	}
+
+	& .wp-block-navigation__responsive-container-open {
+		display: flex; /* Gutenberg has the button hardcoded to hide at 600px, but we need it to wait until `--tablet`. */
+
+		@media (--tablet) {
+			display: none;
+		}
 	}
 }
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -24,26 +24,6 @@
 		}
 	}
 
-	& .wp-block-navigation__responsive-container:not(.is-menu-open) {
-		display: none; /* Gutenberg has the menu hardcoded to open at 600px, but we need it to wait until `--tablet`. */
-
-		@media (--tablet) {
-			display: flex;
-		}
-	}
-
-	& .wp-block-navigation__responsive-container-open {
-		display: flex; /* Gutenberg has the button hardcoded to hide at 600px, but we need it to wait until `--tablet`. */
-
-		@media (--tablet) {
-			display: none;
-		}
-
-		&[aria-expanded=true] {
-			visibility: hidden; /* Not needed when expanded, and behaves strangely. */
-		}
-	}
-
 	& .wp-block-navigation__container {
 		padding: 0 0 var(--wp--custom--margin--vertical) 0;
 		row-gap: 0;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -41,7 +41,7 @@
 			background-size: 17px 17px;
 			background-image: url('../images/search.svg');
 			background-repeat: no-repeat;
-			background-position: top 10px left 5px;
+			background-position: center center;
 
 			& svg {
 				display: none;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -1,14 +1,98 @@
-.wp-block-group.site-header .site-header__search-container {
+.wp-block-group.site-header .site-header__search {
 	border-left: 1px solid var(--wp--preset--color--darker-grey);
 	border-right: 1px solid var(--wp--preset--color--darker-grey);
 
 	@media (--tablet) {
 		order: 3;
 		border-right: none;
-		padding-bottom: 28px;
+		padding-bottom: 0;
+	}
+
+	& .wp-block-navigation__responsive-container-open {
+		width: 24px;
+		height: 24px;
+		background-image: url('../images/search.svg');
+		background-repeat: no-repeat;
+		background-position: top 5px left 5px;
+
+		& svg {
+			display: none;
+		}
+	}
+
+	& .wp-block-navigation__container {
+		padding-top: 0;
+
+		& > .wp-block-navigation-item {
+			padding-bottom: 28px;
+		}
+	}
+
+	& .wp-block-navigation-item__label {
+		display: none;
+	}
+
+	& .wp-block-navigation__submenu-icon {
+		/* Replace the submenu icon with the search icon. */
+		@media (--tablet) {
+			display: inline-block;
+			width: 24px;
+			height: 24px;
+			background-size: 17px 17px;
+			background-image: url('../images/search.svg');
+			background-repeat: no-repeat;
+			background-position: top 10px left 5px;
+
+			& svg {
+				display: none;
+			}
+		}
+	}
+
+	& .wp-block-navigation__submenu-container {
+		@media (--tablet) {
+			width: 300px;
+			top: 47px;
+			right: -25px;
+			left: auto;
+			border: none;
+		}
 	}
 
 	& .site-header__search-form {
-		display: none;
+		& .wp-block-search__label {
+			@media (--tablet) {
+				display: none;
+			}
+		}
+
+		& .wp-block-search__input {
+			padding-right: 50px; /* Prevent user input from running into icon. */
+			border: none;
+			background-color: var(--wp--preset--color--white);
+			color: var(--wp--preset--color--dark-grey);
+			margin: 20px;
+		}
+
+		& .wp-block-search__button {
+			position: relative;
+			right: 60px;
+			top: 40px;
+			width: 24px;
+			height: 24px;
+			mask-image: url('../images/search.svg');
+			mask-repeat: no-repeat;
+			background-color: var(--wp--preset--color--dark-grey);
+
+			&:hover {
+				cursor: pointer;
+			}
+
+			@media (--tablet) {
+				position: absolute;
+				right: 15px;
+				top: 50px;
+			}
+		}
 	}
 }


### PR DESCRIPTION
See https://github.com/WordPress/wporg-news-2021/issues/6

Builds on top of https://github.com/WordPress/wporg-mu-plugins/pull/8 

Should roughly match the mockup, but not be pixel perfect. On mobile, click the icon to open menu; on desktop hover over it. searches should go to w.org/search to cover all sites.