### PR TITLE
Search: Fix accessibility issues in search dropdown

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -38,6 +38,14 @@ function register_block_types() {
 		filemtime( __DIR__ . '/js/wporg-global-header-script.js' ),
 		true
 	);
+	wp_localize_script(
+		'wporg-global-header-script',
+		'wporgGlobalHeaderI18n',
+		array(
+			'openSearchLabel' => __( 'Open Search', 'wporg' ),
+			'closeSearchLabel' => __( 'Close Search', 'wporg' ),
+		)
+	);
 
 	register_block_type(
 		'wporg/global-header',

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -94,50 +94,46 @@ if ( ! empty( $locale_title ) ) {
 		calls for. It also provides a consistent experience with the primary navigation menu, with respect to
 		keyboard navigation, ARIA states, etc. It also saves having to write custom code for all the interactions.
 	-->
-	<!-- wp:navigation {"orientation":"vertical","className":"global-header__search","overlayMenu":"mobile"} -->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>","url":"#","kind":"custom","isTopLevelLink":false} -->
-			<!-- wp:html -->
-			<li>
-				<!--
-					This markup is forked from the `wp:search` block. The only reason we're not using that, is because the
-					`action` URL can't be customized.
+	<!-- wp:navigation {"orientation":"vertical","className":"global-header__search","overlayMenu":"always"} -->
+		<!-- wp:html -->
+		<!--
+			This markup is forked from the `wp:search` block. The only reason we're not using that, is because the
+			`action` URL can't be customized.
 
-					@link https://github.com/WordPress/gutenberg/issues/35572
+			@link https://github.com/WordPress/gutenberg/issues/35572
 
-					The only things that changed were:
+			The only things that changed were:
 
-					1) The instance ID was changed to `99`, to make it likely to be unique.
-					2) Internationalizing the labels. See https://github.com/WordPress/gutenberg/issues/36061 and
-					   related issues for a possible future alternative.
+			1) The instance ID was changed to `99`, to make it likely to be unique.
+			2) Internationalizing the labels. See https://github.com/WordPress/gutenberg/issues/36061 and
+			   related issues for a possible future alternative.
 
-					If that issue is ever resolved, we should be able to replace this with the Search block, without having
-					to change any CSS.
-				-->
-				<form
-					role="search"
-					method="get"
-					action="https://wordpress.org/search/do-search.php"
-					class="wp-block-search__button-outside wp-block-search__text-button global-header__search-form wp-block-search"
+			If that issue is ever resolved, we should be able to replace this with the Search block, without having
+			to change any CSS.
+		-->
+		<form
+			role="search"
+			method="get"
+			action="https://wordpress.org/search/do-search.php"
+			class="wp-block-search__button-outside wp-block-search__text-button global-header__search-form wp-block-search"
+		>
+			<label for="wp-block-search__input-99" class="wp-block-search__label">
+				<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>
+			</label>
+			<div class="wp-block-search__inside-wrapper">
+				<input
+					type="search"
+					id="wp-block-search__input-99"
+					class="wp-block-search__input"
+					name="s"
+					value=""
+					placeholder="<?php echo esc_attr_x( 'Search WP.org...', 'input field placeholder', 'wporg' ); ?>"
+					required=""
 				>
