### PR TITLE
Dequeue global-styles before deregistering them.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -274,6 +274,7 @@ function unregister_classic_global_styles() {
 		return;
 	}
 
+	wp_dequeue_style( 'global-styles' );
 	wp_deregister_style( 'global-styles' );
 }
 


### PR DESCRIPTION
Deregistering the style will cause the style not to be output, but it will remain in the style stack and be detected as unoutputable at render time.

By dequeueing the style first, it removes it from the stack to print.

This fixes Query Monitor throwing a visual warning on classic themes.

See #166, #86