### PR TITLE
Fix/233 revert header footer link fixes

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
@@ -27,8 +27,4 @@
 			font-size: var(--wp--preset--font-size--small);
 		}
 	}
-
-	& .wp-block-navigation-item .wp-block-navigation-item__content {
-		color: inherit;
-	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -108,7 +108,6 @@
 			padding-top: calc(var(--wp--style--block-gap) / 2);
 			padding-bottom: calc(var(--wp--style--block-gap) / 2);
 			padding-right: var(--wp--style--block-gap);
-			color: inherit;
 
 			&:hover,
 			&:focus-within {


### PR DESCRIPTION
See #233 

In https://github.com/WordPress/wporg-mu-plugins/pull/230 we stopped deregistering the global styles in classic themes. 

This means we don't need the patched styles for navigation links, that were added to mitigate an issue after [some styles moved from CSS to JSON](https://github.com/WordPress/gutenberg/commit/7c7e4f914e05900fa3fea9ab153818d3a72f2737) in Gutenberg 13.6.0.

Header styles back:
![Screen Shot 2022-08-02 at 9 33 32 AM](https://user-images.githubusercontent.com/1017872/182250661-0c6358a0-f09e-4158-b3bf-cb1b296436ba.jpg)

Footer styles back:
![Screen Shot 2022-08-02 at 9 34 08 AM](https://user-images.githubusercontent.com/1017872/182250698-3e728e51-324a-4795-8961-7250bcd3c800.jpg)

**Testing**
This can be tested by building `mu-plugins/blocks/global-header-footer/build/style.css` and replacing the file in your sandbox.
Check wordpress.org, make.wordpress.org. learn.wordpress.org and ensure the navigation links in the header and footer are white, not blue.