### PR TITLE
Header padding & sizing adjustments

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -200,35 +200,4 @@
 			}
 		}
 	} );
-
-	/**
-	 * Scroll throttle flag
-	 *
-	 * @param {bool} throttled or not.
-	 */
-	let scrollThrottled = false;
-
-	/* eslint-disable @wordpress/no-global-event-listener */
-	window.addEventListener( 'scroll', function () {
-		if ( scrollThrottled ) {
-			return;
-		}
-
-		let isSlimline = document.documentElement.classList.contains('slimline'),
-			shouldBeSlimline = Math.max( document.body.scrollTop, document.documentElement.scrollTop ) > 250;
-
-		if ( ! isSlimline && shouldBeSlimline ) {
-			document.documentElement.classList.add('slimline');
-
-			scrollThrottled = true;
-		} else if ( isSlimline && ! shouldBeSlimline ) {
-			document.documentElement.classList.remove('slimline');
-
-			scrollThrottled = true;
-		}
-
-		if ( scrollThrottled ) {
-			setTimeout(() => scrollThrottled = false, 400 );
-		}
-	} );
 } )();

--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -200,4 +200,35 @@
 			}
 		}
 	} );
+
+	/**
+	 * Scroll throttle flag
+	 *
+	 * @param {bool} throttled or not.
+	 */
+	let scrollThrottled = false;
+
+	/* eslint-disable @wordpress/no-global-event-listener */
+	window.addEventListener( 'scroll', function () {
+		if ( scrollThrottled ) {
+			return;
+		}
+
+		let isSlimline = document.documentElement.classList.contains('slimline'),
+			shouldBeSlimline = Math.max( document.body.scrollTop, document.documentElement.scrollTop ) > 250;
+
+		if ( ! isSlimline && shouldBeSlimline ) {
+			document.documentElement.classList.add('slimline');
+
+			scrollThrottled = true;
+		} else if ( isSlimline && ! shouldBeSlimline ) {
+			document.documentElement.classList.remove('slimline');
+
+			scrollThrottled = true;
+		}
+
+		if ( scrollThrottled ) {
+			setTimeout(() => scrollThrottled = false, 400 );
+		}
+	} );
 } )();

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -16,7 +16,7 @@
 
 /* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
 html {
-	scroll-padding-top: calc(105px + var(--wp-admin--admin-bar--height, 0px)); /* 105px = height of header. */
+	scroll-padding-top: calc( var(--wp-global-header-height,  0px) + var(--wp-admin--admin-bar--height, 0px));
 	height: unset; /* Let height use default browser height. */
 }
 

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -14,9 +14,12 @@
 @custom-media --desktop (min-width: 1152px);
 @custom-media --desktop-wide (min-width: 1440px);
 
+/* Height breakpoint to toggle the short header on desktop screens. */
+@custom-media --short-screen ((max-height: 800px) and (min-width: 890px));
+
 /* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
 html {
-	scroll-padding-top: calc( var(--wp-global-header-height,  0px) + var(--wp-admin--admin-bar--height, 0px));
+	scroll-padding-top: calc(var(--wp-global-header-height, 0px) + var(--wp-admin--admin-bar--height, 0px));
 	height: unset; /* Let height use default browser height. */
 }
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -13,19 +13,29 @@
 html.slimline .wp-block-group.global-header {
 	& .wp-block-navigation__container .wp-block-navigation-item {
 		&.current-menu-item > a {
-			padding-bottom: calc( 20px - var(--active-menu-item-border-height) );
+			padding-bottom: calc(20px - var(--active-menu-item-border-height));
 		}
+
 		& a {
 			padding-bottom: 20px;
 			padding-top: 15px;
 		}
 	}
+
 	& > * {
 		padding-top: 20px;
 		padding-bottom: 20px;
 	}
+
 	& > nav {
 		padding-bottom: 0;
+	}
+
+	& .global-header__search .wp-block-navigation__responsive-container-close,
+	& .global-header__search .wp-block-navigation__responsive-container-open {
+		padding-bottom: 20px;
+		padding-top: 16px;
+		background-position: center;
 	}
 }
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -3,8 +3,35 @@
 
 	@media (--tablet) {
 		--wp-global-header-height: 90px;
+
+		&.slimline {
+			--wp-global-header-height: 60px;
+		}
 	}
 }
