### PR TITLE
Global nav refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Production-only files
 README-svn.txt
 build
+**/node_modules

--- a/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
@@ -7,6 +7,8 @@
 		background-color: var(--wp--preset--color--blue-1) !important; /* Override Gutenberg's !important */
 		color: var(--wp--preset--color--white);
 		padding: 10px 19px;
+		border-radius: 2px;
+		font-weight: bold;
 
 		& a {
 			margin: 0 auto;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -55,13 +55,16 @@
 
 			&.current-menu-item {
 				border-left: var(--active-menu-item-border-height) solid #7B90FF;
-				color: #7B90FF;
 				font-weight: bold;
 
 				@media (--tablet) {
 					padding-bottom: calc(37px - var(--active-menu-item-border-height));
 					border-bottom: var(--active-menu-item-border-height) solid #7B90FF;
 					border-left: none;
+				}
+
+				& a {
+					color: #7B90FF;
 				}
 			}
 		}
@@ -72,6 +75,16 @@
 	}
 
 	& .wp-block-navigation__container .wp-block-navigation__submenu-container {
+		font-size: 0.7em;
+		gap: 0.5em;
+		padding-bottom: calc(var(--wp--style--block-gap) / 2);
+
+		@media (--tablet) {
+			font-size: inherit;
+			gap: inherit;
+			padding-bottom: 0;
+		}
+
 		& .wp-block-navigation-item {
 			padding: 0;
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -137,3 +137,10 @@ body.admin-bar .global-header {
 		top: calc( 110px + var(--wp-admin--admin-bar--height) );
 	}
 }
+
+//this aligns the close button with the position of the burger menu icon
+.wp-block-navigation__responsive-container-close {
+	position: fixed;
+	right: calc( var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
+	top: 65px;
+}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -55,6 +55,8 @@
 
 			&.current-menu-item {
 				border-left: var(--active-menu-item-border-height) solid #7B90FF;
+				color: #7B90FF;
+				font-weight: bold;
 
 				@media (--tablet) {
 					padding-bottom: calc(37px - var(--active-menu-item-border-height));

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -138,7 +138,6 @@ body.admin-bar .global-header {
 	}
 }
 
-//this aligns the close button with the position of the burger menu icon
 .wp-block-navigation__responsive-container-close {
 	position: fixed;
 	right: calc( var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -129,6 +129,9 @@
 body:not(.admin-bar) .global-header {
 	& .wp-block-navigation__responsive-container.is-menu-open {
 		top: 110px;
+		&:not(.has-background) {
+			background: #1C2024;
+		}
 	}
 }
 
@@ -138,8 +141,13 @@ body.admin-bar .global-header {
 	}
 }
 
-.wp-block-navigation__responsive-container-close {
+.wp-block-group.global-header .wp-block-navigation__responsive-container-close {
 	position: fixed;
-	right: calc( var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
-	top: 65px;
+	right: 0; 
+	top: 0;
+	padding-bottom: 24px;
+	padding-left: var(--wp--style--block-gap);
+	padding-right:calc( var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width) );
+	padding-top: 63px;
+	background-color: #1C2024;
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -124,6 +124,19 @@
 	& .wp-block-navigation-item {
 		padding-bottom: 0;
 	}
+
+	& .wp-block-navigation__submenu-icon {
+		& svg {
+			display: none;
+		}
+		background-image: url("data:image/svg+xml,%3Csvg width='10' height='7' viewBox='0 0 10 7' fill='none' stroke='white' stroke-width='1.2' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.416667 1.33325L5 5.49992L9.58331 1.33325'%3E%3C/path%3E%3C/svg%3E");
+		background-repeat: no-repeat;
+		background-size: 100% auto;
+		display: inline-block;
+		vertical-align: middle;
+		width: 7px;
+		height: 4px;
+	}
 }
 
 body:not(.admin-bar) .global-header {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -42,6 +42,7 @@
 			background-image: url('../images/search.svg');
 			background-repeat: no-repeat;
 			background-position: center center;
+			margin-left: 0;
 
 			& svg {
 				display: none;


### PR DESCRIPTION
This PR introduces refinements to the global header defined over at https://github.com/WordPress/wporg-news-2021/issues/86

So far this includes:

- [x] The active menu link (News in this case) should be **bold** and highlighted through color `#7B90FF`
- [x] The "Get WordPress" button should have a `2px` border radius and its text should be **bold**
- [x] Search icon should be centered to its container

**On mobile:**

- [x] Let's decrease the text size of the submenu items
- [x] "Close" icon should be inside its container
- [x] "Close" section and the menu's background should be a darker shade specified in Figma `#1C2024`

TO DO (these affect directly the block's functionality):

- [x] Arrows in Global Nav Bar should match with Local Nav Bar's
- [ ] The header responsiveness isn't ideal at the moment, because the links jump straight into the smallest version of the `…` nav, when they should go in there gradually. Here's what we could use to improve that: https://css-tricks.com/the-priority-navigation-pattern/
