### PR TITLE
CSS: Update class name after gutenberg 13.7 change

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -89,12 +89,12 @@ html {
  * @link https://github.com/WordPress/wporg-news-2021/pull/30
  */
 
-[class*="wp-container-"].global-header,
-[class*="wp-container-"].global-footer,
-[class*="wp-container-"].global-header > * + *,
-[class*="wp-container-"].global-footer > * + *,
-.global-header [class*="wp-container-"] > * + *,
-.global-footer [class*="wp-container-"] > * + * {
+[class*="wp-block-"].global-header,
+[class*="wp-block-"].global-footer,
+[class*="wp-block-"].global-header > * + *,
+[class*="wp-block-"].global-footer > * + *,
+.global-header [class*="wp-block-"] > * + *,
+.global-footer [class*="wp-block-"] > * + * {
 	margin-top: initial;
 }
 

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -1,4 +1,4 @@
-.wp-block-group.global-footer [class*="wp-container-"].global-footer__logos-container {
+.wp-block-group.global-footer .global-footer__logos-container {
 	position: relative;
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
The `wp-container-*` class is no longer added to all blocks, instead we should use the `wp-block-*` class. In `_common`, the selector is necessary for specificity, so use `wp-block-*` instead. In `logos`, it's not needed for specificity, so it's been removed.

| Before | After |
|--------|------|
| ![before-header](https://user-images.githubusercontent.com/541093/180317798-d2cd7df6-e0fc-45fc-ab23-bb7aef210638.png) | ![after-header](https://user-images.githubusercontent.com/541093/180317794-b644dae7-716a-49b7-8507-997a55656722.png) |
| ![before-footer](https://user-images.githubusercontent.com/541093/180317825-598284f6-1919-4f1f-a178-28f13b8b4523.png) | ![after-footer](https://user-images.githubusercontent.com/541093/180317820-46c32784-29a4-4b95-9345-0d283181ca0b.png) |