+
+html.slimline .wp-block-group.global-header {
+	& .wp-block-navigation-item a {
+		padding-top: 18px;
+		padding-bottom: 18px;
+	}
+	& .wp-block-navigation__container .wp-block-navigation-item {
+		&.current-menu-item > a {
+			padding-bottom: calc( 20px - var(--active-menu-item-border-height) );
+		}
+		& a {
+			padding-bottom: 20px;
+		}
+	}
+	& > * {
+		padding-top: 20px;
+		padding-bottom: 20px;
+	}
+	& > .global-header__navigation {
+		padding-bottom: 0;
+	}
+}
+
 .wp-block-group.global-header {
 	display: flex;
 	align-items: flex-end;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -32,7 +32,7 @@
 
 		@media (--tablet) {
 			padding-top: 33px;
-			padding-bottom: 30px;
+			padding-bottom: 33px;
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -31,8 +31,8 @@
 		margin: 0;
 
 		@media (--tablet) {
-			padding-top: 37px;
-			padding-bottom: 37px;
+			padding-top: 33px;
+			padding-bottom: 30px;
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -1,7 +1,15 @@
+:root {
+	--wp-global-header-height: 60px;
+
+	@media (--tablet) {
+		--wp-global-header-height: 90px;
+	}
+}
 .wp-block-group.global-header {
 	display: flex;
 	align-items: flex-end;
 	font-size: 21px;
+	height: var(--wp-global-header-height);
 
 	/*
 	 * Some themes set a `z-index` on content elements that follow the header, like `#masthead` in
@@ -34,8 +42,8 @@
 
 		& .wp-block-navigation__responsive-container-open {
 
-			/* Magic numbers to center the 24px icon in 117px height. */
-			padding: 70px var(--wp--style--block-gap) 23px;
+			/* Magic numbers to center the 24px icon in 60px height. */
+			padding: 18px var(--wp--style--block-gap) 18px;
 
 			@media (--tablet) {
 				padding-top: 37px;
@@ -64,9 +72,9 @@
 		position: fixed;
 		right: 0;
 		top: var(--wp-admin--admin-bar--height, 0);
-		padding-top: 70px; /* Magic numbers to center the 24px icon in 117px height. */
+		padding-top: 18px; /* Magic numbers to center the 24px icon in 60px height. */
 		padding-right: calc(var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
-		padding-bottom: 23px; /* Magic numbers to center the 24px icon in 117px height. */
+		padding-bottom: 28px; /* Magic numbers to center the 24px icon in 60px height. */
 		padding-left: var(--wp--style--block-gap);
 		background-color: var(--wp--preset--color--darker-grey);
 	}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -11,23 +11,20 @@
 }
 
 html.slimline .wp-block-group.global-header {
-	& .wp-block-navigation-item a {
-		padding-top: 18px;
-		padding-bottom: 18px;
-	}
 	& .wp-block-navigation__container .wp-block-navigation-item {
 		&.current-menu-item > a {
 			padding-bottom: calc( 20px - var(--active-menu-item-border-height) );
 		}
 		& a {
 			padding-bottom: 20px;
+			padding-top: 15px;
 		}
 	}
 	& > * {
 		padding-top: 20px;
 		padding-bottom: 20px;
 	}
-	& > .global-header__navigation {
+	& > nav {
 		padding-bottom: 0;
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -1,41 +1,12 @@
-:root {
+html {
 	--wp-global-header-height: 60px;
 
 	@media (--tablet) {
 		--wp-global-header-height: 90px;
-
-		&.slimline {
-			--wp-global-header-height: 60px;
-		}
-	}
-}
-
-html.slimline .wp-block-group.global-header {
-	& .wp-block-navigation__container .wp-block-navigation-item {
-		&.current-menu-item > a {
-			padding-bottom: calc(20px - var(--active-menu-item-border-height));
-		}
-
-		& a {
-			padding-bottom: 20px;
-			padding-top: 15px;
-		}
 	}
 
-	& > * {
-		padding-top: 20px;
-		padding-bottom: 20px;
-	}
-
-	& > nav {
-		padding-bottom: 0;
-	}
-
-	& .global-header__search .wp-block-navigation__responsive-container-close,
-	& .global-header__search .wp-block-navigation__responsive-container-open {
-		padding-bottom: 20px;
-		padding-top: 16px;
-		background-position: center;
+	@media (--short-screen) {
+		--wp-global-header-height: 60px;
 	}
 }
 
@@ -111,5 +82,18 @@ html.slimline .wp-block-group.global-header {
 		padding-bottom: 28px; /* Magic numbers to center the 24px icon in 60px height. */
 		padding-left: var(--wp--style--block-gap);
 		background-color: var(--wp--preset--color--darker-grey);
+	}
+}
+
+@media (--short-screen) {
+	.wp-block-group.global-header {
+		& > * {
+			padding-top: 20px;
+			padding-bottom: 20px;
+		}
+
+		& > nav {
+			padding-bottom: 0;
+		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -45,7 +45,7 @@
 		font-family: var(--wp--preset--font-family--eb-garamond);
 		font-size: var(--wp--preset--font-size--large);
 		font-weight: 400;
-		line-height: 1.3;
+		line-height: 1.35;
 
 		& span {
 			border-left: 1px solid;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -175,12 +175,7 @@
 	}
 
 	& .wp-block-navigation__responsive-container.is-menu-open {
-
-		/*
-		 * 117px = height of .global-header
-		 * var() fallback must be `0px` with unit for calc addition to work.
-		 */
-		top: calc(117px + var(--wp-admin--admin-bar--height, 0px));
+		top: calc(var(--wp-global-header-height, 0px) + var(--wp-admin--admin-bar--height, 0px));
 
 		@media (--tablet) {
 			position: absolute;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -106,6 +106,7 @@
 		font-size: 15px;
 		gap: 0.5em;
 		padding-bottom: calc(var(--wp--style--block-gap) / 2);
+		border: none;
 
 		@media (--tablet) {
 			font-size: inherit;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -56,53 +56,48 @@
 		}
 
 		& .wp-block-navigation-item {
+			&:hover,
+			&:focus-within {
+				background-color: var(--wp--preset--color--darker-grey);
+			}
+
+			&.current-menu-item > a {
+				border-left: var(--active-menu-item-border-height) solid #7b90ff;
+				color: #7b90ff;
+				font-weight: 700;
+
+				@media (--tablet) {
+					border-bottom: var(--active-menu-item-border-height) solid #7b90ff;
+					border-left: none;
+					padding-bottom: calc( var(--wp--style--block-gap) + var(--active-menu-item-border-height, 0px) );
+				}
+			}
+
+			&.has-child {
+				padding-bottom: 0;
+			}
+
+			& ul .current-menu-item a {
+				border-left: none;
+				border-bottom: none;
+			}
+		}
+
+		& .wp-block-navigation-item a {
 			padding-left: var(--wp--style--block-gap);
 			padding-top: calc(var(--wp--style--block-gap) / 2);
 			padding-bottom: calc(var(--wp--style--block-gap) / 2);
 
-			&.has-child {
-				padding-bottom: 0;
-
-				@media (--tablet) {
-					padding-bottom: 37px;
-				}
-			}
-
-			@media (--tablet) {
-				padding-bottom: 37px;
-				padding-top: 42px;
-				padding-left: calc(var(--wp--style--block-gap) / 2);
-				padding-right: calc(var(--wp--style--block-gap) / 2);
-			}
-
 			&:hover,
 			&:focus-within {
 				background-color: var(--wp--preset--color--darker-grey);
-
-				& ul {
-					border-top: none;
-					background-color: var(--wp--preset--color--darker-grey);
-				}
 			}
 
-			&.current-menu-item {
-				border-left: var(--active-menu-item-border-height) solid #7b90ff;
-
-				@media (--tablet) {
-					padding-bottom: calc(37px - var(--active-menu-item-border-height));
-					border-bottom: var(--active-menu-item-border-height) solid #7b90ff;
-					border-left: none;
-				}
-
-				& > a {
-					color: #7b90ff;
-					font-weight: 700;
-				}
-			}
-
-			& ul .current-menu-item {
-				border-left: none;
-				border-bottom: none;
+			@media (--tablet) {
+				padding-bottom: 33px;
+				padding-top: 33px;
+				padding-left: calc(var(--wp--style--block-gap) / 2);
+				padding-right: calc(var(--wp--style--block-gap) / 2);
 			}
 		}
 	}
@@ -111,31 +106,31 @@
 		font-size: 15px;
 		gap: 0.5em;
 		padding-bottom: calc(var(--wp--style--block-gap) / 2);
-		padding-left: calc(var(--wp--style--block-gap) / 2);
 
 		@media (--tablet) {
 			font-size: inherit;
 			gap: inherit;
 			padding-bottom: 0;
+
+			& a:hover,
+			& a:focus {
+				text-decoration: underline;
+			}
 		}
 
-		& .wp-block-navigation-item {
-			padding: calc(var(--wp--style--block-gap) / 4);
-		}
-
-		& a:hover,
-		& a:focus {
-			text-decoration: underline;
+		& .wp-block-navigation-item a {
+			padding: calc(var(--wp--style--block-gap) / 2) var(--wp--style--block-gap);
 		}
 	}
 
 	& .wp-block-navigation__container .wp-block-navigation-item.global-header__overflow-menu {
 
 		@media (--tablet) {
-
 			/* Add extra space around the overflow … to make a bigger tap/hover target. */
-			padding-left: var(--wp--style--block-gap);
-			padding-right: var(--wp--style--block-gap);
+			& a {
+				padding-left: var(--wp--style--block-gap);
+				padding-right: var(--wp--style--block-gap);
+			}
 		}
 
 		& .global-header__overflow-item {
@@ -149,8 +144,8 @@
 		& > ul {
 			padding-left: 0;
 
-			& li {
-				padding-left: calc(var(--wp--style--block-gap) / 2 );
+			& li a {
+				padding-left: var(--wp--style--block-gap);
 			}
 		}
 	}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -69,7 +69,7 @@
 				@media (--tablet) {
 					border-bottom: var(--active-menu-item-border-height) solid #7b90ff;
 					border-left: none;
-					padding-bottom: calc( var(--wp--style--block-gap) + var(--active-menu-item-border-height, 0px) );
+					padding-bottom: calc(var(--wp--style--block-gap) + var(--active-menu-item-border-height, 0px));
 				}
 			}
 
@@ -105,12 +105,15 @@
 	& .wp-block-navigation__container .wp-block-navigation__submenu-container {
 		font-size: 15px;
 		gap: 0.5em;
+		padding-top: calc(var(--wp--style--block-gap) / 2);
 		padding-bottom: calc(var(--wp--style--block-gap) / 2);
 		border: none;
+		left: 0;
 
 		@media (--tablet) {
 			font-size: inherit;
 			gap: inherit;
+			padding-top: 0;
 			padding-bottom: 0;
 
 			& a:hover,
@@ -120,13 +123,18 @@
 		}
 
 		& .wp-block-navigation-item a {
-			padding: calc(var(--wp--style--block-gap) / 2) var(--wp--style--block-gap);
+			padding: calc(var(--wp--style--block-gap) / 4);
+
+			@media (--tablet) {
+				padding: calc(var(--wp--style--block-gap) / 2) var(--wp--style--block-gap);
+			}
 		}
 	}
 
 	& .wp-block-navigation__container .wp-block-navigation-item.global-header__overflow-menu {
 
 		@media (--tablet) {
+
 			/* Add extra space around the overflow … to make a bigger tap/hover target. */
 			& a {
 				padding-left: var(--wp--style--block-gap);

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -27,9 +27,7 @@
 		}
 
 		&.is-menu-open {
-			padding-left: 0;
-			padding-right: 0;
-			padding-top: 0;
+			padding: 0;
 
 			& .wp-block-navigation__container {
 				line-height: 1em;
@@ -71,6 +69,10 @@
 					border-left: none;
 					padding-bottom: calc(var(--wp--style--block-gap) + var(--active-menu-item-border-height, 0px));
 				}
+
+				@media (--short-screen) {
+					padding-bottom: calc(20px - var(--active-menu-item-border-height));
+				}
 			}
 
 			&.has-child {
@@ -98,6 +100,11 @@
 				padding-top: 33px;
 				padding-left: calc(var(--wp--style--block-gap) / 2);
 				padding-right: calc(var(--wp--style--block-gap) / 2);
+			}
+
+			@media (--short-screen) {
+				padding-bottom: 20px;
+				padding-top: 15px;
 			}
 		}
 	}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -29,7 +29,7 @@
 		height: 24px;
 		background-image: url(../images/search.svg);
 		background-repeat: no-repeat;
-		background-position: top 72px left var(--wp--style--block-gap);
+		background-position: top 20px left var(--wp--style--block-gap);
 
 		@media (--tablet) {
 			background-size: 17px 17px;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -18,8 +18,8 @@
 	& .wp-block-navigation__responsive-container-close {
 
 		@media (--tablet) {
-			padding-top: 42px;
-			padding-bottom: 38px;
+			padding-top: 33px;
+			padding-bottom: 33px;
 		}
 	}
 
@@ -33,7 +33,7 @@
 
 		@media (--tablet) {
 			background-size: 17px 17px;
-			background-position: top 46px left calc(var(--wp--style--block-gap) + 3px);
+			background-position: center;
 		}
 
 		&:hover {
@@ -51,7 +51,7 @@
 
 		@media (--tablet) {
 			position: absolute;
-			top: -104px;
+			top: calc(var(--wp-global-header-height) * -1);
 			right: 0;
 		}
 	}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -21,6 +21,12 @@
 			padding-top: 33px;
 			padding-bottom: 33px;
 		}
+
+		@media (--short-screen) {
+			padding-bottom: 20px;
+			padding-top: 16px;
+			background-position: center;
+		}
 	}
 
 	& .wp-block-navigation__responsive-container-open {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -64,9 +64,11 @@
 
 	& .global-header__search-form {
 		margin-top: 0;
+		width: 100%;
 
 		@media (--tablet) {
 			padding: 20px;
+			width: auto;
 		}
 
 		& .wp-block-search__label {


### PR DESCRIPTION
This PR is focused on several issues:

 - Desktop Header height was implemented at 105px rather than 90px, #115
 - Desktop Menu targets should have been larger, #16
 - Mobile Menu padding doesn't need to be as large, #16 
 - Desktop header is too large consistently on scroll for small viewports, common community complaint, as suggested by a few, reducing it on scroll make sense IMO. This might not be as required due to the 15px removed in #115, but another 30px is not insignificant on some screen resolutions.

60px for mobile was chosen as at 2/3's of the 90px expected height, and any smaller felt cramped. It's also just over twice the logo sizes.

A CSS variable is introduced for those different header sizes, as it's needed in other themes for determining placement.

The 'slimline' variant introduced on scroll here was an experiment, and easily removable, but did not make sense as a separate PR due to the other size changes required here (and for the functionality). 063b3487a0ecd5a29c31e73606bff6e6453c5203 & 9a8708da7723d4f57edb4f3bfcd17975c30947c6 can be removed if required and pushed to a different PR dependant upon this one.
It might make sense to only use the slim header on smaller window resolutions, or not implement it at all, and instead simply disable the fixed positioning in small windows.

Full header:
<img width="1412" alt="Screen Shot 2022-01-25 at 5 17 58 pm" src="https://user-images.githubusercontent.com/767313/150932891-4ea035b0-ae84-4bf6-8b5c-6f3cb7f06aa3.png">

Slim header:
<img width="1407" alt="Screen Shot 2022-01-25 at 5 23 04 pm" src="https://user-images.githubusercontent.com/767313/150932943-ff2c133a-ab6e-45a0-922a-efc4fd326352.png">

Video:
https://user-images.githubusercontent.com/767313/150933331-36fb7f15-b0b5-432e-b2ae-065b7bfae18e.mov
