### PR TITLE
Styles: Update google fonts to use API v2

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -10,6 +10,8 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_types_js' )
 add_filter( 'pre_set_transient_global_styles_wporg-news-2021', __NAMESPACE__ . '\save_dependent_global_styles' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles' );
+add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
+add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
 
 /**
  * Register block types
@@ -126,6 +128,28 @@ function register_block_types_js() {
 	}( window.wp ));
 	<?php
 	wp_add_inline_script( 'wp-editor', ob_get_clean(), 'after' );
+}
+
+/**
+ * Filter the google fonts URL to use the "CSS2" version of the API.
+ *
+ * @param string $src    The source URL of the enqueued style.
+ * @param string $handle The style's registered handle.
+ * @return string Updated URL for `open-sans`.
+ */
+function update_google_fonts_url( $src, $handle ) {
+	if ( 'open-sans' === $handle ) {
+		return 'https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&display=swap';
+	}
+	return $src;
+}
+
+/**
+ * Add preconnect resource hints for the Google Fonts API.
+ */
+function preload_google_fonts() {
+	echo '<link rel="preconnect" href="https://fonts.googleapis.com">';
+	echo '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin> ';
 }
 
 /**


### PR DESCRIPTION
The style URL for Open Sans is registered in WP core, but is not actually used there anymore. It's registered using the older, `fonts.googleapis.com/css` path, while the current version is `fonts.googleapis.com/css2`. See the info in [this update post](https://developers.google.com/fonts/docs/css2).

In updating the header, we could also update this API, which will give us better performance - at the very least by using `display=swap`. I've also added the preconnect resource hints for the header.

Note that if/when the whole of wp.org is using the new design, this will become obsolete, since the new design does not use Open Sans, and the fonts registered by `theme.json` already use this v2 API.

Fixes [#5610-meta](https://meta.trac.wordpress.org/ticket/5610).

To test:
- On any site, look for the Open Sans call in the source code or network tab, it should load from `css2`
- There should be no visual difference
- Load a few different locales, Open Sans should be loaded correctly for each subset (cyrillic, greek, etc) 
