### PR TITLE
Add the Rosetta site name to the header.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -206,7 +206,7 @@ function enqueue_compat_wp4_styles() {
 }
 
 /**
- * Load Inter (font) for use in header & footer on classic themes.
+ * Load EB Garamond & Inter (fonts) for use in header & footer on classic themes.
  *
  * In the block theme, this is loaded by `theme.json` & `WordPressdotorg\Theme\News_2021\enqueue_assets`.
  */
@@ -217,7 +217,7 @@ function enqueue_fonts() {
 
 	wp_enqueue_style(
 		'wporg-news-fonts-css',
-		'https://fonts.googleapis.com/css2?family=Inter:wght@200..700&display=swap',
+		'https://fonts.googleapis.com/css2?family=Inter:wght@200..700&family=EB+Garamond:wght@400&display=swap',
 		array(),
 	);
 }

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -350,9 +350,11 @@ function render_global_header() {
 	remove_inner_group_container();
 
 	if ( is_rosetta_site() ) {
-		$menu_items = get_rosetta_menu_items();
+		$menu_items   = get_rosetta_menu_items();
+		$locale_title = get_rosetta_name();
 	} else {
-		$menu_items = get_global_menu_items();
+		$menu_items   = get_global_menu_items();
+		$locale_title = '';
 	}
 
 	// The mobile Get WordPress button needs to be in both menus.
@@ -535,6 +537,18 @@ function get_rosetta_menu_items() : array {
 	restore_current_blog();
 
 	return $normalized_items;
+}
+
+/**
+ * Fetch the Rosetta site name.
+ *
+ * @return string
+ */
+function get_rosetta_name() : string {
+	/** @var Rosetta_Sites $rosetta */
+	global $rosetta;
+
+	return get_blog_option( $rosetta->get_root_site_id(), 'blogname' );
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -41,7 +41,7 @@ defined( 'WPINC' ) || die();
 	<?php if ( ! empty( $locale_title ) ) : ?>
 	<!-- wp:paragraph {"className":"global-header__wporg-local-title"} -->
 	<p class="global-header__wporg-local-title">
-		<span><?php echo $locale_title; ?></span>
+		<span><?php esc_html_e( $locale_title ); ?></span>
 	</p>
 	<!-- /wp:paragraph -->
 	<?php endif; ?>

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -41,7 +41,7 @@ defined( 'WPINC' ) || die();
 	<?php if ( ! empty( $locale_title ) ) : ?>
 	<!-- wp:paragraph {"className":"global-header__wporg-local-title"} -->
 	<p class="global-header__wporg-local-title">
-		<span><?php esc_html_e( $locale_title ); ?></span>
+		<span><?php echo esc_html( $locale_title ); ?></span>
 	</p>
 	<!-- /wp:paragraph -->
 	<?php endif; ?>

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -39,8 +39,8 @@ defined( 'WPINC' ) || die();
 	<!-- /wp:image -->
 
 	<?php if ( ! empty( $locale_title ) ) : ?>
-	<!-- wp:paragraph {"className":"global-header__wporg-local-title"} -->
-	<p class="global-header__wporg-local-title">
+	<!-- wp:paragraph {"className":"global-header__wporg-locale-title"} -->
+	<p class="global-header__wporg-locale-title">
 		<span><?php echo esc_html( $locale_title ); ?></span>
 	</p>
 	<!-- /wp:paragraph -->

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -11,6 +11,12 @@ defined( 'WPINC' ) || die();
  * @var array $menu_items
  */
 
+/**
+ * Defined in `render_global_header()`.
+ *
+ * @var string $locale_title
+ */
+
 ?>
 
 <!-- wp:group {"tagName":"header","align":"full","className":"global-header"} -->
@@ -31,6 +37,14 @@ defined( 'WPINC' ) || die();
 		</a>
 	</figure>
 	<!-- /wp:image -->
+
+	<?php if ( ! empty( $locale_title ) ) : ?>
+	<!-- wp:paragraph {"className":"global-header__wporg-local-title"} -->
+	<p class="global-header__wporg-local-title">
+		<span><?php echo $locale_title; ?></span>
+	</p>
+	<!-- /wp:paragraph -->
+	<?php endif; ?>
 
 	<!-- wp:navigation {"orientation":"horizontal","className":"global-header__navigation","overlayMenu":"mobile"} -->
 		<?php

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -20,7 +20,7 @@
 	& > * {
 		flex-shrink: 0;
 		padding: 60px var(--wp--style--block-gap) 17px;
-		margin: 0 auto;
+		margin: 0;
 
 		@media (--tablet) {
 			padding-top: 37px;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -22,8 +22,8 @@
 		}
 	}
 
-	& .global-header__wporg-local-title {
-		--wp--preset--font-size--large: 20px;
+	& .global-header__wporg-locale-title {
+		--wp--preset--font-size--large: 20px; /* Ensure this is set to the correct size. */
 		padding-left: 0;
 		flex-basis: max-content;
 		flex-grow: 1;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -27,7 +27,7 @@
 		padding-left: 0;
 		flex-basis: max-content;
 		flex-grow: 1;
-		flex-shrink: 0;
+		flex-shrink: 1;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -44,6 +44,7 @@
 		@media (--tablet) {
 			max-width: 15em;
 			flex-basis: min-content;
+			flex-shrink: 0;
 		}
 
 		@media (--desktop-wide) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -22,4 +22,31 @@
 			display: none;
 		}
 	}
+
+	& .global-header__wporg-local-title {
+		flex-basis: 60%;
+		flex-shrink: 0;
+		line-height: 1;
+		overflow: hidden;
+		padding-left: 0;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		@media (--tablet) {
+			display: inline;
+			flex-basis: initial;
+			font-size: 1.2em;
+			line-height: 1.5;
+			max-width: 200px;
+		}
+
+		@media (--desktop-wide) {
+			max-width: inherit;
+		}
+
+		& span {
+			border-left: 1px solid;
+			padding-left: var(--wp--style--block-gap);
+		}
+	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -9,8 +9,7 @@
 	}
 
 	& .wp-block-image.global-header__wporg-logo-mark {
-		flex-basis: 100%;
-		flex-shrink: 1;
+		flex-basis: auto;
 		text-align: left;
 
 		@media (--tablet) {
@@ -24,29 +23,31 @@
 	}
 
 	& .global-header__wporg-local-title {
-		flex-basis: 60%;
-		flex-shrink: 0;
-		line-height: 1;
-		overflow: hidden;
+		--wp--preset--font-size--large: 20px;
 		padding-left: 0;
+		flex-basis: max-content;
+		flex-grow: 1;
+		flex-shrink: 0;
+		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-
-		@media (--tablet) {
-			display: inline;
-			flex-basis: initial;
-			font-size: 1.2em;
-			line-height: 1.5;
-			max-width: 200px;
-		}
-
-		@media (--desktop-wide) {
-			max-width: inherit;
-		}
+		font-family: var(--wp--preset--font-family--eb-garamond);
+		font-size: var(--wp--preset--font-size--large);
+		font-weight: 400;
+		line-height: 1.3;
 
 		& span {
 			border-left: 1px solid;
 			padding-left: var(--wp--style--block-gap);
+		}
+
+		@media (--tablet) {
+			max-width: 15em;
+			flex-basis: min-content;
+		}
+
+		@media (--desktop-wide) {
+			max-width: 20em;
 		}
 	}
 }


### PR DESCRIPTION
This is an initial attempt at adding the Rosetta site name to the header.

My CSS skills were not up to the job to make this work properly, particularly for the mobile view.
**Someone else please take over :)**

Things of note:
 - Overflow to prevent a super long title filling the header (just hard-code it in the variable to test this)
 - Text is free-form from the Blog Name field, it's not always the locale although is usually pretty close to it.
 - I wasn't able to overcome the CSS flexing it's might over me for the mobile view; the logo is 100% flex wide and I couldn't find a way to shrink it down and place this text beside it without causing it to shink the logo size at smaller mobile widths. I experimented with grouping the icons & text, but quickly got out of my depth.
 - I've not attempted to match the header spacings requested, and just kept it with the current gaps. Gapping it appropriately can probably be done with a followup PR?

<img width="1583" alt="Screen Shot 2022-01-18 at 1 57 18 pm" src="https://user-images.githubusercontent.com/767313/149868420-ab777d00-70b1-483e-8f4b-547bc0c73712.png">

<img width="1391" alt="Screen Shot 2022-01-18 at 1 57 41 pm" src="https://user-images.githubusercontent.com/767313/149868456-7b0a1cc6-221d-411b-b10e-123a7f00dff8.png">

<img width="868" alt="Screen Shot 2022-01-18 at 1 58 04 pm" src="https://user-images.githubusercontent.com/767313/149868491-d9b6ef70-800f-436c-8b9d-d39d3477a2b8.png">


See #50