### PR TITLE
Prevent header FOUC by forcing the navigation not to wrap, but rather be clipped

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -29,6 +29,8 @@
 			this.removeSubMenu();
 			this.hasHiddenItems = false;
 			this.listItems = this.getListItems();
+
+			this.wrapper.classList.remove( 'has-overflow-menu' );
 		};
 
 		/**
@@ -93,7 +95,9 @@
 
 				let itemsContainer = this.wrapper.querySelector( '.wp-block-navigation__container' );
 
-				//create the ... menu list item
+				this.wrapper.classList.add( 'has-overflow-menu' );
+
+				// Create the ... menu list item.
 				let newItem = document.createElement( 'li' );
 				newItem.classList.add(
 					'wp-block-navigation-item',
@@ -108,12 +112,12 @@
 				newLink.appendChild( document.createTextNode( '...' ) );
 				newItem.appendChild( newLink );
 
-				//create the submenu where the hidden links will live
+				// Create the submenu where the hidden links will live.
 				let newSubMenu = document.createElement( 'ul' );
 				newSubMenu.classList.add( 'wp-block-navigation__submenu-container' );
 				newItem.appendChild( newSubMenu );
 
-				//populate submenu with clones of the hidden menu items
+				// Populate submenu with clones of the hidden menu items.
 				for ( const el of this.listItems ) {
 					if ( el.classList.contains( 'global-header__overflow-item' ) ) {
 						let clone = el.cloneNode( true );

--- a/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
@@ -8,7 +8,7 @@
 		color: var(--wp--preset--color--white);
 		padding: 10px 19px;
 		border-radius: 2px;
-		font-weight: bold;
+		font-weight: 700;
 
 		& a {
 			margin: 0 auto;
@@ -21,6 +21,11 @@
 
 		@media (--tablet) {
 			display: inline;
+		}
+
+		@media (--short-screen) {
+			padding-top: 18px;
+			padding-bottom: 18px;
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -28,6 +28,7 @@ html {
 		position: sticky;
 		top: var(--wp-admin--admin-bar--height, 0);
 		font-size: var(--wp--preset--font-size--small);
+		line-height: 24px;
 	}
 
 	& > * {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -12,7 +12,7 @@ html {
 
 .wp-block-group.global-header {
 	display: flex;
-	align-items: flex-end;
+	align-items: flex-start;
 	font-size: 21px;
 	height: var(--wp-global-header-height);
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -7,6 +7,11 @@
 		display: none;
 		padding-right: var(--wp--style--block-gap);
 
+		@media (--short-screen) {
+			padding-bottom: 18px;
+			padding-top: 18px;
+		}
+
 		@media (--desktop-wide) {
 			display: inline;
 		}
@@ -21,6 +26,11 @@
 		@media (--tablet) {
 			flex-basis: auto;
 			flex-shrink: 0;
+		}
+
+		@media (--short-screen) {
+			padding-bottom: 16px;
+			padding-top: 16px;
 		}
 
 		@media (--desktop-wide) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -7,7 +7,8 @@
 		order: unset;
 		padding-bottom: 0;
 		text-align: left;
-		overflow-x: clip;
+		overflow: clip;
+		height: var(--wp-global-header-height);
 
 		&.has-overflow-menu {
 			overflow: visible;
@@ -53,8 +54,6 @@
 		padding: 0 0 var(--wp--custom--margin--vertical) 0;
 		row-gap: 0;
 		column-gap: 0;
-		flex-wrap: nowrap;
-		white-space: nowrap;
 
 		@media (--tablet) {
 			padding-bottom: 0;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -7,6 +7,11 @@
 		order: unset;
 		padding-bottom: 0;
 		text-align: left;
+		overflow-x: clip;
+
+		&.has-overflow-menu {
+			overflow: visible;
+		}
 	}
 
 	& .wp-block-navigation__responsive-container-open {
@@ -48,6 +53,8 @@
 		padding: 0 0 var(--wp--custom--margin--vertical) 0;
 		row-gap: 0;
 		column-gap: 0;
+		flex-wrap: nowrap;
+		white-space: nowrap;
 
 		@media (--tablet) {
 			padding-bottom: 0;
@@ -115,7 +122,6 @@
 		padding-top: calc(var(--wp--style--block-gap) / 2);
 		padding-bottom: calc(var(--wp--style--block-gap) / 2);
 		border: none;
-		left: 0;
 
 		@media (--tablet) {
 			font-size: inherit;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -109,8 +109,8 @@
 			}
 
 			@media (--short-screen) {
-				padding-bottom: 20px;
-				padding-top: 15px;
+				padding-bottom: 18px;
+				padding-top: 18px;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #41.

This forces the navigational menu to overflow horizontally, and be clipped. 

The simplest way to test this is to use a browser with JS disabled, you should be able to access the first few menu items.

Then with JS enabled, you should be able to access the overflow menu, and everything should be visually correct.

https://user-images.githubusercontent.com/767313/151741568-c358a21f-6c30-4fae-895c-95e0f0c8557c.mov

A `.has-overflow-menu` class was added to allow disabling the Overflow-X, as otherwise you'd have this:
(Note the background of the menu is clipped)
<img width="531" alt="Screen Shot 2022-01-31 at 3 05 52 pm" src="https://user-images.githubusercontent.com/767313/151741719-8468d9c3-af0f-441b-89de-1df1107a95a0.png">

The removal of the `left: 0` is to place the submenu correctly, I'm not sure why It's needed.. but I can't find any regressions and you otherwise end up with this, with 5ftf overlaying on Get Involved:
<img width="524" alt="Screen Shot 2022-01-31 at 3 08 19 pm" src="https://user-images.githubusercontent.com/767313/151741926-7f3da875-ddd8-4fd4-852a-d2ae3be79ccf.png">

