### PR TITLE
Navigation: Return early if no nav wrapper is found.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -15,6 +15,11 @@
 	const navMenu = function ( selector ) {
 
 		this.wrapper = document.querySelector(selector);
+
+		if ( ! this.wrapper ) {
+			return;
+		}
+
 		this.listItems = this.wrapper.getElementsByTagName("li");
 		this.itemsWidths = [];
 		this.hasHiddenItems = false;


### PR DESCRIPTION
This script is loaded on all w.org sites, but not all sites have the new header yet. This change prevents a JS error when `wrapper` is null.