### PR TITLE
Footer: increase spacing above logos

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -2,7 +2,7 @@
 	position: relative;
 	display: flex;
 	flex-wrap: wrap;
-	margin-top: calc(66px - var(--wp--style--block-gap));
+	margin-top: 60px;
 
 	@media (--tablet) {
 		justify-content: space-between;


### PR DESCRIPTION
Quick PR to increase the spacing above the logos in the footer, as mentioned in https://github.com/WordPress/wporg-mu-plugins/pull/27.

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/1645628/145383051-aed7f27d-ed96-4bbb-bb94-92a2a3140fec.png)   |  ![image](https://user-images.githubusercontent.com/1645628/145382948-343a066a-df5f-4de5-9c4b-5f3c8f4def88.png)   |