### PR TITLE
Header: Switch from `sticky` to `fixed` positioning

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -7,6 +7,7 @@ use Rosetta_Sites, WP_Post, WP_REST_Server, WP_Theme_JSON_Resolver;
 defined( 'WPINC' ) || die();
 
 add_action( 'init', __NAMESPACE__ . '\register_block_types' );
+add_action( 'init', __NAMESPACE__ . '\remove_admin_bar_callback' );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_types_js' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles', 5 ); // Before any theme CSS.
@@ -67,6 +68,15 @@ function register_block_types() {
 			'editor_style'    => 'wporg-global-header-footer',
 		)
 	);
+}
+
+/**
+ * Remove the default margin-top added when the admin bar is used.
+ *
+ * The core handling uses `!important`, which overrides the sticky header offset in `common.pcss`.
+ */
+function remove_admin_bar_callback() {
+	add_theme_support( 'admin-bar', array( 'callback' => '__return_false' ) );
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -8,6 +8,7 @@ defined( 'WPINC' ) || die();
 
 add_action( 'init', __NAMESPACE__ . '\register_block_types' );
 add_action( 'init', __NAMESPACE__ . '\remove_admin_bar_callback' );
+add_filter( 'print_styles_array', __NAMESPACE__ . '\output_styles_last' );
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_types_js' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles', 5 ); // Before any theme CSS.
@@ -77,6 +78,26 @@ function register_block_types() {
  */
 function remove_admin_bar_callback() {
 	add_theme_support( 'admin-bar', array( 'callback' => '__return_false' ) );
+}
+
+/**
+ * Shift the block styles to be the last stylesheet loaded, to override any default theme styles.
+ *
+ * @param string[] $handles The list of enqueued style handles about to be processed.
+ * @return string[]
+ */
+function output_styles_last( $handles ) {
+	if ( in_array( 'wporg-global-header-footer', $handles ) ) {
+		$handles = array_filter(
+			$handles,
+			function( $handle ) {
+				return 'wporg-global-header-footer' !== $handle;
+			}
+		);
+		$handles[] = 'wporg-global-header-footer';
+	}
+
+	return $handles;
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -8,9 +8,9 @@ defined( 'WPINC' ) || die();
 
 add_action( 'init', __NAMESPACE__ . '\register_block_types' );
 add_action( 'init', __NAMESPACE__ . '\remove_admin_bar_callback' );
-add_filter( 'print_styles_array', __NAMESPACE__ . '\output_styles_last' );
-add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_types_js' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_types_js' );
+add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_block_assets', 200 ); // Always last.
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles', 5 ); // Before any theme CSS.
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_fonts' );
 add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
@@ -24,31 +24,6 @@ add_filter( 'render_block_core/navigation-link', __NAMESPACE__ . '\swap_submenu_
  * showing up in the Block Inserter, regardless of which theme is running.
  */
 function register_block_types() {
-	$suffix = is_rtl() ? '-rtl' : '';
-
-	wp_register_style(
-		'wporg-global-header-footer',
-		plugins_url( "/build/style$suffix.css", __FILE__ ),
-		array( 'wp-block-library' ), // Load `block-library` styles first, so that our styles override them.
-		filemtime( __DIR__ . "/build/style$suffix.css" )
-	);
-
-	wp_register_script(
-		'wporg-global-header-script',
-		plugins_url( '/js/wporg-global-header-script.js', __FILE__ ),
-		array(),
-		filemtime( __DIR__ . '/js/wporg-global-header-script.js' ),
-		true
-	);
-	wp_localize_script(
-		'wporg-global-header-script',
-		'wporgGlobalHeaderI18n',
-		array(
-			'openSearchLabel' => __( 'Open Search', 'wporg' ),
-			'closeSearchLabel' => __( 'Close Search', 'wporg' ),
-		)
-	);
-
 	register_block_type(
 		'wporg/global-header',
 		array(
@@ -72,32 +47,43 @@ function register_block_types() {
 }
 
 /**
+ * Register the script & stylesheet for use in the blocks.
+ */
+function register_block_assets() {
+	$suffix = is_rtl() ? '-rtl' : '';
+
+	wp_register_style(
+		'wporg-global-header-footer',
+		plugins_url( "/build/style$suffix.css", __FILE__ ),
+		array( 'wp-block-library' ), // Load `block-library` styles first, so that our styles override them.
+		filemtime( __DIR__ . "/build/style$suffix.css" )
+	);
+
+	wp_register_script(
+		'wporg-global-header-script',
+		plugins_url( '/js/wporg-global-header-script.js', __FILE__ ),
+		array(),
+		filemtime( __DIR__ . '/js/wporg-global-header-script.js' ),
+		true
+	);
+
+	wp_localize_script(
+		'wporg-global-header-script',
+		'wporgGlobalHeaderI18n',
+		array(
+			'openSearchLabel' => __( 'Open Search', 'wporg' ),
+			'closeSearchLabel' => __( 'Close Search', 'wporg' ),
+		)
+	);
+}
+
+/**
  * Remove the default margin-top added when the admin bar is used.
  *
  * The core handling uses `!important`, which overrides the sticky header offset in `common.pcss`.
  */
 function remove_admin_bar_callback() {
 	add_theme_support( 'admin-bar', array( 'callback' => '__return_false' ) );
-}
-
-/**
- * Shift the block styles to be the last stylesheet loaded, to override any default theme styles.
- *
- * @param string[] $handles The list of enqueued style handles about to be processed.
- * @return string[]
- */
-function output_styles_last( $handles ) {
-	if ( in_array( 'wporg-global-header-footer', $handles ) ) {
-		$handles = array_filter(
-			$handles,
-			function( $handle ) {
-				return 'wporg-global-header-footer' !== $handle;
-			}
-		);
-		$handles[] = 'wporg-global-header-footer';
-	}
-
-	return $handles;
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -17,13 +17,7 @@
 /* Height breakpoint to toggle the short header on desktop screens. */
 @custom-media --short-screen (max-height: 800px) and (min-width: 890px);
 
-/* Two selectors:
- * - `html[lang]` adds some specificity to override default `html` styles from `p2-breathe`.
- * - `html` for any sites that don't set the lang attribute (ex, trac).
- */
-
-html,
-html[lang] {
+html {
 	--wp--custom--alignment--scroll-bar-width: 8px;
 
 	/* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -20,8 +20,14 @@
 /* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
 html {
 	--wp--custom--alignment--scroll-bar-width: 8px;
-	scroll-padding-top: calc(var(--wp-global-header-height, 0px) + var(--wp-admin--admin-bar--height, 0px));
+	--wp-global-header-offset: calc(var(--wp-global-header-height, 0px) + var(--wp-admin--admin-bar--height, 0px));
+	margin-top: var(--wp-admin--admin-bar--height, 0);
 	height: unset; /* Let height use default browser height. */
+
+	@media (--tablet) {
+		scroll-padding-top: var(--wp-global-header-offset, 0);
+		margin-top: var(--wp-global-header-offset, 0);
+	}
 }
 
 /*

--- a/mu-plugins/blocks/global-header-footer/postcss/common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/common.pcss
@@ -17,9 +17,16 @@
 /* Height breakpoint to toggle the short header on desktop screens. */
 @custom-media --short-screen (max-height: 800px) and (min-width: 890px);
 
-/* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
-html {
+/* Two selectors:
+ * - `html[lang]` adds some specificity to override default `html` styles from `p2-breathe`.
+ * - `html` for any sites that don't set the lang attribute (ex, trac).
+ */
+
+html,
+html[lang] {
 	--wp--custom--alignment--scroll-bar-width: 8px;
+
+	/* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
 	--wp-global-header-offset: calc(var(--wp-global-header-height, 0px) + var(--wp-admin--admin-bar--height, 0px));
 	margin-top: var(--wp-admin--admin-bar--height, 0);
 	height: unset; /* Let height use default browser height. */

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -25,8 +25,10 @@ html {
 	z-index: 250;
 
 	@media (--tablet) {
-		position: sticky;
+		position: fixed;
 		top: var(--wp-admin--admin-bar--height, 0);
+		left: 0;
+		right: 0;
 		font-size: var(--wp--preset--font-size--small);
 		line-height: 24px;
 	}


### PR DESCRIPTION
Fixes #147 by switching from `sticky` positioning to `fixed`. I'm pretty sure the reasoning here is that `fixed` takes the element out of the document context, so the browser doesn't think it needs to scroll up to get the focused content on-screen.

This uses a `margin-top` to cover the space of the menu, to offset the whole page under the menu; and `scroll-padding-top` to make sure in-page anchor links work correctly.

To test:

- Sync this to a sandbox
- Try a few different pages, with & without admin bars
- Try at different browser sizes — at `890px` the header stops being sticky, so try at least one size above & one below
- The header should stay stuck to the top of the page
- When scrolled to the top of the page, all content should be visible, no content hidden by the header
- Try using some relative links (for example, [a make/core handbook page](https://make.wordpress.org/core/handbook/#contribute-with-code)), the header should not overlap the link target.

Note: The news site needs an extra fix, will PR that next.
