### PR TITLE
Dynamically assign `active-menu-item` to the menu

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -624,8 +624,30 @@ function get_menu_url_for_current_page( $menu_items ) {
 		return 'https://make.wordpress.org/';
 	}
 
+	if ( 'developer.wordpress.prg' === $_SERVER['HTTP_HOST'] ) {
+		// DevHub doesn't exist within the menu.
+		return '';
+	}
+
+	// Temporary
 	if ( 'https://wordpress.org/news-test/' === home_url( '/' ) ) {
 		return 'https://wordpress.org/news/';
+	}
+
+	$compare = "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+
+	// Is it the Global Search?
+	if ( 0 === stripos( $compare, 'https://wordpress.org/search/' ) ) {
+		if ( isset( $_GET['in'] ) ) {
+			if ( 'support_docs' === $_GET['in'] ) {
+				return 'https://wordpress.org/support/';
+			} elseif ( 'developer_documentation' === $_GET['in'] ) {
+				// DevHub doesn't exist within the menu.
+				return '';
+			}
+		}
+
+		return 'https://wordpress.org/support/forums/';
 	}
 
 	// Extract all URLs, toplevel and child.
@@ -638,12 +660,11 @@ function get_menu_url_for_current_page( $menu_items ) {
 			}
 		}
 	);
-	// Sort long to short.
+
+	// Sort long to short, we need the deepest path to match.
 	usort( $urls, function( $a, $b ) {
 		return strlen( $b ) - strlen( $a );
 	} );
-
-	$compare = "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 
 	foreach ( $urls as $url ) {
 		if ( 0 === stripos( $compare, $url ) ) {

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -650,6 +650,11 @@ function get_menu_url_for_current_page( $menu_items ) {
 		return 'https://wordpress.org/support/forums/';
 	}
 
+	// These prefixes are Support Forums, not Support Documentation.
+	if ( preg_match( '!/support/(forum|view|topic|reply|users)/!i', $_SERVER['REQUEST_URI'] ) ) {
+		$compare = "https://{$_SERVER['HTTP_HOST']}/support/forums/";
+	}
+
 	// Extract all URLs, toplevel and child.
 	$urls = [];
 	array_walk_recursive(

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -104,6 +104,10 @@
 		& .global-header__get-wordpress {
 			display: none;
 		}
+
+		& .wp-block-navigation__submenu-icon {
+			transform: rotate( -90deg );
+		}
 	}
 
 	& .global-header__overflow-item {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -62,9 +62,14 @@
 					border-left: none;
 				}
 
-				& a {
+				& > a {
 					color: #7b90ff;
 				}
+			}
+
+			& ul .current-menu-item {
+				border-left: none;
+				border-bottom: none;
 			}
 		}
 	}


### PR DESCRIPTION
This is probably not the most efficient way, but is more dynamic than what we currently use on WordPress.org (which is mostly a tightly coupled if-branching setup).

Some style changes were required to make submenu active highlighting work more correctly, see below screenshots of the after effect.

https://user-images.githubusercontent.com/767313/148885968-309a0e84-397a-415a-8755-2a3860002911.mov

And for the reasoning for the CSS rotation:

<img width="968" alt="Screen Shot 2022-01-11 at 3 20 20 pm" src="https://user-images.githubusercontent.com/767313/148885854-78e70bf7-dcdd-4b07-8577-552a4588a569.png">

See #35