### PR TITLE
Add Codex/Planet required bits to header

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -618,7 +618,11 @@ function get_download_url() {
  */
 function rest_render_global_footer( $request ) {
 
-	$markup = render_global_footer();
+	/*
+	 * Render the header but discard the markup, so that any header styles/scripts
+	 * required are then available for output in the footer.
+	 */
+	render_global_header();
 
 	// Serve the request as HTML
 	add_filter( 'rest_pre_serve_request', function( $served, $result ) {
@@ -629,7 +633,7 @@ function rest_render_global_footer( $request ) {
 		return true;
 	}, 10, 2 );
 
-	return $markup;
+	return render_global_footer();
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -88,6 +88,18 @@ function register_routes() {
 
 	register_rest_route(
 		'global-header-footer/v1',
+		'header/planet',
+		array(
+			array(
+				'methods'  => WP_REST_Server::READABLE,
+				'callback' => __NAMESPACE__ . '\rest_render_planet_global_header',
+				'permission_callback' => '__return_true',
+			),
+		)
+	);
+
+	register_rest_route(
+		'global-header-footer/v1',
 		'footer',
 		array(
 			array(
@@ -284,6 +296,33 @@ function rest_render_codex_global_header( $request ) {
 	$markup = preg_replace( '!<html[^>]+>!i', '<!-- [codex head html] -->', $markup );
 
 	return $markup;
+}
+
+/**
+ * Render the global header via a REST request for use with Planet.
+ *
+ * @return string
+ */
+function rest_render_planet_global_header( $request ) {
+	add_filter( 'pre_get_document_title', function() {
+		return 'Planet &mdash; WordPress.org';
+	} );
+
+	add_filter( 'wporg_canonical_url', function() {
+		return 'https://planet.wordpress.org/';
+	} );
+
+	add_filter( 'body_class', function( $class ) {
+		return [
+			'wporg-responsive',
+			'wporg-planet'
+		];
+	} );
+
+	// hreflang tags are not needed for this site.
+	remove_action( 'wp_head', 'WordPressdotorg\Theme\hreflang_link_attributes' );
+
+	return rest_render_global_header( $request );
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -273,6 +273,9 @@ function rest_render_codex_global_header( $request ) {
 		];
 	} );
 
+	wp_enqueue_style( 'wp4', 'https://s.w.org/style/wp4.css', array(), 95 );
+	wp_enqueue_style( 'codex-wp4', 'https://s.w.org/style/codex-wp4.css', array( 'wp4' ), 3 );
+
 	// hreflang tags are not needed for this site.
 	remove_action( 'wp_head', 'WordPressdotorg\Theme\hreflang_link_attributes' );
 

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -165,13 +165,15 @@ function preload_google_fonts() {
  * Output styles for themes that don't use `wp4-styles`. This provides compat with the classic header.php.
  */
 function enqueue_compat_wp4_styles() {
-	if ( ! wp_is_block_theme() && ! current_theme_supports( 'wp4-styles' ) ) {
-		$cdn_domain = defined( 'WPORG_SANDBOXED' ) && WPORG_SANDBOXED ? 'wordpress.org' : 's.w.org';
+	if (
+		( ! wp_is_block_theme() && ! current_theme_supports( 'wp4-styles' ) ) ||
+		( defined( 'REST_REQUEST' ) && REST_REQUEST )
+	) {
 		$suffix = 'rtl' === is_rtl() ? '-rtl' : '';
 
 		wp_register_style(
 			'wp4-styles',
-			'https://' . $cdn_domain . '/style/wp4' . $suffix . '.css',
+			'https://s.w.org/style/wp4' . $suffix . '.css',
 			array( 'open-sans' ),
 			'95'
 		);
@@ -273,8 +275,7 @@ function rest_render_codex_global_header( $request ) {
 		];
 	} );
 
-	wp_enqueue_style( 'wp4', 'https://s.w.org/style/wp4.css', array(), 95 );
-	wp_enqueue_style( 'codex-wp4', 'https://s.w.org/style/codex-wp4.css', array( 'wp4' ), 3 );
+	wp_enqueue_style( 'codex-wp4', 'https://s.w.org/style/codex-wp4.css', array( 'wp4-styles' ), 3 );
 
 	// hreflang tags are not needed for this site.
 	remove_action( 'wp_head', 'WordPressdotorg\Theme\hreflang_link_attributes' );

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -625,7 +625,7 @@ function rest_render_global_footer( $request ) {
 
 		echo $result->get_data();
 
-		return $served = true;
+		return true;
 	}, 10, 2 );
 
 	return $markup;

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -246,7 +246,7 @@ function rest_render_global_header( $request ) {
 
 		echo $result->get_data();
 
-		return $served = true;
+		return true;
 	}, 10, 2 );
 
 	return $markup;

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -9,7 +9,7 @@ defined( 'WPINC' ) || die();
 add_action( 'init', __NAMESPACE__ . '\register_block_types' );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_types_js' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles', 30 );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_fonts' );
 add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
 add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
@@ -187,7 +187,7 @@ function enqueue_compat_wp4_styles() {
 			'wp4-styles',
 			'https://s.w.org/style/wp4' . $suffix . '.css',
 			array( 'open-sans' ),
-			'95'
+			96
 		);
 
 		wp_enqueue_style( 'wp4-styles' );
@@ -252,9 +252,16 @@ function restore_inner_group_container() {
  */
 function rest_render_global_header( $request ) {
 
-	$markup = render_global_header();
+	// Remove the theme stylesheet from rest requests.
+	add_filter( 'wp_enqueue_scripts', function() {
+		remove_theme_support( 'wp4-styles' );
 
-	// Serve the request as HTML
+		wp_dequeue_style( 'wporg-style' );
+		wp_enqueue_style( 'dashicons' );
+		wp_enqueue_style( 'open-sans' );
+	}, 20 );
+
+	// Serve the request as HTML.
 	add_filter( 'rest_pre_serve_request', function( $served, $result ) {
 		header( 'Content-Type: text/html' );
 
@@ -263,7 +270,7 @@ function rest_render_global_header( $request ) {
 		return true;
 	}, 10, 2 );
 
-	return $markup;
+	return render_global_header();
 }
 
 /**
@@ -287,7 +294,7 @@ function rest_render_codex_global_header( $request ) {
 		];
 	} );
 
-	wp_enqueue_style( 'codex-wp4', 'https://s.w.org/style/codex-wp4.css', array( 'wp4-styles' ), 3 );
+	wp_enqueue_style( 'codex-wp4', 'https://s.w.org/style/codex-wp4.css', array( 'wp4-styles' ), 4 );
 
 	// hreflang tags are not needed for this site.
 	remove_action( 'wp_head', 'WordPressdotorg\Theme\hreflang_link_attributes' );


### PR DESCRIPTION
See #42 & #38

Unfortunately the Codex requires wp4 styles and isn't super pretty with just removing that and dropping in the new header/footer.

as it is with the new header/footer
![no_styles](https://user-images.githubusercontent.com/767313/148726827-1ee62c7a-dc6a-420a-9d0e-843d2c658e4c.png)

as it is with wp4 sttyles after https://github.com/WordPress/wporg-mu-plugins/commit/cc68eb9886612a24917a35b35fb91d629af30755 - Just adding codex-wp4 didn't help here either.
![with_styles](https://user-images.githubusercontent.com/767313/148726821-b9012751-2d6d-47d6-a316-668cb34c9cca.png)

