### PR TITLE
Fix the close button not showing up in Safari

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -167,13 +167,11 @@
 	}
 }
 
-/* Gutenberg bug, override it locally */
-.global-header__navigation {
-	& .has-modal-open {
-		overflow: visible;
+/* Gutenberg bug: Close button is not visible in Safari; override it locally */
+.global-header__navigation .is-menu-open {
+	overflow: visible;
 
-		& div {
-			overflow: scroll;
-		}
+	& div {
+		overflow: scroll;
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -166,3 +166,14 @@
 		}
 	}
 }
+
+/* Gutenberg bug, override it locally */
+.global-header__navigation {
+	& .has-modal-open {
+		overflow: visible;
+
+		& div {
+			overflow: scroll;
+		}
+	}
+}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -171,7 +171,7 @@
 .global-header__navigation .is-menu-open {
 	overflow: visible;
 
-	& div {
+	& > div {
 		overflow: scroll;
 	}
 }


### PR DESCRIPTION
Fix the close button not showing up in Safari, due to the close button being rendered outside of the elements padding box.

This appears to be styles from upstream in Gutenberg, I'm still creating a PR here for testing, as I'm not 100% sure how to verify it against the Gutenberg trunk blocks.

See #110