### PR TITLE
Fix accessibility of global footer links

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
@@ -27,4 +27,8 @@
 			font-size: var(--wp--preset--font-size--small);
 		}
 	}
+
+	& .wp-block-navigation-item .wp-block-navigation-item__content {
+		color: inherit;
+	}
 }


### PR DESCRIPTION
See https://github.com/WordPress/wporg-mu-plugins/issues/213 and follows #214 

Add rule to inherit the global footer link color from the navigation container, fixing the footer link colors on wordpress.org and make.wordpress.org

Gutenberg 13.6.0 has removed this inheritance causing the links to change from white to blue, and greatly effecting the accessibility of the menu links due to low color contrast.

This is intended to be a quick fix until we can make changes to Gutenberg.

The rule removed was:

```
.wp-block-navigation .wp-block-navigation-item__content {
    color: inherit;
}
```

The rule added by this PR is:

```
.wp-block-group.global-footer .wp-block-navigation-item .wp-block-navigation-item__content {
    color: inherit;
}
```