### PR TITLE
Footer font should be smaller

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
@@ -1,5 +1,6 @@
 .wp-block-group.global-footer {
 	padding: 44px var(--wp--custom--alignment--edge-spacing);
+	font-size: 13px;
 
 	@media (--tablet) {
 		padding-top: 69px;


### PR DESCRIPTION
Per figma. See https://github.com/WordPress/wporg-news-2021/issues/101#issuecomment-985065056