### PR TITLE
Footer: Left-align navigation menus

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
@@ -21,5 +21,6 @@
 	& .wp-block-navigation__container {
 		flex-direction: column;
 		gap: 5px;
+		align-items: self-start;
 	}
 }


### PR DESCRIPTION
Fix bug where nav menus are center-aligned.

Props allancole.
Fixes #64.

Before:
<img width="708" alt="Screen Shot 2022-01-10 at 3 11 47 PM" src="https://user-images.githubusercontent.com/541093/148832705-410874f2-7bf6-4eaa-b41c-7b5ef0719e06.png">

After:
<img width="647" alt="Screen Shot 2022-01-10 at 3 12 06 PM" src="https://user-images.githubusercontent.com/541093/148832737-fca2c92c-c438-4d3a-80f3-f7f69ee203ab.png">

