### PR TITLE
Fix positioning of global header search box when open

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -77,6 +77,10 @@ html {
 		display: none;
 	}
 
+	& .has-modal-open .wp-block-navigation__responsive-dialog {
+		margin-top: 0;
+	}
+
 	& .wp-block-navigation__responsive-container-close {
 		position: fixed;
 		right: 0;


### PR DESCRIPTION
See #216 

Override margin set in navigation block when search box is open