### PR TITLE
Users: Add a filter to alter the author link on post-type responses to use our custom endpoint

### DIFF
--- a/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
@@ -99,7 +99,7 @@ class Users_Controller extends \WP_REST_Users_Controller {
 		$user = get_user_by( 'id', $user_id );
 
 		// Remove the existing author link
-		$response->remove_link( 'author', $links['author'][0]['href'] );
+		$response->remove_link( 'author' );
 
 		// Add a link to our endpoint instead
 		$response->add_link(

--- a/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-rest-users-controller.php
@@ -80,23 +80,16 @@ class Users_Controller extends \WP_REST_Users_Controller {
 	 * @return \WP_REST_Response Response object for the request.
 	 */
 	public function alter_post_author_link( $response ) {
-		$links = $response->get_links();
-		if (
-			empty( $links['author'][0]['href'] ) ||
-			! preg_match( '!wp/v2/users/(?P<id>\d+)!i', $links['author'][0]['href'], $m )
-		) {
+		$data = $response->get_data();
+		$user = get_user_by( 'id', $data['author'] ?? 0 );
+		if ( ! $user->exists() ) {
 			return $response;
 		}
-
-		$user_id = absint( $m['id'] );
 
 		// If the core users endpoint will work for this user, no need to change it.
-		if ( is_multisite() && is_user_member_of_blog( $user_id ) ) {
+		if ( is_multisite() && is_user_member_of_blog( $user->ID ) ) {
 			return $response;
 		}
-
-		// Get the user
-		$user = get_user_by( 'id', $user_id );
 
 		// Remove the existing author link
 		$response->remove_link( 'author' );


### PR DESCRIPTION
Currently post endpoints link to a non-accessible endpoint for posts, eg:

```
$ curl -s https://wordpress.org/photos/wp-json/wp/v2/photos/9781 | jq ._links.author[0].href
"https://wordpress.org/photos/wp-json/wp/v2/users/14322318"

$curl -s https://wordpress.org/photos/wp-json/wp/v2/users/14322318 | jq .message
"Invalid user ID."

$ curl -s 'https://wordpress.org/photos/wp-json/wp/v2/photos/9781?_embed=true' -s | jq ._embedded.author[0].message
"Invalid user ID."
```

After this change:
```
$ curl -s https://wordpress.org/photos/wp-json/wp/v2/photos/9781 | jq ._links.author[0].href
"https://wordpress.org/photos/wp-json/wporg/v1/users/femkreations"

$ curl -s https://wordpress.org/photos/wp-json/wporg/v1/users/femkreations | jq .name
"Femy Praseeth"

$ curl -s 'https://wordpress.org/photos/wp-json/wp/v2/photos/9781?_embed=true' -s | jq ._embedded.author[0].name
"Femy Praseeth"
```

See https://meta.trac.wordpress.org/ticket/6313