### PR TITLE
Skip adding current item to downloads button.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -734,7 +734,8 @@ function get_download_url() {
 	}
 
 	if ( ! $url ) {
-		$url = 'https://wordpress.org/download/';
+		$host = strtolower( $_SERVER['HTTP_HOST'] );
+		$url  = "https://$host/download/";
 	}
 
 	return $url;

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -734,8 +734,7 @@ function get_download_url() {
 	}
 
 	if ( ! $url ) {
-		$host = strtolower( $_SERVER['HTTP_HOST'] );
-		$url  = "https://$host/download/";
+		$url = 'https://wordpress.org/download/';
 	}
 
 	return $url;

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -975,12 +975,6 @@ function set_current_item_class( $menu_items ) {
 
 	foreach ( $menu_items as & $item ) {
 		$sub = false;
-
-		// The download menu item is a button, we don't highlight it
-		if ( get_download_url() === $item['url'] ) {
-			continue;
-		}
-
 		if ( ! empty( $item['submenu'] ) ) {
 			foreach ( $item['submenu'] as & $subitem ) {
 				if ( $current_url === $subitem['url'] ) {

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -974,7 +974,9 @@ function set_current_item_class( $menu_items ) {
 	$current_url = get_menu_url_for_current_page( $menu_items );
 
 	// The download menu item is a button, we don't highlight it
-	if ( get_download_url() === $current_url ) return $menu_items;
+	if ( get_download_url() === $current_url ) {
+		return $menu_items;
+	}
 
 	foreach ( $menu_items as & $item ) {
 		$sub = false;

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -975,6 +975,12 @@ function set_current_item_class( $menu_items ) {
 
 	foreach ( $menu_items as & $item ) {
 		$sub = false;
+
+		// The download menu item is a button, we don't highlight it
+		if ( get_download_url() === $item['url'] ) {
+			continue;
+		}
+
 		if ( ! empty( $item['submenu'] ) ) {
 			foreach ( $item['submenu'] as & $subitem ) {
 				if ( $current_url === $subitem['url'] ) {

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -974,6 +974,9 @@ function fetch_global_styles() {
 function set_current_item_class( $menu_items ) {
 	$current_url = get_menu_url_for_current_page( $menu_items );
 
+	// The download menu item is a button, we don't highlight it
+	if ( get_download_url() === $current_url ) return $menu_items;
+
 	foreach ( $menu_items as & $item ) {
 		$sub = false;
 		if ( ! empty( $item['submenu'] ) ) {


### PR DESCRIPTION
Fixes #187 

Skip adding the page menu indicator `current-menu-item` to the download button when on the `/downloads` page.

Props @vijayhardaha