### PR TITLE
Header Navigation: Update styles to match design

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -36,4 +36,15 @@
 	& .global-header__close-menu {
 		display: none;
 	}
+
+	& .wp-block-navigation__responsive-container-close {
+		position: fixed;
+		right: 0;
+		top: var(--wp-admin--admin-bar--height, 0);
+		padding-bottom: 24px;
+		padding-left: var(--wp--style--block-gap);
+		padding-right: calc(var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
+		padding-top: 63px;
+		background-color: #1c2024;
+	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -21,6 +21,10 @@
 			& .wp-block-navigation__container {
 				line-height: 1em;
 			}
+
+			& .wp-block-navigation__submenu-icon {
+				display: none;
+			}
 		}
 	}
 
@@ -70,14 +74,11 @@
 		}
 	}
 
-	& .wp-block-navigation .wp-block-navigation__responsive-container.is-menu-open .has-child .wp-block-navigation__submenu-container {
-		padding-top: calc(var(--wp--style--block-gap) / 2);
-	}
-
 	& .wp-block-navigation__container .wp-block-navigation__submenu-container {
-		font-size: 0.7em;
+		font-size: 15px;
 		gap: 0.5em;
 		padding-bottom: calc(var(--wp--style--block-gap) / 2);
+		padding-left: calc(var(--wp--style--block-gap) / 2);
 
 		@media (--tablet) {
 			font-size: inherit;
@@ -86,11 +87,7 @@
 		}
 
 		& .wp-block-navigation-item {
-			padding: 0;
-
-			@media (--tablet) {
-				padding: calc(var(--wp--style--block-gap) / 2);
-			}
+			padding: calc(var(--wp--style--block-gap) / 4);
 		}
 	}
 
@@ -144,15 +141,4 @@ body.admin-bar .global-header {
 	& .wp-block-navigation__responsive-container.is-menu-open {
 		top: calc( 110px + var(--wp-admin--admin-bar--height) );
 	}
-}
-
-.wp-block-group.global-header .wp-block-navigation__responsive-container-close {
-	position: fixed;
-	right: 0; 
-	top: 0;
-	padding-bottom: 24px;
-	padding-left: var(--wp--style--block-gap);
-	padding-right:calc( var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width) );
-	padding-top: 63px;
-	background-color: #1C2024;
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -102,4 +102,8 @@
 			}
 		}
 	}
+
+	& .wp-block-navigation__responsive-container-close {
+		right: 75px;
+	}
 }


### PR DESCRIPTION
I think this is all that's left to wrap up https://github.com/WordPress/wporg-news-2021/issues/86, updating the submenu text size and spacing, and fixing the X close buttons on search & the menu.

| Before | After |
|--------|------|
| ![before-menu](https://user-images.githubusercontent.com/541093/145280047-19b1a6b6-cc1c-49c9-8914-4a5945180d2f.png) | ![after-menu](https://user-images.githubusercontent.com/541093/145280041-6531b4b3-2de0-44d8-9e6e-c580796bf912.png) |
| ![before-menu-with-ab](https://user-images.githubusercontent.com/541093/145280046-011d14df-93bc-4a18-9da8-9cfd7e76215e.png) | ![after-menu-with-ab](https://user-images.githubusercontent.com/541093/145280040-277ce253-2bf4-41ec-900c-d17922e27524.png) |
| ![Screen Shot 2021-12-08 at 15 33 30](https://user-images.githubusercontent.com/541093/145280247-b2f56d66-4b04-4674-a9b6-4a1023bc7c70.png) | ![after-search-with-ab](https://user-images.githubusercontent.com/541093/145280044-cc9305fb-dcaa-4050-aa80-66a86ba5ccfa.png) |
