### PR TITLE
Add priority navigation script

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -20,6 +20,14 @@ function register_block_types() {
 		filemtime( __DIR__ . '/build/style.css' )
 	);
 
+	wp_enqueue_script(
+		'wporg-global-header-script',
+		plugins_url( '/js/wporg-global-header-script.js', __FILE__ ), 
+		array(), 
+		wp_get_theme()->get( 'Version' ), 
+		true
+	);
+
 	register_block_type(
 		'wporg/global-header',
 		array(

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -101,23 +101,14 @@ if ( ! $is_fse_theme ) {
 			<!-- wp:navigation-link {"label":"Forums","url":"https://wordpress.org/support/forums/","kind":"custom","isTopLevelLink":true} /-->
 		<!-- /wp:navigation-link -->
 		<!-- wp:navigation-link {"label":"News","url":"https://wordpress.org/news","kind":"custom","isTopLevelLink":true,"className":"current-menu-item"} /-->
-		<!-- wp:navigation-link {"label":"About","url":"https://wordpress.org/about/","kind":"custom","isTopLevelLink":true,"className":"global-header__overflow-item"} /-->
-		<!-- wp:navigation-link {"label":"Get Involved","url":"https://make.wordpress.org/","kind":"custom","isTopLevelLink":false,"className":"global-header__overflow-item"} -->
+		<!-- wp:navigation-link {"label":"About","url":"https://wordpress.org/about/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"Get Involved","url":"https://make.wordpress.org/","kind":"custom","isTopLevelLink":false} -->
 			<!-- wp:navigation-link {"label":"Five for the Future","url":"https://wordpress.org/five-for-the-future/","kind":"custom","isTopLevelLink":true} /-->
 		<!-- /wp:navigation-link -->
-		<!-- wp:navigation-link {"label":"Showcase","url":"https://wordpress.org/showcase/","kind":"custom","isTopLevelLink":true,"className":"global-header__overflow-item"} /-->
-		<!-- wp:navigation-link {"label":"Mobile","url":"https://wordpress.org/mobile/","kind":"custom","isTopLevelLink":true,"className":"global-header__overflow-item"} /-->
-		<!-- wp:navigation-link {"label":"Hosting","url":"https://wordpress.org/hosting/","kind":"custom","isTopLevelLink":true,"className":"global-header__overflow-item"} /-->
-		<!-- wp:navigation-link {"label":"Openverse","url":"https://wordpress.org/openverse/","kind":"custom","isTopLevelLink":true,"className":"global-header__overflow-item"} /-->
-		<!-- wp:navigation-link {"label":"...","url":"#","kind":"custom","isTopLevelLink":false,"className":"global-header__overflow-menu"} -->
-			<!-- wp:navigation-link {"label":"About","url":"https://wordpress.org/about/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"Get Involved","url":"https://make.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"Five for the Future","url":"https://wordpress.org/five-for-the-future/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"Showcase","url":"https://wordpress.org/showcase/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"Mobile","url":"https://wordpress.org/mobile/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"Hosting","url":"https://wordpress.org/hosting/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"Openverse","url":"https://wordpress.org/openverse/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- /wp:navigation-link -->
+		<!-- wp:navigation-link {"label":"Showcase","url":"https://wordpress.org/showcase/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"Mobile","url":"https://wordpress.org/mobile/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"Hosting","url":"https://wordpress.org/hosting/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"Openverse","url":"https://wordpress.org/openverse/","kind":"custom","isTopLevelLink":true} /-->
 		<!-- wp:navigation-link {"label":"Get WordPress","url":"https://wordpress.org/download/","kind":"custom","isTopLevelLink":true,"className":"global-header__mobile-get-wordpress global-header__get-wordpress"} /-->
 	<!-- /wp:navigation -->
 </header> <!-- /wp:group -->

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -5,8 +5,7 @@
  * https://css-tricks.com/the-priority-navigation-pattern/
  * 
  */
-//TODO: consider the ... menu item in the widths calculations
-( function () {
+ ( function () {
 
 	/**
 	 * Menu Responsive navigation
@@ -56,6 +55,9 @@
 		this.hideExtraItems = function() {
 
 			let totalWidth = 0;
+			//not pretty! but it's not likely to change
+			const dotMenuWidth = 83;
+			totalWidth += dotMenuWidth;
 			this.resetMenu();
 
 			for (var i = 0, len = this.itemsWidths.length; i < len; i++ ) {
@@ -115,7 +117,6 @@
 			//TODO:
 			//if the menu is responsive, reset everything and leave the menu as it was
 			//else check if all the elements have enough space inside the wrapper
-			console.log(this);
 			this.resetMenu();
 			this.hideExtraItems();
 			this.populateExtendedSubmenu();

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -127,9 +127,6 @@
 		}
 
 		window.addEventListener( 'resize', function () {
-			//TODO:
-			//if the menu is responsive, reset everything and leave the menu as it was
-			//else check if all the elements have enough space inside the wrapper
 			this.resetMenu();
 			if( !this.isResponsive() ) {
 				this.hideExtraItems();

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -27,10 +27,17 @@
 			for (const el of this.listItems) {
 				el.classList.remove('global-header__overflow-item');
 			}
-			if(document.querySelector('global-header__overflow-menu')){
-				document.querySelector('global-header__overflow-menu').remove();
-			}
+			this.removeSubMenu();
 			this.hasHiddenItems = false;
+		}
+
+		/**
+		 * Removes the ... submenu
+		 */
+		this.removeSubMenu = function() {
+			if(this.wrapper.querySelector('.global-header__overflow-menu')){
+				this.wrapper.querySelector('.global-header__overflow-menu').remove();
+			}
 		}
 
 		/**
@@ -69,13 +76,33 @@
 		this.populateExtendedSubmenu = function() {
 			if( this.hasHiddenItems ) {
 
-				//create the ... menu item
+				this.removeSubMenu();
+
 				let itemsContainer = this.wrapper.querySelector(".wp-block-navigation__container");
+
+				//create the ... menu list item
 				let newItem = document.createElement('li');
-				newItem.classList.add("wp-block-navigation-item", "wp-block-navigation-link", "global-header__overflow-menu");
-				newItem.appendChild(document.createTextNode('...'));
+				newItem.classList.add("wp-block-navigation-item", "wp-block-navigation-link", "has-child", "global-header__overflow-menu");
+
+				let newLink = document.createElement('a');
+				newLink.classList.add("wp-block-navigation-item__content");
+				newLink.appendChild(document.createTextNode('...'));
+				newItem.appendChild(newLink);
+
+				//create the submenu where the hidden links will live
+				let newSubMenu = document.createElement('ul'); 
+				newSubMenu.classList.add("wp-block-navigation__submenu-container");
+				newItem.appendChild(newSubMenu);
+
+				//populate submenu with clones of the hidden menu items
+				for (const el of this.listItems) {
+					if( el.classList.contains("global-header__overflow-item") ){
+						let clone = el.cloneNode(true);
+						newSubMenu.appendChild(clone); 
+					}
+				}
+
 				itemsContainer.appendChild(newItem);
-				console.log(this.listItems);
 
 			}
 		}
@@ -84,20 +111,20 @@
 		this.hideExtraItems();
 		this.populateExtendedSubmenu();
 
-	};
+		window.addEventListener( 'resize', function () {
+			//TODO:
+			//if the menu is responsive, reset everything and leave the menu as it was
+			//else check if all the elements have enough space inside the wrapper
+			console.log(this);
+			this.resetMenu();
+			this.hideExtraItems();
+			this.populateExtendedSubmenu();
+		}.bind(this) );
 
+	};
 
 	window.addEventListener( 'load', function () {
 		new navMenu('.global-header .global-header__navigation');
-	} );
-
-	/**
-	 * Check visible menu items on window resize
-	 */
-	window.addEventListener( 'resize', function () {
-		new navMenu('.global-header .global-header__navigation');
-		//if the menu is responsive, reset everything and leave the menu as it was
-		//else check if all the elements have enough space inside the wrapper
 	} );
 
 } )();

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -1,0 +1,103 @@
+/**
+ * File wporg-global-header-script.js.
+ *
+ * Applies a priority navigation pattern to the header menu.
+ * https://css-tricks.com/the-priority-navigation-pattern/
+ * 
+ */
+//TODO: consider the ... menu item in the widths calculations
+( function () {
+
+	/**
+	 * Menu Responsive navigation
+	 *
+	 * @param {Element} element
+	 */
+	const navMenu = function ( selector ) {
+
+		this.wrapper = document.querySelector(selector);
+		this.listItems = this.wrapper.getElementsByTagName("li");
+		this.itemsWidths = [];
+		this.hasHiddenItems = false;
+		
+		/**
+		 * Resets the menu item classes and removes the extra submenu
+		 */
+		this.resetMenu = function() {
+			for (const el of this.listItems) {
+				el.classList.remove('global-header__overflow-item');
+			}
+			if(document.querySelector('global-header__overflow-menu')){
+				document.querySelector('global-header__overflow-menu').remove();
+			}
+			this.hasHiddenItems = false;
+		}
+
+		/**
+		 * Saves an array with the widths of the menu items
+		 */
+		this.getItemWidths = function() {
+			for (const el of this.listItems) {
+				el.classList.remove('global-header__overflow-item');
+				this.itemsWidths.push( el.offsetWidth );
+			}
+		}
+
+		/**
+		 * Hide menu items that exceed the container's width
+		 */
+		this.hideExtraItems = function() {
+
+			let totalWidth = 0;
+			this.resetMenu();
+
+			for (var i = 0, len = this.itemsWidths.length; i < len; i++ ) {
+				totalWidth += this.itemsWidths[i];
+				if( totalWidth >= this.wrapper.offsetWidth ) {
+					this.listItems[i].classList.add("global-header__overflow-item");
+					if( !this.hasHiddenItems ) {
+						this.hasHiddenItems = true;
+					}
+				}
+			}
+
+		}
+
+		/**
+		 * Generates an extra menu item with all the hidden elements inside it
+		 */
+		this.populateExtendedSubmenu = function() {
+			if( this.hasHiddenItems ) {
+
+				//create the ... menu item
+				let itemsContainer = this.wrapper.querySelector(".wp-block-navigation__container");
+				let newItem = document.createElement('li');
+				newItem.classList.add("wp-block-navigation-item", "wp-block-navigation-link", "global-header__overflow-menu");
+				newItem.appendChild(document.createTextNode('...'));
+				itemsContainer.appendChild(newItem);
+				console.log(this.listItems);
+
+			}
+		}
+
+		this.getItemWidths();
+		this.hideExtraItems();
+		this.populateExtendedSubmenu();
+
+	};
+
+
+	window.addEventListener( 'load', function () {
+		new navMenu('.global-header .global-header__navigation');
+	} );
+
+	/**
+	 * Check visible menu items on window resize
+	 */
+	window.addEventListener( 'resize', function () {
+		new navMenu('.global-header .global-header__navigation');
+		//if the menu is responsive, reset everything and leave the menu as it was
+		//else check if all the elements have enough space inside the wrapper
+	} );
+
+} )();

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -109,17 +109,32 @@
 			}
 		}
 
-		this.getItemWidths();
-		this.hideExtraItems();
-		this.populateExtendedSubmenu();
+		/**
+		 * Checks if the responsive menu is visible
+		 */
+		this.isResponsive = function() {
+			let burgerButton = this.wrapper.querySelector('.wp-block-navigation__responsive-container-open');
+			if( burgerButton.offsetWidth > 0 ){
+				return true;
+			}
+			return false;
+		}
+
+		if( !this.isResponsive() ) {
+			this.getItemWidths();
+			this.hideExtraItems();
+			this.populateExtendedSubmenu();
+		}
 
 		window.addEventListener( 'resize', function () {
 			//TODO:
 			//if the menu is responsive, reset everything and leave the menu as it was
 			//else check if all the elements have enough space inside the wrapper
 			this.resetMenu();
-			this.hideExtraItems();
-			this.populateExtendedSubmenu();
+			if( !this.isResponsive() ) {
+				this.hideExtraItems();
+				this.populateExtendedSubmenu();
+			}
 		}.bind(this) );
 
 	};

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -80,30 +80,14 @@
 	}
 
 	& .wp-block-navigation__container .wp-block-navigation-item.global-header__overflow-menu {
-		display: none;
-
-		& .wp-block-navigation__submenu-icon {
-			display: none;
-		}
 
 		@media (--tablet) {
-			display: inherit;
 			padding-right: 60px; /* Give the user more space to keep the menu hovered/open while they move their mouse to the submenu. */
-		}
-
-		@media (--desktop-wide) {
-			display: none;
 		}
 	}
 
 	& .global-header__overflow-item {
-		@media (--tablet) {
-			display: none;
-		}
-
-		@media (--desktop-wide) {
-			display: inherit;
-		}
+		display: none;
 	}
 
 	& .wp-block-navigation-item {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -84,6 +84,14 @@
 		@media (--tablet) {
 			padding-right: 60px; /* Give the user more space to keep the menu hovered/open while they move their mouse to the submenu. */
 		}
+
+		& .global-header__overflow-item {
+			display: inherit;
+		}
+
+		& .global-header__get-wordpress {
+			display: none;
+		}
 	}
 
 	& .global-header__overflow-item {


### PR DESCRIPTION
Continues work for https://github.com/WordPress/wporg-news-2021/issues/86

> The header responsiveness isn't ideal at the moment, because the links jump straight into the smallest version of the … nav, when they should go in there gradually. Here's what we could use to improve that: https://css-tricks.com/the-priority-navigation-pattern/

I simplified the navigation markup to include just what you see when the full menu is on display. This makes the script work no matter the content of the menu (as long as the default classes remain the same) so it will work for other languages too.

The script detects the width of the visible menu elements and hides the last ones when the sum of their widths is bigger than the width of the parent, then adds a flag that there are some hidden items.

When the flag is true, we clone the hidden items into a new submenu that is created programmatically.

![Screen Capture on 2021-12-02 at 17-53-14](https://user-images.githubusercontent.com/3593343/144467098-1344e600-d7ca-4e00-99d4-a649f2a757b4.gif)

