### PR TITLE
Header: Fix console log problems on login page.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
+++ b/mu-plugins/blocks/global-header-footer/js/wporg-global-header-script.js
@@ -197,7 +197,8 @@
 	/* eslint-disable @wordpress/no-global-event-listener */
 	window.addEventListener( 'resize', () => {
 		// Hide any open mobile menus if we're no longer in a mobile view.
-		if ( ! document.querySelector('.global-header__navigation .wp-block-navigation__responsive-container-open').offsetWidth ) {
+		const mobileViewToggle = document.querySelector('.global-header__navigation .wp-block-navigation__responsive-container-open');
+		if ( ! mobileViewToggle || ! mobileViewToggle.offsetWidth ) {
 			const closeMenuButton = document.querySelector( '.wp-block-navigation__responsive-container.is-menu-open button[data-micromodal-close]' );
 			if ( closeMenuButton ) {
 				closeMenuButton.click();


### PR DESCRIPTION
Part of fixing #170.

Check to make sure we have a toggle button before checking its`offsetWidth`.

This doesn't close the issue because we should still make sure the assets don't load on pages without a header.