### PR TITLE
Update Readme with links to wporg references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Over time, this is intended to become the canonical source repository for all `m
 
 ## Usage
 
-1. Add entries to the `repositories` and `require-dev` sections of `composer.json`. See `wporg-news-2021` as an example.
+1. Add entries to the `repositories` and `require-dev` sections of `composer.json`. See [wporg-news-2021](https://github.com/WordPress/wporg-news-2021/) [composer.json](https://github.com/WordPress/wporg-news-2021/blob/trunk/composer.json) as an example.
 1. Run `composer update` to install it
 1. `require_once` the files that you want. e.g.,
 	```php


### PR DESCRIPTION
The readme assumes more WordPress repository knowledge than it probably should.

**Changes:**
- Links the `wporg-news-2021` reference to the repo.
- Links to `wporg-news-2021`'s composer.json file.