### PR TITLE
Fix accessibility of global header links

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -98,6 +98,7 @@
 			padding-top: calc(var(--wp--style--block-gap) / 2);
 			padding-bottom: calc(var(--wp--style--block-gap) / 2);
 			padding-right: var(--wp--style--block-gap);
+			color: inherit;
 
 			&:hover,
 			&:focus-within {


### PR DESCRIPTION
See #213 

Add rule to inherit the global header link color from the navigation container, fixing the header link colors on wordpress.org and make.wordpress.org

Gutenberg 13.6.0 has removed this inheritance causing the links to change from white to blue, and greatly effecting the accessibility of the menu links due to low color contrast.

This is intended to be a quick fix until we can make changes to Gutenberg.

The rule removed was:
```
.wp-block-navigation .wp-block-navigation-item__content {
    color: inherit;
}
```

The rule added by this PR is:
```
.wp-block-group.global-header .global-header__navigation .wp-block-navigation__container .global-header__overflow-menu>button, 
.wp-block-group.global-header .global-header__navigation .wp-block-navigation__container .wp-block-navigation-item a {
    color: inherit;
}
```

See screenshots for the rule in effect:

![Screen Shot 2022-07-07 at 12 22 11 PM](https://user-images.githubusercontent.com/1017872/177664439-7ad70479-d905-4422-b5fc-21e3ae4b7416.jpg)

![Screen Shot 2022-07-07 at 12 21 33 PM](https://user-images.githubusercontent.com/1017872/177664519-13242a14-f30d-4cf3-b660-3999471ec519.jpg)
