### PR TITLE
Localise the footer links to point to the Localised WordPress site when it exists.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -771,7 +771,7 @@ function localize_nav_links( $block ) {
 		'core/navigation-link' === $block['blockName'] &&
 		! empty( $block['attrs']['url'] )
 	) {
-		$block['attrs']['url'] = localize_footer_link( $block['attrs']['url'] );
+		$block['attrs']['url'] = get_localized_footer_link( $block['attrs']['url'] );
 	}
 
 	return $block;
@@ -784,7 +784,7 @@ function localize_nav_links( $block ) {
  *
  * @return string|bool Replacement URL if one exists, false otherwise.
  */
-function localize_footer_link( $url ) {
+function get_localized_footer_link( $url ) {
 	global $rosetta;
 	if ( empty( $rosetta->current_site_domain ) ) {
 		return $url;

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -641,11 +641,7 @@ function get_home_url() {
 
 	if ( is_rosetta_site() ) {
 		$root_site = $rosetta->get_root_site_id();
-		switch_to_blog( $root_site );
-
-		$url = home_url();
-
-		restore_current_blog();
+		$url       = \get_home_url( $root_site, '/' );
 	}
 
 	if ( ! $url ) {

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -733,6 +733,7 @@ function render_global_footer() {
 
 	if ( is_rosetta_site() ) {
 		$locale_title = get_rosetta_name();
+		add_filter( 'render_block_data', __NAMESPACE__ . '\localize_nav_links' );
 	} else {
 		$locale_title = '';
 	}
@@ -753,7 +754,63 @@ function render_global_footer() {
 		$markup .= ob_get_clean();
 	}
 
+	remove_filter( 'render_block_data', __NAMESPACE__ . '\localize_nav_links' );
+
 	return $markup;
+}
+
+/**
+ * Localise a `core/navigation-link` block link to point to the Rosetta site resource.
+ *
+ * Unfortunately WordPress doesn't have a block-specific pre- filter, only a block-specific post-filter.
+ * That's why we specifically check for the blockName here.
+ *
+ * @param array $block The parsed block data.
+ *
+ * @return array
+ */
+function localize_nav_links( $block ) {
+	if (
+		! empty( $block['blockName'] ) &&
+		'core/navigation-link' === $block['blockName'] &&
+		! empty( $block['attrs']['url'] )
+	) {
+		$block['attrs']['url'] = localize_footer_link( $block['attrs']['url'] );
+	}
+
+	return $block;
+}
+
+/**
+ * Get a localized variant of a link included in the global footer.
+ *
+ * @param string $url The URL as it is in the menu.
+ *
+ * @return string|bool Replacement URL if one exists, false otherwise.
+ */
+function localize_footer_link( $url ) {
+	global $rosetta;
+	if ( empty( $rosetta->current_site_domain ) ) {
+		return $url;
+	}
+
+	switch ( $url ) {
+		case 'https://wordpress.org/showcase/':
+		case 'https://wordpress.org/hosting/':
+			return $url;
+
+		case 'https://wordpress.org/support/':
+			// Check if support forum exists.
+			if ( ! $rosetta->has_support_forum() ) {
+				return $url;
+			}
+			break;
+
+		case 'https://learn.wordpress.org/':
+			return add_query_arg( 'locale', get_locale(), $url );
+	}
+
+	return str_replace( 'https://wordpress.org/', 'https://' . $rosetta->current_site_domain . '/', $url );
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -19,7 +19,7 @@ defined( 'WPINC' ) || die();
 	<div class="wp-block-group global-footer__navigation-container">
 		<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-important","overlayMenu":"never"} -->
 			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'About', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/about/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Blog', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/news","kind":"custom","isTopLevelLink":true} /-->
+			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Blog', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/news/","kind":"custom","isTopLevelLink":true} /-->
 			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Hosting', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/hosting/","kind":"custom","isTopLevelLink":true} /-->
 			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Donate', 'Menu item title', 'wporg' ); ?>","url":"https://wordpressfoundation.org/donate/","kind":"custom","isTopLevelLink":true} /-->
 		<!-- /wp:navigation -->


### PR DESCRIPTION
See #52

I've gone with a filter rather than defining a custom array of nav links for ease of future updating; both of the links on the page and more complex logic for the destination url.