### PR TITLE
Header: Fix alignment of logo

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -33,7 +33,8 @@ html {
 
 	& > * {
 		flex-shrink: 0;
-		padding: 60px var(--wp--style--block-gap) 17px;
+		padding-left: var(--wp--style--block-gap);
+		padding-right: var(--wp--style--block-gap);
 		margin: 0;
 
 		@media (--tablet) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -55,6 +55,8 @@
 	& .global-header__wporg-locale-title {
 		--wp--preset--font-size--large: 20px; /* Ensure this is set to the correct size. */
 		padding-left: 0;
+		padding-bottom: 16px;
+		padding-top: 16px;
 		flex-basis: max-content;
 		flex-grow: 1;
 		flex-shrink: 1;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -5,12 +5,7 @@
 
 	& .global-header__wporg-logo-full {
 		display: none;
-		padding-right: var(--wp--style--block-gap);
-
-		@media (--short-screen) {
-			padding-bottom: 18px;
-			padding-top: 18px;
-		}
+		padding: 0 calc(var(--wp--style--block-gap) / 2);
 
 		@media (--desktop-wide) {
 			display: inline;
@@ -22,19 +17,33 @@
 		flex-shrink: 1;
 		text-align: left;
 		min-width: 73px;
+		padding: 0;
+		padding-left: calc(var(--wp--style--block-gap) / 2);
 
 		@media (--tablet) {
 			flex-basis: auto;
 			flex-shrink: 0;
 		}
 
+		@media (--desktop-wide) {
+			display: none;
+		}
+	}
+
+	& .wp-block-image > a {
+		display: inline-flex;
+		box-sizing: content-box;
+		height: 27px;
+		padding: 16px calc(var(--wp--style--block-gap) / 2);
+
+		@media (--tablet) {
+			padding-top: 31px;
+			padding-bottom: 32px;
+		}
+
 		@media (--short-screen) {
 			padding-bottom: 16px;
 			padding-top: 16px;
-		}
-
-		@media (--desktop-wide) {
-			display: none;
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -75,6 +75,13 @@
 			max-width: 15em;
 			flex-basis: min-content;
 			flex-shrink: 0;
+			padding-top: 31px;
+			padding-bottom: 32px;
+		}
+
+		@media (--short-screen) {
+			padding-bottom: 16px;
+			padding-top: 16px;
 		}
 
 		@media (--desktop-wide) {


### PR DESCRIPTION
Fixes #142. The padding on the logo on small screens was incorrect, but it was not visible until the alignment change in #132. This PR moves the padding around the logo to the `a` (creating a larger tap/click target), and fixes it to be correct at all breakpoints. This also fixes the alignment of the rosetta title.

| | Before | After |
|---|------|-------|
| 480px | ![before-mobile-480](https://user-images.githubusercontent.com/541093/152210491-fa8a4a91-6f8b-4575-881f-f51a421aea13.png) | ![mobile-480](https://user-images.githubusercontent.com/541093/152210101-b861735a-37a3-4c01-9bb2-1f984049c1ea.png) |
| 960 x 700 | ![before-mid-short-960](https://user-images.githubusercontent.com/541093/152210489-9f266c51-38ab-4f37-96ab-33016e867800.png) | ![mid-short-960](https://user-images.githubusercontent.com/541093/152210099-a467a158-5653-4791-b7aa-8e2f4c02f96f.png) |
| 960 x 900 | ![before-mid-long-960](https://user-images.githubusercontent.com/541093/152210486-95619935-439b-4ff8-a4ca-07a9933abbf6.png) | ![mid-long-960](https://user-images.githubusercontent.com/541093/152210097-2deb6f8c-c982-4cff-9434-6a2775cdcacb.png) |
| 1440 x 700 | ![before-wide-short-1440](https://user-images.githubusercontent.com/541093/152210498-ff0916a5-576b-4ed7-9e7d-ee302c421512.png) | ![wide-short-1440](https://user-images.githubusercontent.com/541093/152210106-54165d34-9a91-482f-b04b-d898904d2bd3.png) |
| 1440 x 900 | ![before-wide-long-1440](https://user-images.githubusercontent.com/541093/152210495-7f098f68-151d-414b-a790-143174529286.png) | ![wide-long-1440](https://user-images.githubusercontent.com/541093/152210105-f4282685-10bf-486d-8988-ac4f2db0715d.png) |
| Rosetta | ![before-rosetta-short](https://user-images.githubusercontent.com/541093/152210492-8d9e0801-63a9-451d-a9f6-9a724352cd28.png) | ![rosetta-short](https://user-images.githubusercontent.com/541093/152210102-6e9280ff-1503-4ecc-885d-b8e7bef1d6d9.png) |