### PR TITLE
Footer: Add locale name to footer

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -729,6 +729,12 @@ function rest_render_global_footer( $request ) {
 function render_global_footer() {
 	remove_inner_group_container();
 
+	if ( is_rosetta_site() ) {
+		$locale_title = get_rosetta_name();
+	} else {
+		$locale_title = '';
+	}
+
 	// Render the block mockup first, because `wp_render_layout_support_flag()` adds callbacks to `wp_footer`.
 	ob_start();
 	require_once __DIR__ . '/footer.php';

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -5,6 +5,12 @@ use function WordPressdotorg\MU_Plugins\Global_Header_Footer\{ get_home_url };
 
 defined( 'WPINC' ) || die();
 
+/**
+ * Defined in `render_global_footer()`.
+ *
+ * @var string $locale_title
+ */
+
 ?>
 
 <!-- wp:group {"tagName":"footer","align":"full","className":"global-footer"} -->
@@ -49,22 +55,36 @@ defined( 'WPINC' ) || die();
 
 	<!-- wp:group {"className":"global-footer__logos-container"} -->
 	<div class="wp-block-group global-footer__logos-container">
-		<!-- The design calls for two logos, a small "mark" on mobile/tablet, and the full logo for desktops. -->
-		<!-- wp:image {"width":27,"height":27,"className":"global-footer__wporg-logo-mark"} -->
-		<figure class="wp-block-image is-resized global-footer__wporg-logo-mark">
-			<a href="<?php echo esc_url( get_home_url() ); ?>">
-				<img src="https://wordpress.org/style/images/w-mark.svg" alt="<?php echo esc_html_x( 'WordPress.org', 'Image alt text', 'wporg' ); ?>" width="27" height="27" />
-			</a>
-		</figure>
-		<!-- /wp:image -->
+		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false,"justifyContent":"left"}} -->
+		<div class="wp-block-group">
+			<!-- The design calls for two logos, a small "mark" on mobile/tablet, and the full logo for desktops. -->
+			<!-- wp:image {"width":27,"height":27,"className":"global-footer__wporg-logo-mark"} -->
+			<figure class="wp-block-image is-resized global-footer__wporg-logo-mark">
+				<a href="<?php echo esc_url( get_home_url() ); ?>">
+					<img src="https://wordpress.org/style/images/w-mark.svg" alt="<?php echo esc_html_x( 'WordPress.org', 'Image alt text', 'wporg' ); ?>" width="27" height="27" />
+				</a>
+			</figure>
+			<!-- /wp:image -->
 
-		<!-- wp:image {"width":160,"height":24,"className":"global-footer__wporg-logo-full"} -->
-		<figure class="wp-block-image is-resized global-footer__wporg-logo-full">
-			<a href="<?php echo esc_url( get_home_url() ); ?>">
-				<img src="<?php echo plugin_dir_url( __FILE__ ) . 'images/wporg-logo.svg'; ?>" alt="<?php echo esc_html_x( 'WordPress.org', 'Image alt text', 'wporg' ); ?>" width="160" height="24" />
-			</a>
-		</figure>
-		<!-- /wp:image -->
+			<!-- wp:image {"width":160,"height":24,"className":"global-footer__wporg-logo-full"} -->
+			<figure class="wp-block-image is-resized global-footer__wporg-logo-full">
+				<a href="<?php echo esc_url( get_home_url() ); ?>">
+					<img src="<?php echo plugin_dir_url( __FILE__ ) . 'images/wporg-logo.svg'; ?>" alt="<?php echo esc_html_x( 'WordPress.org', 'Image alt text', 'wporg' ); ?>" width="160" height="24" />
+				</a>
+			</figure>
+			<!-- /wp:image -->
+
+			<?php if ( ! empty( $locale_title ) ) : ?>
+			<!-- wp:paragraph {"className":"global-footer__wporg-locale-title"} -->
+			<p class="global-footer__wporg-locale-title">
+				<a href="https://make.wordpress.org/polyglots/teams/">
+					<?php echo esc_html( $locale_title ); ?>
+				</a>
+			</p>
+			<!-- /wp:paragraph -->
+			<?php endif; ?>
+		</div>
+		<!-- /wp:group -->
 
 		<!-- wp:social-links {"className":"is-style-logos-only"} -->
 		<ul class="wp-block-social-links is-style-logos-only">

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -9,13 +9,22 @@
 		flex-wrap: nowrap;
 	}
 
+	& > :first-child {
+		flex-grow: 1;
+		gap: var(--wp--style--block-gap);
+	}
+
 	& .wp-block-image {
 		text-align: left;
 		margin: 0;
+
+		& a {
+			display: block;
+			line-height: 1;
+		}
 	}
 
 	& .global-footer__wporg-logo-mark {
-		flex-basis: 65%;
 
 		@media (--tablet) {
 			display: none;
@@ -27,8 +36,37 @@
 
 		@media (--tablet) {
 			display: inline;
-			flex-basis: 33%;
 			margin-bottom: 0;
+		}
+	}
+
+	& .global-footer__wporg-locale-title {
+		font-size: 16px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		@media (--tablet) {
+			font-size: 13px;
+			max-width: 8em;
+		}
+
+		@media (--desktop) {
+			max-width: 15em;
+		}
+
+		@media (--desktop-wide) {
+			max-width: 20em;
+		}
+
+		& a {
+			color: inherit;
+			text-decoration: none;
+
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
 		}
 	}
 
@@ -38,6 +76,8 @@
 		margin-bottom: 0;
 
 		@media (--tablet) {
+			flex-basis: unset;
+
 			& img {
 				position: absolute;
 				width: 188px;

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/social-links.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/social-links.pcss
@@ -13,7 +13,6 @@
 	position: relative;
 	top: -3px; /* Align with W logo. */
 	justify-content: flex-end;
-	flex-basis: 35%;
 	min-width: 100px;
 
 	@media (--tablet) {


### PR DESCRIPTION
Fixes #50 — The designs also call for the locale name in the footer, as a link to [the polyglots teams list](https://make.wordpress.org/polyglots/teams/). This adds the title, cutting it off at various sizes so it won't overlap "Code is Poetry".

| English (AU) | Spanish (Dominican Republic)  | Hebrew |
|---|---|---|
| ![en-au-480](https://user-images.githubusercontent.com/541093/150189570-b2710310-d669-4315-8c27-b6c6a0209f9c.png) | ![es-do-480](https://user-images.githubusercontent.com/541093/150189576-c3341f61-58cf-4d7f-b8f1-c20f6f6ada24.png) | ![he-480](https://user-images.githubusercontent.com/541093/150189588-8c76575e-7602-4690-952d-0dc5bb3fa97c.png) |
| ![en-au-960](https://user-images.githubusercontent.com/541093/150189572-9edf3717-241e-4241-9e6b-85a62b7c2da3.png) | ![es-do-960](https://user-images.githubusercontent.com/541093/150189579-b22ef846-cb74-4555-aa09-a0b703d14272.png) | ![he-960](https://user-images.githubusercontent.com/541093/150189590-ab13acc5-2ccc-47d7-9a3e-a6b7351708aa.png) |
| ![en-au-1200](https://user-images.githubusercontent.com/541093/150189574-6c4554cd-3c9c-4ad5-b3d9-38c119b0e569.png) | ![es-do-1200](https://user-images.githubusercontent.com/541093/150189581-3e4977b5-4afe-4f87-82ea-4f9d172d43bf.png) | no change |
| no change | ![es-do-1440](https://user-images.githubusercontent.com/541093/150189582-5d7689e4-0fc4-4650-ad56-a4ab1ebd630c.png) | no change |