### PR TITLE
Header search: Fix extra link in search dropdown

### DIFF
--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -79,7 +79,7 @@ defined( 'WPINC' ) || die();
 		keyboard navigation, ARIA states, etc. It also saves having to write custom code for all the interactions.
 	-->
 	<!-- wp:navigation {"orientation":"vertical","className":"global-header__search","overlayMenu":"mobile"} -->
-		<!-- wp:navigation-link {"label":"Search","url":"#","kind":"custom","isTopLevelLink":false} -->
+		<!-- wp:navigation-link {"label":<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>,"url":"#","kind":"custom","isTopLevelLink":false} -->
 			<!-- wp:html -->
 			<li>
 				<!--

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -79,7 +79,7 @@ defined( 'WPINC' ) || die();
 		keyboard navigation, ARIA states, etc. It also saves having to write custom code for all the interactions.
 	-->
 	<!-- wp:navigation {"orientation":"vertical","className":"global-header__search","overlayMenu":"mobile"} -->
-		<!-- wp:navigation-link {"label":<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>,"url":"#","kind":"custom","isTopLevelLink":false} -->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>","url":"#","kind":"custom","isTopLevelLink":false} -->
 			<!-- wp:html -->
 			<li>
 				<!--

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -25,7 +25,18 @@
 	}
 
 	& .wp-block-navigation-item__label {
-		display: none;
+
+		/* See @mixin hide-accessibly in wporg-news-2021 */
+		border: 0;
+		clip: rect(1px, 1px, 1px, 1px);
+		clip-path: inset(50%);
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute;
+		width: 1px;
+		word-wrap: normal !important;
 	}
 
 	& .wp-block-navigation-item__content {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -30,6 +30,11 @@
 
 	& .wp-block-navigation-item__content {
 		padding: 42px var(--wp--style--block-gap) 37px;
+		display: none;
+
+		@media (--tablet) {
+			display: block;
+		}
 	}
 
 	& .wp-block-navigation__submenu-icon {


### PR DESCRIPTION
The search dropdown uses a navigation menu for functionality, which requires adding an extra link "Search" in the menu. When this is converted to the mobile menu, the link (`a` tag) still exists and takes up space, but the contents are invisible. On some sites, where a focus outline has been set, this creates a "focus state on nothing".

This PR hides the whole link tag in mobile-mode, since it's not needed as a label or for functionality. On larger screens, I've switched the label to be visually hidden, not `display: none`, so that the 🔎  icon has a label for screen reader users (this is not a fix for #12, that still requires GB, but it is a decent workaround).

Lastly, I wrapped the `navigation-link`'s `label` in a translation wrapper, since I don't think this will be picked up otherwise.

Fixes #94.

| Before | After |
|-----|----|
| ![menu-closed](https://user-images.githubusercontent.com/541093/149828147-545c9bc9-f87c-43ed-b9cf-1e75f7f511a3.png) | ![pr-menu-closed](https://user-images.githubusercontent.com/541093/149827614-f7e9c34c-d4ef-4bfd-83f5-32d2ebc1806c.png) |
| ![menu-open](https://user-images.githubusercontent.com/541093/149828150-fb607027-83a3-4e5d-803b-602b9dcf139d.png) | ![pr-menu-open](https://user-images.githubusercontent.com/541093/149827616-1ffa7ee7-9b21-443f-87c5-bfde45b436b9.png) |
| ![mobile-closed](https://user-images.githubusercontent.com/541093/149828153-5d6a76d2-ca0d-4065-8dae-509b4209c2f3.png) | ![pr-mobile-closed](https://user-images.githubusercontent.com/541093/149827619-d3da91c4-e5a2-475f-b862-c8169ac67841.png) |
| ![mobile-open](https://user-images.githubusercontent.com/541093/149828154-a52d2ef4-b647-495b-9d4e-77c6467990d9.png) | ![pr-mobile-open](https://user-images.githubusercontent.com/541093/149827620-e1b25d79-1535-4da8-8ad8-a871a2a08d9a.png) |
