### PR TITLE
Add plugin for wporg_export context

### DIFF
--- a/mu-plugins/rest-api/extras/class-wporg-export-context.php
+++ b/mu-plugins/rest-api/extras/class-wporg-export-context.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Allow some raw data to be exposed in the REST API for certain post types, so that developers can import
+ * a copy of production data for local testing.
+ *
+ * This class is available globally but only activated on specific sites as needed. To enable it:
+ *
+ * add_filter( 'wporg_export_context_post_types', function( $types ) {
+ * 		return array_merge( $types, [
+ * 			'my-post-type',
+ * 		]);
+ * } );
+ *
+ * Optionally, to allow more block types in exported posts:
+ *
+ * add_filter( 'allow_raw_block_export', function( $block_names ) {
+ * 		return array_merge( $block_names, [
+ * 			'my/block-name',
+ * 			'myblocks/*',
+ * 		]);
+ * })
+ *
+ * ⚠️ Be careful to only expose public data!
+ */
+
+namespace WordPressdotorg\MU_Plugins\REST_API;
+
+class Export_Context {
+
+	public $context_name = 'wporg_export';
+
+	public function init() {
+		/**
+		 * Filter: Modify the list of post types that will have the `wporg_export` context.
+		 * Only post types with that context can be exported.
+		 *
+		 * @param array $post_types An array of allowed post types.
+		 */
+		$post_types = apply_filters( 'wporg_export_context_post_types', [] );
+		if ( $post_types ) {
+			foreach ( array_unique( $post_types ) as $post_type ) {
+				$this->register_raw_content_for_post_type( $post_type );
+			}
+		}
+	}
+	/**
+	 * Register a `wporg_export` context for a given post type.
+	 *
+	 * @param string $post_type Post type to allow for export.
+	 */
+	function register_raw_content_for_post_type( $post_type ) {
+
+		register_rest_field(
+			$post_type,
+			'content_raw',
+			array(
+				'get_callback' => array( $this, 'show_post_content_raw' ),
+				'schema'       => array(
+					'type' => 'string',
+					'context' => array( $this->context_name ),
+				),
+			)
+		);
+
+		add_filter( "rest_{$post_type}_item_schema", array( $this, 'add_export_context_to_schema' ) );
+	}
+
+	/**
+	 * Filter a CPT item schema and make it so that every item with 'view' context also has 'export' context.
+	 *
+	 * @param array $schema The schema object.
+	 */
+	public function add_export_context_to_schema( $schema ) {
+		$this->update_schema_array_recursive( $schema );
+
+		return $schema;
+	}
+
+	/**
+	 * Find every item in the schema that has a 'view' context, and add an 'export' context to it.
+	 * Had to use a recursive function because array_walk_recursive only walks leaf nodes.
+	 *
+	 * @param array $schema The schema object.
+	 */
+	protected function update_schema_array_recursive( &$schema ) {
+		foreach ( $schema as $key => &$value ) {
+			// Head recursion
+			if ( is_array( $value ) ) {
+				$this->update_schema_array_recursive( $value );
+			}
+			if ( 'context' === $key && in_array( 'view', $value ) ) {
+				$value[] = $this->context_name;
+			}
+		}
+	}
+
+	/**
+	 * Given an array of blocks, return an array of just the names of those blocks.
+	 *
+	 * @param array $blocks An array of blocks.
+	 * @return array An array of block names.
+	 */
+	function get_all_block_names( $blocks ) {
+		$block_names = array();
+		if ( ! $blocks ) {
+			return array();
+		}
+		foreach ( $blocks as $block ) {
+			if ( null !== $block['blockName'] ) {
+				$block_names[] = $block['blockName'];
+				if ( $block['innerBlocks'] ) {
+					// Recursive call to get inner blocks
+					$block_names = array_merge( $block_names, $this->get_all_block_names( $block['innerBlocks'] ) );
+				}
+			}
+		}
+
+		return array_unique( $block_names );
+	}
+
+	/**
+	 * Callback: If a post contains only allowed blocks, then return the raw block markup for the post.
+	 *
+	 * @param array  $object The post object relating to the REST request.
+	 * @param string $field_name The field name.
+	 * @param array  $request The request object.
+	 *
+	 * @return string The raw post content, if it contains only allowed blocks; a placeholder string otherwise.
+	 */
+	function show_post_content_raw( $object, $field_name, $request ) {
+
+		/**
+		 * Filter: Modify the list of blocks permitted in posts available via the 'export' context.
+		 * Posts containing any other blocks will not be exported.
+		 *
+		 * @param array $allowed_blocks An array of allowed block names. Simple wildcards are permitted, like 'core/*'.
+		 */
+		$allowed_blocks = apply_filters( 'allow_raw_block_export', array(
+			'core/*',
+			'wporg/*',
+			// other allowed blocks:
+			'jetpack/image-compare',
+			'jetpack/tiled-gallery',
+			'syntaxhighlighter/code',
+		) );
+
+		if ( ! empty( $object['id'] ) ) {
+			$post = get_post( $object['id'] );
+		} else {
+			$post = get_post();
+		}
+
+		// Exit early if the post contains any blocks that are not explicitly allowed.
+		if ( $post && has_blocks( $post->post_content ) || true ) {
+
+			$regexes = array();
+			foreach ( $allowed_blocks as $allowed_block_name ) {
+				$regexes[] = strtr( preg_quote( $allowed_block_name, '#' ), array( '\*' => '.*' ) );
+			}
+
+			$regex = '#^(' . implode( '|', $regexes ) . ')$#';
+
+			$blocks = parse_blocks( $post->post_content );
+			$block_names = $this->get_all_block_names( $blocks );
+
+			foreach ( $block_names as $block_name ) {
+				// If it contains a disallowed block, then return no content.
+				// Better to raise an error instead?
+				if ( ! preg_match( $regex, $block_name ) ) {
+					return '<p>Post contains a disallowed block ' . esc_html( $block_name ) . '</p>';
+				}
+			}
+		}
+
+		return $post->post_content;
+	}
+}

--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -6,6 +6,7 @@ namespace WordPressdotorg\MU_Plugins\REST_API;
  * Actions and filters.
  */
 add_action( 'rest_api_init', __NAMESPACE__ . '\initialize_rest_endpoints' );
+add_action( 'rest_api_init', __NAMESPACE__ . '\initialize_rest_contexts' );
 add_filter( 'rest_user_query', __NAMESPACE__ . '\modify_user_query_parameters', 10, 2 );
 
 /**
@@ -18,6 +19,16 @@ function initialize_rest_endpoints() {
 
 	$users_controller = new Users_Controller();
 	$users_controller->register_routes();
+}
+
+/**
+ * Enable extra contexts.
+ */
+function initialize_rest_contexts() {
+	require_once __DIR__ . '/extras/class-wporg-export-context.php';
+
+	$export_context = new Export_Context();
+	$export_context->init();
 }
 
 /**


### PR DESCRIPTION
This adds a file to the `rest-api` plugin that implements the server side of https://github.com/WordPress/Learn/pull/249

Basically it allows sites to expose raw block content in the REST API for selected post types, so that local dev environments can import live site data for testing. This would replace the code in Learn, and be available on any site that needs it.

The plugin has no effect unless it's explicitly invoked by a theme or plugin on the site, like this:

```php
add_filter( 'wporg_export_context_post_types', function( $types ) {
    return array_merge( $types, [
        'post',
        'page',
        ]);
} );
```

I'm adding it here so it can be used in the wporg-main-2022 theme.