-					<label for="wp-block-search__input-99" class="wp-block-search__label">
-						<?php echo esc_html_x( 'Search', 'button label', 'wporg' ); ?>
-					</label>
-					<div class="wp-block-search__inside-wrapper">
-						<input
-							type="search"
-							id="wp-block-search__input-99"
-							class="wp-block-search__input"
-							name="s"
-							value=""
-							placeholder="<?php echo esc_attr_x( 'Search WP.org...', 'input field placeholder', 'wporg' ); ?>"
-							required=""
-						>
-						<button type="submit" class="wp-block-search__button" aria-label="<?php echo esc_attr_x( 'Submit search', 'button label', 'wporg' ); ?>"></button>
-					</div>
-				</form>
-			</li>
-			<!-- /wp:html -->
-		<!-- /wp:navigation-link -->
+				<button type="submit" class="wp-block-search__button" aria-label="<?php echo esc_attr_x( 'Submit search', 'button label', 'wporg' ); ?>"></button>
+			</div>
+		</form>
+		<!-- /wp:html -->
 	<!-- /wp:navigation -->
 	<?php endif; ?>
 

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -1,3 +1,4 @@
+/* global wporgGlobalHeaderI18n */
 /**
  * File wporg-global-header-script.js.
  *
@@ -171,6 +172,11 @@
 	/* eslint-disable @wordpress/no-global-event-listener */
 	window.addEventListener( 'load', function () {
 		new navMenu( '.global-header .global-header__navigation' );
+
+		const openSearchButton = document.querySelector( '.global-header__search [data-micromodal-trigger]' );
+		const closeSearchButton = document.querySelector( '.global-header__search button[data-micromodal-close]' );
+		openSearchButton.setAttribute( 'aria-label', wporgGlobalHeaderI18n.openSearchLabel );
+		closeSearchButton.setAttribute( 'aria-label', wporgGlobalHeaderI18n.closeSearchLabel );
 
 		const openButtons = document.querySelectorAll( '[data-micromodal-trigger]' );
 		openButtons.forEach( function ( button ) {

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -66,24 +66,7 @@ html {
 		font-size: 21px;
 
 		@media (--tablet) {
-			background-color: var(--wp--preset--color--dark-grey);
 			font-size: 13px;
-		}
-	}
-
-	& .wp-block-navigation__responsive-container:not(.is-menu-open) {
-		display: none; /* Gutenberg has the menu hardcoded to open at 600px, but we need it to wait until `--tablet`. */
-
-		@media (--tablet) {
-			display: flex;
-		}
-	}
-
-	& .wp-block-navigation__responsive-container-open {
-		display: flex; /* Gutenberg has the button hardcoded to hide at 600px, but we need it to wait until `--tablet`. */
-
-		@media (--tablet) {
-			display: none;
 		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -9,7 +9,23 @@
 		text-align: left;
 	}
 
+	& .wp-block-navigation__responsive-container-open {
+		display: flex; /* Gutenberg has the button hardcoded to hide at 600px, but we need it to wait until `--tablet`. */
+
+		@media (--tablet) {
+			display: none;
+		}
+	}
+
 	& .wp-block-navigation__responsive-container {
+		&:not(.is-menu-open) {
+			display: none; /* Gutenberg has the menu hardcoded to open at 600px, but we need it to wait until `--tablet`. */
+
+			@media (--tablet) {
+				display: flex;
+			}
+		}
+
 		&.is-menu-open {
 			padding-left: 0;
 			padding-right: 0;
@@ -154,6 +170,10 @@
 }
 
 .global-header {
+	& .global-header__search {
+		position: relative;
+	}
+
 	& .wp-block-navigation__responsive-container.is-menu-open {
 
 		/*
@@ -161,6 +181,20 @@
 		 * var() fallback must be `0px` with unit for calc addition to work.
 		 */
 		top: calc(117px + var(--wp-admin--admin-bar--height, 0px));
+
+		@media (--tablet) {
+			position: absolute;
+			top: 100%;
+			left: auto;
+			right: 0;
+			bottom: auto;
+			width: 300px;
+			padding: 0;
+
+			& .wp-block-navigation__responsive-container-content {
+				padding-top: 0;
+			}
+		}
 
 		&:not(.has-background) {
 			background: var(--wp--preset--color--darker-grey);

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -99,7 +99,18 @@
 			font-size: 21px;
 
 			@media (--tablet) {
-				display: none;
+
+				/* See @mixin hide-accessibly in wporg-news-2021 */
+				border: 0;
+				clip: rect(1px, 1px, 1px, 1px);
+				clip-path: inset(50%);
+				height: 1px;
+				margin: -1px;
+				overflow: hidden;
+				padding: 0;
+				position: absolute;
+				width: 1px;
+				word-wrap: normal !important;
 			}
 		}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -7,6 +7,22 @@
 		padding-bottom: 0;
 	}
 
+	& .wp-block-navigation__responsive-container {
+
+		@media (--tablet) {
+			overflow: visible;
+		}
+	}
+
+	& .wp-block-navigation__responsive-container-open,
+	& .wp-block-navigation__responsive-container-close {
+
+		@media (--tablet) {
+			padding-top: 42px;
+			padding-bottom: 38px;
+		}
+	}
+
 	& .wp-block-navigation__responsive-container-open {
 		box-sizing: content-box;
 		width: 24px;
@@ -15,74 +31,28 @@
 		background-repeat: no-repeat;
 		background-position: top 72px left var(--wp--style--block-gap);
 
+		@media (--tablet) {
+			background-size: 17px 17px;
+			background-position: top 46px left calc(var(--wp--style--block-gap) + 3px);
+		}
+
+		&:hover {
+			background-color: var(--wp--preset--color--darker-grey);
+		}
+
 		& svg {
 			display: none;
 		}
 	}
 
-	& .wp-block-navigation__container {
-		padding-top: 0;
-	}
-
-	& .wp-block-navigation-item__label {
-
-		/* See @mixin hide-accessibly in wporg-news-2021 */
-		border: 0;
-		clip: rect(1px, 1px, 1px, 1px);
-		clip-path: inset(50%);
-		height: 1px;
-		margin: -1px;
-		overflow: hidden;
-		padding: 0;
-		position: absolute;
-		width: 1px;
-		word-wrap: normal !important;
-	}
-
-	& .wp-block-navigation-item__content {
-		padding: 42px var(--wp--style--block-gap) 37px;
-		display: none;
+	& .wp-block-navigation__responsive-container-close {
+		right: calc(73px + var(--wp--custom--alignment--scroll-bar-width));
+		padding-right: var(--wp--style--block-gap);
 
 		@media (--tablet) {
-			display: block;
-		}
-	}
-
-	& .wp-block-navigation__submenu-icon {
-
-		/* Replace the submenu icon with the search icon. */
-		@media (--tablet) {
-			display: inline-block;
-			width: 24px;
-			height: 24px;
-			background-size: 17px 17px;
-			background-image: url(../images/search.svg);
-			background-repeat: no-repeat;
-			background-position: center center;
-			margin-left: 0;
-
-			& svg {
-				display: none;
-			}
-		}
-	}
-
-	& .has-child:hover .wp-block-navigation-item__content,
-	& .has-child:focus-within .wp-block-navigation-item__content,
-	&:not(.has-background) .wp-block-navigation__submenu-container .global-header__search-form {
-		background-color: var(--wp--preset--color--darker-grey);
-	}
-
-	& .wp-block-navigation__responsive-container-content .wp-block-navigation__submenu-container {
-		padding: 0;
-
-		@media (--tablet) {
-			width: 300px;
-			bottom: 0;
+			position: absolute;
+			top: -104px;
 			right: 0;
-			left: auto;
-			transform: translateY(-100%);
-			border: none;
 		}
 	}
 
@@ -173,10 +143,5 @@
 				cursor: pointer;
 			}
 		}
-	}
-
-	& .wp-block-navigation__responsive-container-close {
-		right: calc(73px + var(--wp--custom--alignment--scroll-bar-width));
-		padding-right: var(--wp--style--block-gap);
 	}
 }


### PR DESCRIPTION
Fixes #118 — this switches the search navigation menu to use `"overlayMenu":"always"`, so that the toggle button has the correct semantics for a show/hide button.

Currently the search icon in the header is a link that shows a submenu, which works visually, but if you're navigating via screen reader you just hear "Search, link", and clicking it appears to do nothing. By switching to the mobile menu interface always, the search link becomes a button with a popup, and clicking it shows the search menu.

⚠️  This does remove the hover effect (where the search appears on hover), but IMO fixing the accessibility issue is more important than the hover effect. cc @beafialho 

Props to @alexstine for the original bug report.

**Screenshots**

Aside from the hover issue, there should be no visual changes between trunk & this PR.
|   | Before | After |
|---|--------|-------|
| Default | ![](https://user-images.githubusercontent.com/541093/150856315-3f044253-900f-4187-8cdb-5c0ff522e418.png) | ![](https://user-images.githubusercontent.com/541093/150856347-fabceb37-71dc-462d-867e-11ffe0bf5a0f.png) |
| Menu open | ![](https://user-images.githubusercontent.com/541093/150856316-d6020801-e4da-42e3-99fd-3dc98af557d7.png) | ![](https://user-images.githubusercontent.com/541093/150856348-61ac7242-d62d-45ab-851b-8685006b0bcf.png) |
| Search open | ![](https://user-images.githubusercontent.com/541093/150856319-52719998-4dc6-46c2-bb6d-7e88ffc8fe83.png) | ![](https://user-images.githubusercontent.com/541093/150856350-70485b3d-eb26-4d24-b38c-413c5466e5e2.png) |
| Default | ![](https://user-images.githubusercontent.com/541093/150856320-cb7c390a-b50e-45f4-a0c7-9359a90256d2.png) | ![](https://user-images.githubusercontent.com/541093/150856351-36824ed1-016b-48d9-ae28-c61992cf84a5.png) |
| Menu open | ![](https://user-images.githubusercontent.com/541093/150856321-0737b115-e26b-4107-86c4-8d08744b946f.png)| ![](https://user-images.githubusercontent.com/541093/150856354-677e492b-bcd9-4016-86f6-f84c781be270.png) |
| Search open | ![](https://user-images.githubusercontent.com/541093/150856324-db20dd66-59fb-4034-9449-8aaec56b1f74.png) | ![](https://user-images.githubusercontent.com/541093/150856355-b177f41a-0ce4-4dcc-b9ee-3715ace678ae.png) |
| Default | ![](https://user-images.githubusercontent.com/541093/150856326-c0cdf518-84f0-4c93-a6a4-277577063e69.png) | ![](https://user-images.githubusercontent.com/541093/150856357-6e1c4032-a9e3-44b7-b754-4dbe3aabce3b.png) |
| Search open | ![](https://user-images.githubusercontent.com/541093/150856327-0d3f5004-eede-4e76-9f2a-eb5452504b1d.png) | ![](https://user-images.githubusercontent.com/541093/150856360-412ba2e1-7c2a-4baf-adb2-b95be7fdccfa.png) |

**To test**

1. Using a screen reader, navigate through the header
2. You _should not_ hear a "Search, link" item
3. You _should_ hear something like "Open search, menu popup, button"
4. Activate the button, you'll be moved into the search field, which is labelled now
5. Tabbing through keeps you in the search popup - hit tab twice to get back to the close button
6. Hit close or escape to get out
7. Continue on to other content

Also test without using a screen reader, and/or at various sizes. On small screens, there's now a label difference between the navigation menu label ("Open menu") and search menu label ("Open search").

