### PR TITLE
Add a REST API endpoint for wporg users

### DIFF
--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -5,5 +5,6 @@
 
 require_once __DIR__ . '/blocks/global-header-footer/blocks.php';
 require_once __DIR__ . '/global-fonts/index.php';
+require_once __DIR__ . '/rest-api/index.php';
 require_once __DIR__ . '/skip-to/skip-to.php';
 require_once __DIR__ . '/stream-tweaks/index.php';

--- a/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace WordPressdotorg\MU_Plugins\REST_API;
+
+/**
+ * Users_Controller
+ */
+class Users_Controller extends \WP_REST_Users_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->namespace = 'wporg/v1';
+	}
+
+	/**
+	 * Registers the routes for users.
+	 *
+	 * At this time, this endpoint is exclusively read-only. Other routes from the parent class have been omitted.
+	 *
+	 * @see register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the user.' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => array(
+							'description'       => __( 'Scope under which the request is made; determines fields present in response.', 'wporg' ),
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_key',
+							'validate_callback' => 'rest_validate_request_arg',
+							// Omit the 'edit' context since this is read-only. This prevents including fields
+							// containing non-public personal information.
+							'enum'              => array( 'view', 'embed' ),
+							'default'           => 'view',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Get the user, if the ID is valid.
+	 *
+	 * Modified from the parent method to remove the call to `is_user_member_of_blog()`.
+	 *
+	 * @param int $id Supplied ID.
+	 *
+	 * @return \WP_User|\WP_Error True if ID is valid, WP_Error otherwise.
+	 */
+	protected function get_user( $id ) {
+		$error = new \WP_Error(
+			'rest_user_invalid_id',
+			__( 'Invalid user ID.' ),
+			array( 'status' => 404 )
+		);
+
+		if ( (int) $id <= 0 ) {
+			return $error;
+		}
+
+		$user = get_userdata( (int) $id );
+		if ( empty( $user ) || ! $user->exists() ) {
+			return $error;
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Checks if a given request has access to read a user.
+	 *
+	 * Modified from the parent method to remove capability checks that necessitate blog membership.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|\WP_Error True if the request has read access for the item, otherwise WP_Error object.
+	 */
+	public function get_item_permissions_check( $request ) {
+		$user = $this->get_user( $request['id'] );
+		if ( is_wp_error( $user ) ) {
+			return $user;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Prepares a single user output for response.
+	 *
+	 * @param \WP_User         $item    User object.
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$response = parent::prepare_item_for_response( $item, $request );
+
+		// The collection link is irrelevant since this endpoint only allows access to individual records.
+		$response->remove_link( 'collection' );
+
+		return $response;
+	}
+}

--- a/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
@@ -25,12 +25,26 @@ class Users_Controller extends \WP_REST_Users_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<slug>[\w-]+)',
 			array(
 				'args'   => array(
-					'id' => array(
-						'description' => __( 'Unique identifier for the user.', 'wporg' ),
-						'type'        => 'integer',
+					'slug' => array(
+						'description' => __( 'A unique alphanumeric identifier for the user.', 'wporg' ),
+						'type'        => 'string',
 					),
 				),
 				array(
@@ -38,16 +52,7 @@ class Users_Controller extends \WP_REST_Users_Controller {
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
-						'context' => array(
-							'description'       => __( 'Scope under which the request is made; determines fields present in response.', 'wporg' ),
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_key',
-							'validate_callback' => 'rest_validate_request_arg',
-							// Omit the 'edit' context since this is read-only. This prevents including fields
-							// containing non-public personal information.
-							'enum'              => array( 'view', 'embed' ),
-							'default'           => 'view',
-						),
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
@@ -56,26 +61,48 @@ class Users_Controller extends \WP_REST_Users_Controller {
 	}
 
 	/**
-	 * Get the user, if the ID is valid.
+	 * Permissions check for getting all users.
 	 *
-	 * Modified from the parent method to remove the call to `is_user_member_of_blog()`.
+	 * @param \WP_REST_Request $request Full details about the request.
 	 *
-	 * @param int $id Supplied ID.
-	 *
-	 * @return \WP_User|\WP_Error True if ID is valid, WP_Error otherwise.
+	 * @return true|\WP_Error True if the request has read access, otherwise WP_Error object.
 	 */
-	protected function get_user( $id ) {
+	public function get_items_permissions_check( $request ) {
+		$check = parent::get_items_permissions_check( $request );
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		if ( empty( $request['slug'] ) ) {
+			return new \WP_Error(
+				'rest_invalid request',
+				__( 'You must use the slug parameter for requests to this endpoint.', 'wporg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the user, if the slug is valid.
+	 *
+	 * @param string $slug Supplied slug.
+	 *
+	 * @return \WP_User|\WP_Error True if slug is valid, WP_Error otherwise.
+	 */
+	protected function get_user_by_slug( $slug ) {
 		$error = new \WP_Error(
-			'rest_user_invalid_id',
-			__( 'Invalid user ID.', 'wporg' ),
+			'rest_user_invalid_slug',
+			__( 'Invalid user slug.', 'wporg' ),
 			array( 'status' => 404 )
 		);
 
-		if ( (int) $id <= 0 ) {
+		if ( mb_strlen( $slug ) > 50 || ! sanitize_title( $slug ) ) {
 			return $error;
 		}
 
-		$user = get_userdata( (int) $id );
+		$user = get_user_by( 'slug', $slug );
 		if ( empty( $user ) || ! $user->exists() ) {
 			return $error;
 		}
@@ -86,14 +113,15 @@ class Users_Controller extends \WP_REST_Users_Controller {
 	/**
 	 * Checks if a given request has access to read a user.
 	 *
-	 * Modified from the parent method to remove capability checks that necessitate blog membership.
+	 * Modified from the parent method to use slug instead of id and remove capability checks that necessitate
+	 * blog membership.
 	 *
 	 * @param \WP_REST_Request $request Full details about the request.
 	 *
 	 * @return true|\WP_Error True if the request has read access for the item, otherwise WP_Error object.
 	 */
 	public function get_item_permissions_check( $request ) {
-		$user = $this->get_user( $request['id'] );
+		$user = $this->get_user_by_slug( $request['slug'] );
 		if ( is_wp_error( $user ) ) {
 			return $user;
 		}
@@ -102,19 +130,88 @@ class Users_Controller extends \WP_REST_Users_Controller {
 	}
 
 	/**
-	 * Prepares a single user output for response.
+	 * Retrieves a single user.
 	 *
-	 * @param \WP_User         $item    User object.
-	 * @param \WP_REST_Request $request Request object.
+	 * Modified from the parent method to use slug instead of id.
 	 *
-	 * @return \WP_REST_Response Response object.
+	 * @param \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
-	public function prepare_item_for_response( $item, $request ) {
-		$response = parent::prepare_item_for_response( $item, $request );
+	public function get_item( $request ) {
+		$user = $this->get_user_by_slug( $request['slug'] );
+		if ( is_wp_error( $user ) ) {
+			return $user;
+		}
 
-		// The collection link is irrelevant since this endpoint only allows access to individual records.
-		$response->remove_link( 'collection' );
+		$user     = $this->prepare_item_for_response( $user, $request );
+		$response = rest_ensure_response( $user );
 
 		return $response;
+	}
+
+	/**
+	 * Prepares links for the user request.
+	 *
+	 * @param \WP_User $user User object.
+	 *
+	 * @return array Links for the given user.
+	 */
+	protected function prepare_links( $user ) {
+		$links = parent::prepare_links( $user );
+
+		// Prepending / is to avoid replacing the 1 in wporg/v1 if the user ID is 1 :D
+		$links['self']['href'] = str_replace( '/' . $user->ID, '/' . $user->user_nicename, $links['self']['href'] );
+
+		$links['collection']['href'] = add_query_arg(
+			'slug',
+			$user->user_nicename,
+			$links['collection']['href']
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Retrieves the query params for collections.
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$allowed_params = array(
+			'context'  => '',
+			'page'     => '',
+			'per_page' => '',
+			'order'    => '',
+			'orderby'  => '',
+			'slug'     => '',
+		);
+
+		$query_params = array_intersect_key( parent::get_collection_params(), $allowed_params );
+
+		if ( isset( $query_params['orderby']['enum'] ) ) {
+			$allowed_orderby = array( 'id', 'name', 'slug', 'include_slugs' );
+			$query_params['orderby']['enum'] = array_intersect( $query_params['orderby']['enum'], $allowed_orderby );
+		}
+
+		return $query_params;
+	}
+
+	/**
+	 * Retrieves the magical context param.
+	 *
+	 * Prevents usage of contexts (such as edit) that potentially reveal users' sensitive account information.
+	 *
+	 * @param array $args Optional. Additional arguments for context parameter. Default empty array.
+	 *
+	 * @return array Context parameter details.
+	 */
+	public function get_context_param( $args = array() ) {
+		$context = parent::get_context_param( $args );
+		$allowed_contexts = array( 'view', 'embed' );
+
+		$context['enum'] = array_intersect( $context['enum'], $allowed_contexts );
+
+		return $context;
 	}
 }

--- a/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
@@ -29,7 +29,7 @@ class Users_Controller extends \WP_REST_Users_Controller {
 			array(
 				'args'   => array(
 					'id' => array(
-						'description' => __( 'Unique identifier for the user.' ),
+						'description' => __( 'Unique identifier for the user.', 'wporg' ),
 						'type'        => 'integer',
 					),
 				),
@@ -67,7 +67,7 @@ class Users_Controller extends \WP_REST_Users_Controller {
 	protected function get_user( $id ) {
 		$error = new \WP_Error(
 			'rest_user_invalid_id',
-			__( 'Invalid user ID.' ),
+			__( 'Invalid user ID.', 'wporg' ),
 			array( 'status' => 404 )
 		);
 

--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -6,6 +6,7 @@ namespace WordPressdotorg\MU_Plugins\REST_API;
  * Actions and filters.
  */
 add_action( 'rest_api_init', __NAMESPACE__ . '\initialize_rest_endpoints' );
+add_filter( 'rest_user_query', __NAMESPACE__ . '\modify_user_query_parameters', 10, 2 );
 
 /**
  * Turn on API endpoints.
@@ -17,4 +18,24 @@ function initialize_rest_endpoints() {
 
 	$users_controller = new Users_Controller();
 	$users_controller->register_routes();
+}
+
+/**
+ * Tweak the user query to allow for getting users who aren't blog members.
+ *
+ * @param array            $prepared_args
+ * @param \WP_REST_Request $request
+ *
+ * @return array
+ */
+function modify_user_query_parameters( $prepared_args, $request ) {
+	// Only for this specific endpoint.
+	if ( '/wporg/v1' !== substr( $request->get_route(), 0, 9 ) ) {
+		return $prepared_args;
+	}
+
+	$prepared_args['blog_id'] = 0; // Avoid check for blog membership.
+	unset( $prepared_args['has_published_posts'] ); // Avoid another check for blog membership.
+
+	return $prepared_args;
 }

--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WordPressdotorg\MU_Plugins\REST_API;
+
+/**
+ * Actions and filters.
+ */
+add_action( 'rest_api_init', __NAMESPACE__ . '\initialize_rest_endpoints' );
+
+/**
+ * Turn on API endpoints.
+ *
+ * @return void
+ */
+function initialize_rest_endpoints() {
+	require_once __DIR__ . '/endpoints/class-wporg-rest-users-controller.php';
+
+	$users_controller = new Users_Controller();
+	$users_controller->register_routes();
+}


### PR DESCRIPTION
This is a proof-of-concept for #182. It simply clones the Core users controller, but then strips out all the endpoints except the read access ones. The single user endpoint takes a slug instead of a numerical ID. The multiple users endpoint requires adding the `slug` query parameter and listing the specific user slugs you want to retrieve.

Additionally this controller limits the request context to either `view` or `embed` (omitting `edit`) so that only data fields that are already public are available in the response.

Another thing we could do here is add in some fields specifically from profiles.wordpress.org. Things that are viewable at a user's public profile page, like their bio, whether they are sponsored, maybe their badges?

## To test

1. Best to do this on a wporg sandbox.
2. Upload the files and then while sandboxed, go to `https://wordpress.org/wp-json/wporg/v1/users/{your wporg user slug}` in your browser.
3. Try adding the context parameter `?context=embed`. That should show identical info to the default response. Changing `embed` to `edit` or anything else should give you an error message.
4. Now try going to `https://wordpress.org/wp-json/wporg/v1/users?slug={your wporg user slug}`
5. It should be the same as the first endpoint, except returns an array with one item.
6. Try adding other user slugs, separated by commas.
7. Compare the data shown to something like `https://wordpress.org/wp-json/wp/v2/users`. It should be all the same fields.
8. Trying to retrieve user data via fields other than slug (e.g. id) shouldn't work.