### PR TITLE
Fix --short-screen @media queries for non-FF browsers

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -15,7 +15,7 @@
 @custom-media --desktop-wide (min-width: 1440px);
 
 /* Height breakpoint to toggle the short header on desktop screens. */
-@custom-media --short-screen ((max-height: 800px) and (min-width: 890px));
+@custom-media --short-screen (max-height: 800px) and (min-width: 890px);
 
 /* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
 html {


### PR DESCRIPTION
The Small-screen header minimizing is only working in Firefox, Not in Chrome/Safari.

This appears to be caused by these browsers not accepting `@media ( (a) and (b) )`, but they're happy with `@media (a) and (b)`.
Example:
 - working: https://jsfiddle.net/7386khqe/
 - broken: https://jsfiddle.net/vdh6pq4n/ (but working in Firefox)

I think this is because the CSS @media queries are not designed for nested sets, but rather only `(property:value)`.

It seems like this syntax is the expected format, as post-css-custom-media supports it:
https://github.com/postcss/postcss-custom-media/blob/master/test/export-media.css#L8

See #121

