### PR TITLE
Attempt to remove our custom search html block with the code search block

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -14,6 +14,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_fonts' );
 add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
 add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
 add_filter( 'render_block_core/navigation-link', __NAMESPACE__ . '\swap_submenu_arrow_svg' );
+add_filter( 'render_block_core/search', __NAMESPACE__ . '\swap_header_search_action', 10, 2 );
 
 /**
  * Register block types
@@ -1043,4 +1044,23 @@ function get_menu_url_for_current_page( $menu_items ) {
  */
 function swap_submenu_arrow_svg( $block_content ) {
 	return str_replace( block_core_navigation_link_render_submenu_icon(), "<svg width='10' height='7' viewBox='0 0 10 7' stroke-width='1.2' xmlns='http://www.w3.org/2000/svg'><path d='M0.416667 1.33325L5 5.49992L9.58331 1.33325'></path></svg>", $block_content );
+}
+
+/**
+ * Replace the search action url with the custom attribute.
+ *
+ * @param string $block_content The block content about to be appended.
+ * @param array  $block         The block details.
+ * @return string The filtered block content.
+ */
+function swap_header_search_action( $block_content, $block ) {
+	if ( ! empty( $block['attrs']['formAction'] ) ) {
+		$block_content = str_replace(
+			'action="' . esc_url( home_url('/') ) . '"',
+			'action="' . esc_url( $block['attrs']['formAction'] ) . '"',
+			$block_content
+		);
+	}
+
+	return $block_content;
 }

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -97,9 +97,9 @@ if ( ! empty( $locale_title ) ) {
 	<!-- wp:navigation {"orientation":"vertical","className":"global-header__search","overlayMenu":"mobile"} -->
 		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>","url":"#","kind":"custom","isTopLevelLink":false} -->
 			<!-- wp:html -->
-				<li>
-					<!-- wp:search <?php echo wp_json_encode( [ 'label' => _x( 'Search', 'button label', 'wporg' ), 'placeholder' => _x( 'Search WP.org...', 'input field placeholder', 'wporg' ), 'buttonText' => _x( 'Submit search', 'button label', 'wporg' ), 'formAction' => 'https://wordpress.org/search/do-search.php' ] ); ?> /-->
-				</li>
+			<li>
+				<!-- wp:search <?php echo wp_json_encode( [ 'label' => _x( 'Search', 'button label', 'wporg' ), 'placeholder' => _x( 'Search WP.org...', 'input field placeholder', 'wporg' ), 'buttonText' => _x( 'Submit search', 'button label', 'wporg' ), 'formAction' => 'https://wordpress.org/search/do-search.php' ] ); ?> /-->
+			</li>
 			<!-- /wp:html -->
 		<!-- /wp:navigation-link -->
 	<!-- /wp:navigation -->

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -98,7 +98,7 @@ if ( ! empty( $locale_title ) ) {
 		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>","url":"#","kind":"custom","isTopLevelLink":false} -->
 			<!-- wp:html -->
 				<li>
-					<!-- wp:search {"label":"<?php echo esc_attr_x( 'Search', 'button label', 'wporg' ); ?>","placeholder":"<?php echo esc_attr_x( 'Search WP.org...', 'input field placeholder', 'wporg' ); ?>","buttonText":"<?php echo esc_attr_x( 'Submit search', 'button label', 'wporg' ); ?>","formAction":"https://wordpress.org/search/do-search.php"} /-->
+					<!-- wp:search <?php echo wp_json_encode( [ 'label' => _x( 'Search', 'button label', 'wporg' ), 'placeholder' => _x( 'Search WP.org...', 'input field placeholder', 'wporg' ), 'buttonText' => _x( 'Submit search', 'button label', 'wporg' ), 'formAction' => 'https://wordpress.org/search/do-search.php' ] ); ?> /-->
 				</li>
 			<!-- /wp:html -->
 		<!-- /wp:navigation-link -->

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -97,45 +97,9 @@ if ( ! empty( $locale_title ) ) {
 	<!-- wp:navigation {"orientation":"vertical","className":"global-header__search","overlayMenu":"mobile"} -->
 		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>","url":"#","kind":"custom","isTopLevelLink":false} -->
 			<!-- wp:html -->
-			<li>
-				<!--
-					This markup is forked from the `wp:search` block. The only reason we're not using that, is because the
-					`action` URL can't be customized.
-
-					@link https://github.com/WordPress/gutenberg/issues/35572
-
-					The only things that changed were:
-
-					1) The instance ID was changed to `99`, to make it likely to be unique.
-					2) Internationalizing the labels. See https://github.com/WordPress/gutenberg/issues/36061 and
-					   related issues for a possible future alternative.
-
-					If that issue is ever resolved, we should be able to replace this with the Search block, without having
-					to change any CSS.
-				-->
-				<form
-					role="search"
-					method="get"
-					action="https://wordpress.org/search/do-search.php"
-					class="wp-block-search__button-outside wp-block-search__text-button global-header__search-form wp-block-search"
-				>
-					<label for="wp-block-search__input-99" class="wp-block-search__label">
-						<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>
-					</label>
-					<div class="wp-block-search__inside-wrapper">
-						<input
-							type="search"
-							id="wp-block-search__input-99"
-							class="wp-block-search__input"
-							name="s"
-							value=""
-							placeholder="<?php echo esc_attr_x( 'Search WP.org...', 'input field placeholder', 'wporg' ); ?>"
-							required=""
-						>
-						<button type="submit" class="wp-block-search__button" aria-label="<?php echo esc_attr_x( 'Submit search', 'button label', 'wporg' ); ?>"></button>
-					</div>
-				</form>
-			</li>
+				<li>
+					<!-- wp:search {"label":"<?php echo esc_attr_x( 'Search', 'button label', 'wporg' ); ?>","placeholder":"<?php echo esc_attr_x( 'Search WP.org...', 'input field placeholder', 'wporg' ); ?>","buttonText":"<?php echo esc_attr_x( 'Submit search', 'button label', 'wporg' ); ?>","formAction":"https://wordpress.org/search/do-search.php"} /-->
+				</li>
 			<!-- /wp:html -->
 		<!-- /wp:navigation-link -->
 	<!-- /wp:navigation -->

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -69,7 +69,7 @@
 
 	& .has-child:hover .wp-block-navigation-item__content,
 	& .has-child:focus-within .wp-block-navigation-item__content,
-	&:not(.has-background) .wp-block-navigation__submenu-container .global-header__search-form {
+	&:not(.has-background) .wp-block-navigation__submenu-container .wp-block-search {
 		background-color: var(--wp--preset--color--darker-grey);
 	}
 
@@ -86,7 +86,7 @@
 		}
 	}
 
-	& .global-header__search-form {
+	& .wp-block-search {
 		margin-top: 0;
 
 		@media (--tablet) {


### PR DESCRIPTION
This is an attempt at migrating from using a custom html block to using the core search block.

This renders correctly, but I've not tested with FSE.

The HTML block is still needed, as there's no other way to wrap it in a `<li/>`..

The `global-header__search-form` class was removed, as I couldn't see any way to define it / didn't seem required with the CSS selector change - There's only so many search fields in the header.

Using `esc_attr_*()` inside JSON doesn't feel right, which is the reason for cb113fd instead.

See #13

**Draft as this is not intended on being used straight away, just looking at what is needed**