### PR TITLE
Menu: Close other modals when when the "open" button is clicked

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -1,3 +1,4 @@
+/* global MicroModal */
 /**
  * File wporg-global-header-script.js.
  *
@@ -168,7 +169,24 @@
 		);
 	};
 
+	/* eslint-disable @wordpress/no-global-event-listener */
 	window.addEventListener( 'load', function () {
 		new navMenu( '.global-header .global-header__navigation' );
+
+		const buttons = document.querySelectorAll( '[data-micromodal-trigger]' );
+		const modalIds = Array.from( buttons ).map( ( button ) =>
+			button.getAttribute( 'data-micromodal-trigger' )
+		);
+		buttons.forEach( function ( button ) {
+			button.addEventListener( 'click', function ( event ) {
+				const thisModal = event.target.getAttribute( 'data-micromodal-trigger' );
+				modalIds.forEach( function ( modalId ) {
+					if ( thisModal !== modalId ) {
+						// This overwrites the internally tracked modal 😞
+						MicroModal.close( modalId );
+					}
+				} );
+			} );
+		} );
 	} );
 } )();

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -1,4 +1,3 @@
-/* global MicroModal */
 /**
  * File wporg-global-header-script.js.
  *
@@ -173,19 +172,19 @@
 	window.addEventListener( 'load', function () {
 		new navMenu( '.global-header .global-header__navigation' );
 
-		const buttons = document.querySelectorAll( '[data-micromodal-trigger]' );
-		const modalIds = Array.from( buttons ).map( ( button ) =>
-			button.getAttribute( 'data-micromodal-trigger' )
-		);
-		buttons.forEach( function ( button ) {
+		const openButtons = document.querySelectorAll( '[data-micromodal-trigger]' );
+		openButtons.forEach( function ( button ) {
+			// When any open menu button is clicked, find any existing close buttons and click them.
 			button.addEventListener( 'click', function ( event ) {
 				const thisModal = event.target.getAttribute( 'data-micromodal-trigger' );
-				modalIds.forEach( function ( modalId ) {
-					if ( thisModal !== modalId ) {
-						// This overwrites the internally tracked modal 😞
-						MicroModal.close( modalId );
-					}
-				} );
+				const closeButtons = Array.from(
+					document.querySelectorAll( 'button[data-micromodal-close]' )
+				).filter(
+					// Filter to find visible close buttons that are not for this modal.
+					( _button ) => _button.offsetWidth > 0 && null === _button.closest( `#${ thisModal }` )
+				);
+
+				closeButtons.forEach( ( _button ) => _button.click() );
 			} );
 		} );
 	} );


### PR DESCRIPTION
This is a little bit of a workaround, since there isn't a way to do this via Gutenberg, and the library used does not support it either. Whenever an open button is clicked, we quickly check if there are any visible close buttons that don't belong to the just-opened modal, and trigger a click on them.

Fixes #57 

https://user-images.githubusercontent.com/541093/149850733-619e67ce-9d2f-4849-aecb-d147691d76e5.mov
