### PR TITLE
Make the Get WordPress button wider in the mobile header

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -12,9 +12,11 @@
 	& .wp-block-navigation__responsive-container {
 		&.is-menu-open {
 			padding-left: 0;
+			padding-right: 0;
 
 			& .wp-block-navigation__container {
 				line-height: 1em;
+				width: 100%;
 			}
 
 			& .wp-block-navigation__submenu-icon {


### PR DESCRIPTION
<img width="610" alt="News_Theme_2021_Test_–_Testing_github_com_WordPress_wporg-news-2021" src="https://user-images.githubusercontent.com/905781/149257814-6a50931b-9ebf-40e5-9ec2-05b6cb19d117.png">
