### PR TITLE
Header menu: Fixes for minor style issues

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -13,6 +13,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles', 
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_fonts' );
 add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
 add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
+add_filter( 'render_block_core/navigation-link', __NAMESPACE__ . '\swap_submenu_arrow_svg' );
 
 /**
  * Register block types
@@ -837,4 +838,14 @@ function get_menu_url_for_current_page( $menu_items ) {
 	}
 
 	return home_url('/');
+}
+
+/**
+ * Replace the current submenu down-arrow with a custom icon.
+ *
+ * @param string $block_content The block content about to be appended.
+ * @return string IDK
+ */
+function swap_submenu_arrow_svg( $block_content ) {
+	return str_replace( block_core_navigation_link_render_submenu_icon(), "<svg width='10' height='7' viewBox='0 0 10 7' stroke-width='1.2' xmlns='http://www.w3.org/2000/svg'><path d='M0.416667 1.33325L5 5.49992L9.58331 1.33325'></path></svg>", $block_content );
 }

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -844,7 +844,7 @@ function get_menu_url_for_current_page( $menu_items ) {
  * Replace the current submenu down-arrow with a custom icon.
  *
  * @param string $block_content The block content about to be appended.
- * @return string IDK
+ * @return string The filtered block content.
  */
 function swap_submenu_arrow_svg( $block_content ) {
 	return str_replace( block_core_navigation_link_render_submenu_icon(), "<svg width='10' height='7' viewBox='0 0 10 7' stroke-width='1.2' xmlns='http://www.w3.org/2000/svg'><path d='M0.416667 1.33325L5 5.49992L9.58331 1.33325'></path></svg>", $block_content );

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -45,6 +45,10 @@
 	/* Smooth out the fonts. */
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+
+	& * {
+		box-sizing: border-box;
+	}
 }
 
 .wp-block-group.global-header .global-header__navigation,

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -66,7 +66,6 @@
 
 			&.current-menu-item {
 				border-left: var(--active-menu-item-border-height) solid #7b90ff;
-				font-weight: bold;
 
 				@media (--tablet) {
 					padding-bottom: calc(37px - var(--active-menu-item-border-height));
@@ -76,6 +75,7 @@
 
 				& > a {
 					color: #7b90ff;
+					font-weight: 700;
 				}
 			}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -141,17 +141,9 @@
 		padding-bottom: 0;
 	}
 
-	& .wp-block-navigation__submenu-icon {
-		& svg {
-			display: none;
-		}
-		background-image: url("data:image/svg+xml,%3Csvg width='10' height='7' viewBox='0 0 10 7' fill='none' stroke='white' stroke-width='1.2' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.416667 1.33325L5 5.49992L9.58331 1.33325'%3E%3C/path%3E%3C/svg%3E");
-		background-repeat: no-repeat;
-		background-size: 100% auto;
-		display: inline-block;
-		vertical-align: middle;
-		width: 7px;
-		height: 4px;
+	& .wp-block-navigation__submenu-icon svg {
+		fill: none;
+		stroke: currentColor;
 	}
 }
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -101,6 +101,11 @@
 		& .wp-block-navigation-item {
 			padding: calc(var(--wp--style--block-gap) / 4);
 		}
+
+		& a:hover,
+		& a:focus {
+			text-decoration: underline;
+		}
 	}
 
 	& .wp-block-navigation__container .wp-block-navigation-item.global-header__overflow-menu {


### PR DESCRIPTION
I noticed a few issues— the chevron was not changing color with the current menu item, and it was not bold on the `make.w.org` homepage. Also on the page, the logo had too much space next to it. In other themes, there's a `box-sizing` reset applied to fix this, so I've added it to the children in header & footer.

Before
![before](https://user-images.githubusercontent.com/541093/149580417-ba182cad-6d4b-45e6-95a0-4267730d426f.png)

After
![after](https://user-images.githubusercontent.com/541093/149581574-476e1c47-93af-41cd-8538-9e44515745bc.png)

This PR also adds the underline to submenu items, see https://github.com/WordPress/wporg-mu-plugins/issues/63#issuecomment-1013379510

<img width="1116" alt="Screen Shot 2022-01-14 at 3 35 17 PM" src="https://user-images.githubusercontent.com/541093/149581651-43350e83-04a2-4152-84d0-6c3ad5e233ca.png">

