### PR TITLE
Change header and footer font sizes to 14px

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -66,7 +66,7 @@ html {
 		font-size: 21px;
 
 		@media (--tablet) {
-			font-size: 13px;
+			font-size: var(--wp--preset--font-size--small);
 		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
@@ -24,7 +24,7 @@
 		align-items: self-start;
 
 		@media (--tablet) {
-			font-size: 13px;
+			font-size: var(--wp--preset--font-size--small);
 		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -14,7 +14,7 @@
 	@media (--tablet) {
 		position: sticky;
 		top: var(--wp-admin--admin-bar--height, 0);
-		font-size: 13px;
+		font-size: var(--wp--preset--font-size--small);
 	}
 
 	& > * {


### PR DESCRIPTION
This changes the header and footer font sizes from `13px` to `14px`, as per the discussion in #127.

I've used the preset variable, `var(--wp--preset--font-size--small)`, as this is currently set to `14px`, but I don't know if these sizes should be independent of the variables. If so we could just use `14px`.

Closes #127.