### PR TITLE
Use Inter font for header & footer

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -10,6 +10,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block_types' );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_types_js' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_fonts' );
 add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
 add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
 
@@ -165,6 +166,23 @@ function enqueue_compat_wp4_styles() {
 
 		wp_enqueue_style( 'wp4-styles' );
 	}
+}
+
+/**
+ * Load Inter (font) for use in header & footer on classic themes.
+ *
+ * In the block theme, this is loaded by `theme.json` & `WordPressdotorg\Theme\News_2021\enqueue_assets`.
+ */
+function enqueue_fonts() {
+	if ( wp_is_block_theme() ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'wporg-news-fonts-css',
+		'https://fonts.googleapis.com/css2?family=Inter:wght@200..700&display=swap',
+		array(),
+	);
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -36,6 +36,9 @@
 
 	background-color: var(--wp--preset--color--dark-grey);
 	color: var(--wp--preset--color--white);
+	font-family: var(--wp--preset--font-family--inter);
+	font-size: var(--wp--preset--font-size--normal);
+	line-height: var(--wp--custom--body--typography--line-height);
 }
 
 .wp-block-group.global-header .global-header__navigation,

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -39,6 +39,10 @@
 	font-family: var(--wp--preset--font-family--inter);
 	font-size: var(--wp--preset--font-size--normal);
 	line-height: var(--wp--custom--body--typography--line-height);
+
+	/* Smooth out the fonts. */
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 .wp-block-group.global-header .global-header__navigation,

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
@@ -1,6 +1,5 @@
 .wp-block-group.global-footer {
 	padding: 44px var(--wp--custom--alignment--edge-spacing);
-	font-size: 13px;
 
 	@media (--tablet) {
 		padding-top: 69px;

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -27,6 +27,7 @@
 		@media (--tablet) {
 			display: inline;
 			flex-basis: 33%;
+			margin-bottom: 0;
 		}
 	}
 


### PR DESCRIPTION
Fixes #74 — Load and use Inter font for header & footer, along with the base body font styles for line-height, font-size, and the font smoothing properties.

This should make the header & footer on classic sites match the News site.

| | Header | Footer |
|---|---|---|
| Before | ![header-before](https://user-images.githubusercontent.com/541093/149239642-30887304-d662-49b5-aae3-53b97f83c719.png) | ![footer-before](https://user-images.githubusercontent.com/541093/149239636-44b4b878-6bec-460b-8887-ce1d42c2c0a1.png) |
| After | ![header-after](https://user-images.githubusercontent.com/541093/149239640-a7de575c-da2b-4cef-8e6b-427b98404ff6.png) | ![footer-after](https://user-images.githubusercontent.com/541093/149239634-f18f376b-a8e3-4ae4-99ed-1b442192d995.png) |
| News | ![header-news](https://user-images.githubusercontent.com/541093/149239643-c8aeaf0f-5a06-44f5-a9ca-d94f4e6334db.png) | ![footer-news](https://user-images.githubusercontent.com/541093/149239638-009c671a-6ca5-45be-abdf-85be302c2201.png) |

