### PR TITLE
Mobile Menu: Reduce the top padding

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -13,6 +13,7 @@
 		&.is-menu-open {
 			padding-left: 0;
 			padding-right: 0;
+			padding-top: 0;
 
 			& .wp-block-navigation__container {
 				line-height: 1em;
@@ -21,6 +22,10 @@
 
 			& .wp-block-navigation__submenu-icon {
 				display: none;
+			}
+
+			& .wp-block-navigation__responsive-container-content {
+				padding-top: 2em;
 			}
 		}
 	}


### PR DESCRIPTION
Before:
<img width="501" alt="Screen Shot 2022-01-24 at 3 45 20 pm" src="https://user-images.githubusercontent.com/767313/150728559-5e6e4a9d-5fd8-4365-8cda-ebb4f0079f51.png">

After:
<img width="500" alt="Screen Shot 2022-01-24 at 3 44 56 pm" src="https://user-images.githubusercontent.com/767313/150728569-18f043aa-6d44-417c-ad69-1deee33d89d0.png">

This brings it closer to the figma design, although maybe not pixel perfect.

<img width="642" alt="Screen Shot 2022-01-24 at 3 46 46 pm" src="https://user-images.githubusercontent.com/767313/150728704-e845e070-6b5a-4237-b809-57c5f7ae708b.png">

