### PR TITLE
Header: Stick header to top of page while scrolling

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -14,6 +14,11 @@
 @custom-media --desktop (min-width: 1152px);
 @custom-media --desktop-wide (min-width: 1440px);
 
+/* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
+html {
+	scroll-padding-top: calc(105px + var(--wp-admin--admin-bar--height, 0px)); /* 105px = height of header. */
+}
+
 /*
  * Shared styles
  */

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -17,6 +17,7 @@
 /* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
 html {
 	scroll-padding-top: calc(105px + var(--wp-admin--admin-bar--height, 0px)); /* 105px = height of header. */
+	height: unset; /* Let height use default browser height. */
 }
 
 /*

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -9,7 +9,7 @@
 	 * covered up by the content when you hover over the parent menu item.
 	 */
 	position: relative;
-	z-index: 200;
+	z-index: 250;
 
 	@media (--tablet) {
 		position: sticky;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -12,6 +12,8 @@
 	z-index: 200;
 
 	@media (--tablet) {
+		position: sticky;
+		top: var(--wp-admin--admin-bar--height, 0);
 		font-size: 13px;
 	}
 


### PR DESCRIPTION
Fixes #67. This uses `position: sticky` to attach the header to the top of the viewport (below the admin bar), so it stays in place while scrolling down the page.

No changes are needed on the news theme— the parent container is sticky there so that both the global and local nav are sticky.

I tested this on my sandbox on a few sites. Mostly this change was smooth, no visual changes (except now the header moves with you). I only had to fix two issues:

- A `z-index` issue with the showcase's `leftsidebar`
- A container height issue on translate.w.org, where `html { height: 100%; }` was set, which caused the header to scroll offscreen at that arbitrary point

I'd appreciate at least one other look-over from a dev with a sandbox- I've checked a handful of wporg sites, but i'm sure there are other edge cases.

**Screenshots**

https://user-images.githubusercontent.com/541093/149838664-91557f3b-c6b2-4fba-8253-5be990ec3304.mov


