### PR TITLE
Use the environment type, rather than the WPORG_SANDBOX constant

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -915,7 +915,7 @@ function fetch_global_styles() {
 		$request_args = array();
 
 		// Route request to sandbox when testing.
-		if ( defined( 'WPORG_SANDBOXED' ) && WPORG_SANDBOXED ) {
+		if ( 'staging' === wp_get_environment_type() ) {
 			$hostname                        = '127.0.0.1';
 			$request_args['headers']['host'] = 'wordpress.org';
 


### PR DESCRIPTION
When the header is used outside of the WordPress.org network, it uses the binary `WPORG_SANDBOX` flag as to whether it should use localhost or wordpress.org to fetch the global styles from.

Unfortunately, some local environments, such as the Pattern Directory, declare themselves to be sandboxes, as they had no other way to differentiate between Production and not production.

WordPress.org sandboxes now declare themselves to be a staging environment, which gives some more granularity here:
 - production: Should request against wordpress.org
 - sandbox: Should request against localhost
 - local/development: Should request against wordpress.org (Unless they're developing the header, in which case, this branch probably won't be hit).

Fixes #138