### PR TITLE
Add a "plugin tweaks" module, and add a tweak for Internal Notes

### DIFF
--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -5,6 +5,7 @@
 
 require_once __DIR__ . '/blocks/global-header-footer/blocks.php';
 require_once __DIR__ . '/global-fonts/index.php';
+require_once __DIR__ . '/plugin-tweaks/index.php';
 require_once __DIR__ . '/rest-api/index.php';
 require_once __DIR__ . '/skip-to/skip-to.php';
 require_once __DIR__ . '/stream-tweaks/index.php';

--- a/mu-plugins/plugin-tweaks/index.php
+++ b/mu-plugins/plugin-tweaks/index.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Tweaks for specific plugins on WordPress.org.
+ *
+ * If there's just one tweak for a plugin, feel free to add it here on the index file. If there's more than
+ * one, or multiple functions/files are needed, consider adding a separate file or directory for that plugin
+ * and loading those files from here.
+ *
+ * When adding a function here, please prefix it with the plugin's name.
+ */
+
+namespace WordPressdotorg\MU_Plugins\Plugin_Tweaks;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_filter( 'wporg_internal_notes_rest_prepare_response', __NAMESPACE__ . '\wporg_internal_notes_replace_rest_author_link' );
+
+/**
+ * Replace the Internal Notes default embeddable author link with one from the wporg endpoint.
+ *
+ * Without this, any note author that isn't a member of the Pattern Directory site will appear as "unknown"
+ * on internal notes and logs.
+ *
+ * @param \WP_REST_Response $response
+ *
+ * @return \WP_REST_Response
+ */
+function wporg_internal_notes_replace_rest_author_link( $response ) {
+	$response_data = $response->get_data();
+	$author = get_user_by( 'id', $response_data['author'] ?? 0 );
+
+	if ( ! $author ) {
+		return $response;
+	}
+
+	$response->remove_link( 'author' );
+	$response->add_link(
+		'author',
+		rest_url( sprintf( 'wporg/v1/users/%s', $author->user_nicename ) ),
+		array(
+			'embeddable' => true,
+		)
+	);
+
+	return $response;
+}

--- a/mu-plugins/plugin-tweaks/index.php
+++ b/mu-plugins/plugin-tweaks/index.php
@@ -2,48 +2,11 @@
 /**
  * Tweaks for specific plugins on WordPress.org.
  *
- * If there's just one tweak for a plugin, feel free to add it here on the index file. If there's more than
- * one, or multiple functions/files are needed, consider adding a separate file or directory for that plugin
- * and loading those files from here.
- *
- * When adding a function here, please prefix it with the plugin's name.
+ * Each plugin gets its own file or subdirectory in the `plugin-tweaks` directory.
  */
 
 namespace WordPressdotorg\MU_Plugins\Plugin_Tweaks;
 
 defined( 'WPINC' ) || die();
 
-/**
- * Actions and filters.
- */
-add_filter( 'wporg_internal_notes_rest_prepare_response', __NAMESPACE__ . '\wporg_internal_notes_replace_rest_author_link' );
-
-/**
- * Replace the Internal Notes default embeddable author link with one from the wporg endpoint.
- *
- * Without this, any note author that isn't a member of the Pattern Directory site will appear as "unknown"
- * on internal notes and logs.
- *
- * @param \WP_REST_Response $response
- *
- * @return \WP_REST_Response
- */
-function wporg_internal_notes_replace_rest_author_link( $response ) {
-	$response_data = $response->get_data();
-	$author = get_user_by( 'id', $response_data['author'] ?? 0 );
-
-	if ( ! $author ) {
-		return $response;
-	}
-
-	$response->remove_link( 'author' );
-	$response->add_link(
-		'author',
-		rest_url( sprintf( 'wporg/v1/users/%s', $author->user_nicename ) ),
-		array(
-			'embeddable' => true,
-		)
-	);
-
-	return $response;
-}
+require_once __DIR__ . '/wporg-internal-notes.php';

--- a/mu-plugins/plugin-tweaks/wporg-internal-notes.php
+++ b/mu-plugins/plugin-tweaks/wporg-internal-notes.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WordPressdotorg\MU_Plugins\Plugin_Tweaks;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_filter( 'wporg_internal_notes_rest_prepare_response', __NAMESPACE__ . '\wporg_internal_notes_replace_rest_author_link' );
+
+/**
+ * Replace the Internal Notes default embeddable author link with one from the wporg endpoint.
+ *
+ * Without this, any note author that isn't a member of the Pattern Directory site will appear as "unknown"
+ * on internal notes and logs.
+ *
+ * @param \WP_REST_Response $response
+ *
+ * @return \WP_REST_Response
+ */
+function wporg_internal_notes_replace_rest_author_link( $response ) {
+	$response_data = $response->get_data();
+	$author = get_user_by( 'id', $response_data['author'] ?? 0 );
+
+	if ( ! $author ) {
+		return $response;
+	}
+
+	$response->remove_link( 'author' );
+	$response->add_link(
+		'author',
+		rest_url( sprintf( 'wporg/v1/users/%s', $author->user_nicename ) ),
+		array(
+			'embeddable' => true,
+		)
+	);
+
+	return $response;
+}


### PR DESCRIPTION
The main mu-plugins directory on wporg is cluttered with files that are for one or more "tweaks" to a particular plugin. The goal with this PR is to not proliferate the same pattern in our pub-sync mu-plugins by stashing all such tweaks in a "plugin-tweaks" subdirectory. Eventually we could also clean up the main mu-plugins directory by migrating open-sourcable tweaks to this new place.

The first tweak for this new system is for the Internal Notes plugin. It started out as [a PR](https://github.com/WordPress/pattern-directory/pull/463) for the pattern directory, but after some discussion it seems better to put it in mu-plugins since it will benefit any use of the Internal Notes plugin anywhere on wporg.

Note that with this PR I haven't moved the existing "stream-tweaks" in this repo into "plugin tweaks". This is because that particular tweak is no longer needed, and will be removed in a separate PR.

For reviewing this PR, I'm more interested in feedback about the implementation of `plugin-tweaks` than in the particular Internal Notes tweak, which I believe was already tested in the other PR. E.g. would it be better to have each tweaked plugin have its own file even if there's only one function?