### PR TITLE
Navigation menu: Fix alignment, background color, and font size.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -31,10 +31,12 @@
 		};
 
 		/**
-		 * Get the visible list items (filtering on display hides the extra "Get WordPress" link).
+		 * Get the top-level list items.
 		 */
 		this.getListItems = function () {
-			return this.wrapper.querySelectorAll( 'li:not(.global-header__mobile-get-wordpress)' );
+			return this.wrapper.querySelectorAll(
+				'.wp-block-navigation__container > li:not(.global-header__mobile-get-wordpress)'
+			);
 		};
 
 		/**
@@ -61,10 +63,9 @@
 		 * Hide menu items that exceed the container's width
 		 */
 		this.hideExtraItems = function () {
-			let totalWidth = 0;
 			//not pretty! but it's not likely to change
 			const dotMenuWidth = 83;
-			totalWidth += dotMenuWidth;
+			let totalWidth = dotMenuWidth;
 			this.resetMenu();
 
 			for ( let i = 0, len = this.itemsWidths.length; i < len; i++ ) {

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -3,147 +3,161 @@
  *
  * Applies a priority navigation pattern to the header menu.
  * https://css-tricks.com/the-priority-navigation-pattern/
- * 
+ *
  */
- ( function () {
-
+( function () {
 	/**
 	 * Menu Responsive navigation
 	 *
-	 * @param {Element} element
+	 * @param {string} selector
 	 */
 	const navMenu = function ( selector ) {
-
-		this.wrapper = document.querySelector(selector);
+		this.wrapper = document.querySelector( selector );
 
 		if ( ! this.wrapper ) {
 			return;
 		}
 
-		this.listItems = this.wrapper.getElementsByTagName("li");
-		this.itemsWidths = [];
-		this.hasHiddenItems = false;
-		
 		/**
 		 * Resets the menu item classes and removes the extra submenu
 		 */
-		this.resetMenu = function() {
-			for (const el of this.listItems) {
-				el.classList.remove('global-header__overflow-item');
+		this.resetMenu = function () {
+			for ( const el of this.listItems ) {
+				el.classList.remove( 'global-header__overflow-item' );
 			}
 			this.removeSubMenu();
 			this.hasHiddenItems = false;
-		}
+			this.listItems = this.getListItems();
+		};
+
+		/**
+		 * Get the visible list items (filtering on display hides the extra "Get WordPress" link).
+		 */
+		this.getListItems = function () {
+			return this.wrapper.querySelectorAll( 'li:not(.global-header__mobile-get-wordpress)' );
+		};
 
 		/**
 		 * Removes the ... submenu
 		 */
-		this.removeSubMenu = function() {
-			if(this.wrapper.querySelector('.global-header__overflow-menu')){
-				this.wrapper.querySelector('.global-header__overflow-menu').remove();
+		this.removeSubMenu = function () {
+			if ( this.wrapper.querySelector( '.global-header__overflow-menu' ) ) {
+				this.wrapper.querySelector( '.global-header__overflow-menu' ).remove();
 			}
-		}
+		};
 
 		/**
 		 * Saves an array with the widths of the menu items
 		 */
-		this.getItemWidths = function() {
-			for (const el of this.listItems) {
-				el.classList.remove('global-header__overflow-item');
+		this.getItemWidths = function () {
+			this.itemsWidths = [];
+			for ( const el of this.listItems ) {
+				el.classList.remove( 'global-header__overflow-item' );
 				this.itemsWidths.push( el.offsetWidth );
 			}
-		}
+		};
 
 		/**
 		 * Hide menu items that exceed the container's width
 		 */
-		this.hideExtraItems = function() {
-
+		this.hideExtraItems = function () {
 			let totalWidth = 0;
 			//not pretty! but it's not likely to change
 			const dotMenuWidth = 83;
 			totalWidth += dotMenuWidth;
 			this.resetMenu();
 
-			for (var i = 0, len = this.itemsWidths.length; i < len; i++ ) {
-				totalWidth += this.itemsWidths[i];
-				if( totalWidth >= this.wrapper.offsetWidth ) {
-					this.listItems[i].classList.add("global-header__overflow-item");
-					if( !this.hasHiddenItems ) {
+			for ( let i = 0, len = this.itemsWidths.length; i < len; i++ ) {
+				totalWidth += this.itemsWidths[ i ];
+				// If this is the last item, we don't need to account for the … menu item.
+				if ( i === len - 1 ) {
+					totalWidth -= dotMenuWidth;
+				}
+				if ( totalWidth >= this.wrapper.offsetWidth ) {
+					this.listItems[ i ].classList.add( 'global-header__overflow-item' );
+					if ( ! this.hasHiddenItems ) {
 						this.hasHiddenItems = true;
 					}
 				}
 			}
-
-		}
+		};
 
 		/**
 		 * Generates an extra menu item with all the hidden elements inside it
 		 */
-		this.populateExtendedSubmenu = function() {
-			if( this.hasHiddenItems ) {
-
+		this.populateExtendedSubmenu = function () {
+			if ( this.hasHiddenItems ) {
 				this.removeSubMenu();
 
-				let itemsContainer = this.wrapper.querySelector(".wp-block-navigation__container");
+				let itemsContainer = this.wrapper.querySelector( '.wp-block-navigation__container' );
 
 				//create the ... menu list item
-				let newItem = document.createElement('li');
-				newItem.classList.add("wp-block-navigation-item", "wp-block-navigation-link", "has-child", "global-header__overflow-menu");
+				let newItem = document.createElement( 'li' );
+				newItem.classList.add(
+					'wp-block-navigation-item',
+					'wp-block-navigation-link',
+					'has-child',
+					'global-header__overflow-menu'
+				);
 
-				let newLink = document.createElement('a');
-				newLink.classList.add("wp-block-navigation-item__content");
-				newLink.setAttribute("href","#");
-				newLink.appendChild(document.createTextNode('...'));
-				newItem.appendChild(newLink);
+				let newLink = document.createElement( 'a' );
+				newLink.classList.add( 'wp-block-navigation-item__content' );
+				newLink.setAttribute( 'href', '#' );
+				newLink.appendChild( document.createTextNode( '...' ) );
+				newItem.appendChild( newLink );
 
 				//create the submenu where the hidden links will live
-				let newSubMenu = document.createElement('ul'); 
-				newSubMenu.classList.add("wp-block-navigation__submenu-container");
-				newItem.appendChild(newSubMenu);
+				let newSubMenu = document.createElement( 'ul' );
+				newSubMenu.classList.add( 'wp-block-navigation__submenu-container' );
+				newItem.appendChild( newSubMenu );
 
 				//populate submenu with clones of the hidden menu items
-				for (const el of this.listItems) {
-					if( el.classList.contains("global-header__overflow-item") ){
-						let clone = el.cloneNode(true);
-						newSubMenu.appendChild(clone); 
+				for ( const el of this.listItems ) {
+					if ( el.classList.contains( 'global-header__overflow-item' ) ) {
+						let clone = el.cloneNode( true );
+						newSubMenu.appendChild( clone );
 					}
 				}
 
-				itemsContainer.appendChild(newItem);
-
+				itemsContainer.appendChild( newItem );
 			}
-		}
+		};
 
 		/**
 		 * Checks if the responsive menu is visible
 		 */
-		this.isResponsive = function() {
-			let burgerButton = this.wrapper.querySelector('.wp-block-navigation__responsive-container-open');
-			if( burgerButton.offsetWidth > 0 ){
+		this.isResponsive = function () {
+			let burgerButton = this.wrapper.querySelector( '.wp-block-navigation__responsive-container-open' );
+			if ( burgerButton.offsetWidth > 0 ) {
 				return true;
 			}
 			return false;
-		}
+		};
 
-		if( !this.isResponsive() ) {
+		this.listItems = this.getListItems();
+		this.itemsWidths = [];
+		this.hasHiddenItems = false;
+
+		if ( ! this.isResponsive() ) {
 			this.getItemWidths();
 			this.hideExtraItems();
 			this.populateExtendedSubmenu();
 		}
 
-		window.addEventListener( 'resize', function () {
-			this.resetMenu();
-			if( !this.isResponsive() ) {
-				this.hideExtraItems();
-				this.populateExtendedSubmenu();
-			}
-		}.bind(this) );
-
+		window.addEventListener(
+			'resize',
+			function () {
+				this.resetMenu();
+				if ( ! this.isResponsive() ) {
+					this.getItemWidths();
+					this.hideExtraItems();
+					this.populateExtendedSubmenu();
+				}
+			}.bind( this )
+		);
 	};
 
 	window.addEventListener( 'load', function () {
-		new navMenu('.global-header .global-header__navigation');
+		new navMenu( '.global-header .global-header__navigation' );
 	} );
-
 } )();

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -31,8 +31,7 @@
 }
 
 .wp-block-group.global-header,
-.wp-block-group.global-footer,
-.wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
+.wp-block-group.global-footer {
 	--active-menu-item-border-height: 4px;
 
 	background-color: var(--wp--preset--color--dark-grey);
@@ -41,6 +40,18 @@
 
 .wp-block-group.global-header .global-header__navigation,
 .wp-block-group.global-header .global-header__search {
+	&:not(.has-background) .wp-block-navigation__responsive-container,
+	&:not(.has-background) .wp-block-navigation__submenu-container {
+		background-color: var(--wp--preset--color--darker-grey);
+		color: var(--wp--preset--color--white);
+		font-size: var(--wp--preset--font-size--large);
+
+		@media (--tablet) {
+			background-color: var(--wp--preset--color--dark-grey);
+			font-size: var(--wp--preset--font-size--small);
+		}
+	}
+
 	& .wp-block-navigation__responsive-container:not(.is-menu-open) {
 		display: none; /* Gutenberg has the menu hardcoded to open at 600px, but we need it to wait until `--tablet`. */
 

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -32,7 +32,6 @@
 
 .wp-block-group.global-header,
 .wp-block-group.global-footer,
-.wp-block-group.global-header .wp-block-navigation:not(.has-background) .wp-block-navigation__responsive-container,
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	--active-menu-item-border-height: 4px;
 

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -44,11 +44,11 @@
 	&:not(.has-background) .wp-block-navigation__submenu-container {
 		background-color: var(--wp--preset--color--darker-grey);
 		color: var(--wp--preset--color--white);
-		font-size: var(--wp--preset--font-size--large);
+		font-size: 21px;
 
 		@media (--tablet) {
 			background-color: var(--wp--preset--color--dark-grey);
-			font-size: var(--wp--preset--font-size--small);
+			font-size: 13px;
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -41,10 +41,10 @@
 		position: fixed;
 		right: 0;
 		top: var(--wp-admin--admin-bar--height, 0);
-		padding-bottom: 24px;
-		padding-left: var(--wp--style--block-gap);
+		padding-top: 70px; /* Magic numbers to center the 24px icon in 117px height. */
 		padding-right: calc(var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
-		padding-top: 63px;
-		background-color: #1c2024;
+		padding-bottom: 23px; /* Magic numbers to center the 24px icon in 117px height. */
+		padding-left: var(--wp--style--block-gap);
+		background-color: var(--wp--preset--color--black);
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -58,6 +58,6 @@
 		padding-right: calc(var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
 		padding-bottom: 23px; /* Magic numbers to center the 24px icon in 117px height. */
 		padding-left: var(--wp--style--block-gap);
-		background-color: var(--wp--preset--color--black);
+		background-color: var(--wp--preset--color--darker-grey);
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -1,6 +1,6 @@
 .wp-block-group.global-header {
 	display: flex;
-	align-items: center;
+	align-items: flex-end;
 	font-size: 21px;
 
 	@media (--tablet) {
@@ -9,15 +9,28 @@
 
 	& > * {
 		flex-shrink: 0;
-		padding-top: 60px;
-		padding-bottom: 17px;
-		padding-right: var(--wp--style--block-gap);
-		padding-left: var(--wp--style--block-gap);
+		padding: 60px var(--wp--style--block-gap) 17px;
 		margin: 0 auto;
 
 		@media (--tablet) {
 			padding-top: 37px;
 			padding-bottom: 37px;
+		}
+	}
+
+	& .global-header__search,
+	& .global-header__navigation {
+		padding: 0;
+
+		& .wp-block-navigation__responsive-container-open {
+
+			/* Magic numbers to center the 24px icon in 117px height. */
+			padding: 70px var(--wp--style--block-gap) 23px;
+
+			@media (--tablet) {
+				padding-top: 37px;
+				padding-bottom: 37px;
+			}
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -1,7 +1,9 @@
 .wp-block-group.global-header {
 	& .global-header__wporg-logo-mark,
 	& .global-header__wporg-logo-full {
-		border-right: 1px solid var(--wp--preset--color--darker-grey);
+		@media (--tablet) {
+			border-right: 1px solid var(--wp--preset--color--darker-grey);
+		}
 	}
 
 	& .global-header__wporg-logo-full {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -2,11 +2,6 @@
 	& .global-header__wporg-logo-mark,
 	& .global-header__wporg-logo-full {
 		border-right: 1px solid var(--wp--preset--color--darker-grey);
-
-		@media (--tablet) {
-			padding-top: 34px;
-			padding-bottom: 28px;
-		}
 	}
 
 	& .global-header__wporg-logo-full {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -7,11 +7,14 @@
 		text-align: left;
 	}
 
-	& .wp-block-navigation:not(.has-background) .wp-block-navigation__responsive-container {
+	&:not(.has-background) .wp-block-navigation__responsive-container {
 		background-color: var(--wp--preset--color--darker-grey);
+		color: var(--wp--preset--color--white);
+		font-size: var(--wp--preset--font-size--large);
 
 		@media (--tablet) {
 			background-color: var(--wp--preset--color--dark-grey);
+			font-size: var(--wp--preset--font-size--small);
 		}
 	}
 
@@ -76,7 +79,7 @@
 	}
 
 	& .wp-block-navigation__container .wp-block-navigation__submenu-container {
-		font-size: 15px;
+		font-size: inherit;
 		gap: 0.5em;
 		padding-bottom: calc(var(--wp--style--block-gap) / 2);
 		padding-left: calc(var(--wp--style--block-gap) / 2);
@@ -129,17 +132,17 @@
 	}
 }
 
-body:not(.admin-bar) .global-header {
+.global-header {
 	& .wp-block-navigation__responsive-container.is-menu-open {
-		top: 110px;
-		&:not(.has-background) {
-			background: #1C2024;
-		}
-	}
-}
 
-body.admin-bar .global-header {
-	& .wp-block-navigation__responsive-container.is-menu-open {
-		top: calc( 110px + var(--wp-admin--admin-bar--height) );
+		/*
+		 * 117px = height of .global-header
+		 * var() fallback must be `0px` with unit for calc addition to work.
+		 */
+		top: calc(117px + var(--wp-admin--admin-bar--height, 0px));
+
+		&:not(.has-background) {
+			background: var(--wp--preset--color--darker-grey);
+		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -7,17 +7,6 @@
 		text-align: left;
 	}
 
-	&:not(.has-background) .wp-block-navigation__responsive-container {
-		background-color: var(--wp--preset--color--darker-grey);
-		color: var(--wp--preset--color--white);
-		font-size: var(--wp--preset--font-size--large);
-
-		@media (--tablet) {
-			background-color: var(--wp--preset--color--dark-grey);
-			font-size: var(--wp--preset--font-size--small);
-		}
-	}
-
 	& .wp-block-navigation__responsive-container {
 		&.is-menu-open {
 			padding-left: 0;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -9,11 +9,12 @@
 	}
 
 	& .wp-block-navigation__responsive-container-open {
+		box-sizing: content-box;
 		width: 24px;
 		height: 24px;
-		background-image: url('../images/search.svg');
+		background-image: url(../images/search.svg);
 		background-repeat: no-repeat;
-		background-position: top 5px left 0;
+		background-position: top 72px left var(--wp--style--block-gap);
 
 		& svg {
 			display: none;
@@ -22,24 +23,25 @@
 
 	& .wp-block-navigation__container {
 		padding-top: 0;
-
-		& > .wp-block-navigation-item {
-			padding-bottom: 28px;
-		}
 	}
 
 	& .wp-block-navigation-item__label {
 		display: none;
 	}
 
+	& .wp-block-navigation-item__content {
+		padding: 37px var(--wp--style--block-gap);
+	}
+
 	& .wp-block-navigation__submenu-icon {
+
 		/* Replace the submenu icon with the search icon. */
 		@media (--tablet) {
 			display: inline-block;
 			width: 24px;
 			height: 24px;
 			background-size: 17px 17px;
-			background-image: url('../images/search.svg');
+			background-image: url(../images/search.svg);
 			background-repeat: no-repeat;
 			background-position: center center;
 			margin-left: 0;
@@ -55,7 +57,7 @@
 
 		@media (--tablet) {
 			width: 300px;
-			top: 47px;
+			top: 100px;
 			right: -25px;
 			left: auto;
 			border: none;
@@ -113,6 +115,7 @@
 	}
 
 	& .wp-block-navigation__responsive-container-close {
-		right: 75px;
+		right: calc(73px + var(--wp--custom--alignment--scroll-bar-width));
+		padding-right: var(--wp--style--block-gap);
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -52,6 +52,12 @@
 		}
 	}
 
+	& .has-child:hover .wp-block-navigation-item__content,
+	& .has-child:focus-within .wp-block-navigation-item__content,
+	&:not(.has-background) .wp-block-navigation__submenu-container {
+		background-color: var(--wp--preset--color--darker-grey);
+	}
+
 	& .wp-block-navigation__responsive-container-content .wp-block-navigation__submenu-container {
 		padding: 0;
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -76,25 +76,34 @@
 
 		& .wp-block-search__inside-wrapper {
 			position: relative;
+
+			&:focus-within {
+				outline: 1px dotted currentColor;
+			}
 		}
 
 		& .wp-block-search__input {
 			width: 100%;
-			
 			padding-right: 35px; /* Prevent user input from running into icon. */
 			border: none;
 			background-color: var(--wp--preset--color--white);
 			color: var(--wp--preset--color--dark-grey);
+			font-size: inherit;
+
+			&:focus {
+				outline: none;
+			}
 		}
 
 		& .wp-block-search__button {
 			position: absolute;
 			right: 0;
-			top: 18px;
+			top: 0;
 			width: 24px;
-			height: 24px;
-			mask-image: url('../images/search.svg');
+			height: 100%;
+			mask-image: url(../images/search.svg);
 			mask-repeat: no-repeat;
+			mask-position: center;
 			background-color: var(--wp--preset--color--dark-grey);
 
 			&:hover {


### PR DESCRIPTION
See https://github.com/WordPress/wporg-mu-plugins/pull/30#issuecomment-989728416, this should address all the listed issues. It also updates the font size on the large-screen header to match the design (well, it uses `--wp--preset--font-size--small`, which is 14px, not 13px — can use 13px directly if it's important).

> The X button should be centered to its container, it's slightly aligned to the left here

This is to account for the scrollbar, the whole nav is shifted slightly. I don't want to change this, since I don't fully understand why it was done this way.

![small-closed](https://user-images.githubusercontent.com/541093/145456489-fff74ebb-0b92-45f6-8d63-5962d3b4de58.png)
![small-menu](https://user-images.githubusercontent.com/541093/145456490-1881175f-0a27-402b-906c-3528a6a43c00.png)
![small-search](https://user-images.githubusercontent.com/541093/145456491-a8a1e47b-4a1c-4207-8d97-839e853131cf.png)

![large-closed](https://user-images.githubusercontent.com/541093/145456487-391354c1-5387-471e-aa7b-b57d2c529c8f.png)
![large-search](https://user-images.githubusercontent.com/541093/145456488-fad02d1c-11fa-4d41-a4ab-7afabdf4cb23.png)

![Screen Shot 2021-12-09 at 13 46 25](https://user-images.githubusercontent.com/541093/145457030-1a02d4a9-4377-4b63-98e8-3c3428682219.png)