### PR TITLE
Unregister the `global-styles` from classic themes

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -13,6 +13,7 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\register_block_types_js' )
 add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_block_assets', 200 ); // Always last.
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles', 5 ); // Before any theme CSS.
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_fonts' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\unregister_classic_global_styles', 20 );
 add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
 add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
 add_filter( 'render_block_core/navigation-link', __NAMESPACE__ . '\swap_submenu_arrow_svg' );
@@ -263,6 +264,17 @@ function enqueue_fonts() {
 		array(),
 		null
 	);
+}
+
+/**
+ * Unregister the `global-styles` from classic themes, to avoid overwriting our custom properties.
+ */
+function unregister_classic_global_styles() {
+	if ( wp_is_block_theme() ) {
+		return;
+	}
+
+	wp_deregister_style( 'global-styles' );
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -921,7 +921,7 @@ function get_global_styles() {
 	// Clear the static `$theme` property, which is set by the current (classic theme) site.
 	WP_Theme_JSON_Resolver::clean_cached_data();
 
-	$styles = wp_get_global_stylesheet( [ 'variables' ] );
+	$styles = wp_get_global_stylesheet( [ 'variables', 'presets' ] );
 	// Also set the block-gap style, which isn't technically a theme variable.
 	$styles .= 'body { --wp--style--block-gap: 24px; }';
 


### PR DESCRIPTION
Fixes #86  — By default, Gutenberg outputs some basic presets (font sizes, colors, etc). The News theme overwrites a few of them (by virtue of using the same slugs), like font-sizes. In the header & footer, the font size is set to `--wp--preset--font-size--small`, which should be 14px (set by News), but the default `global-styles` code resets it to 13px on classic themes.

The news styles output in `global-styles-for-classic-themes` includes the gutenberg default presets, so we can safely remove the second set of custom property definitions from classic themes.

To test:

- Visit a classic theme (ex, learn) on desktop
- The header & footer font sizes should be 14px
- Visit News
- The header & footer font sizes should be 14px
- There should be no other visible changes on either News or classic themes