### PR TITLE
Remove underline from global header and footer navigation links in block themes

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -132,6 +132,7 @@ html {
 		&:hover,
 		&:focus {
 			text-decoration-line: underline;
+			color: inherit;
 		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -123,6 +123,17 @@ html {
 	& * {
 		box-sizing: border-box;
 	}
+
+	& .wp-block-navigation-item__content {
+		text-decoration: none;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.15em;
+
+		&:hover,
+		&:focus {
+			text-decoration-line: underline;
+		}
+	}
 }
 
 .wp-block-group.global-header .global-header__navigation,

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -124,7 +124,7 @@ html {
 		box-sizing: border-box;
 	}
 
-	& .wp-block-navigation-item__content {
+	& a {
 		text-decoration: none;
 		text-decoration-thickness: 1px;
 		text-underline-offset: 0.15em;


### PR DESCRIPTION
See #232

Using `theme.json` to set `text-decoration` wasn't possible (see details in #232) so this PR provides a CSS based solution, matching [what the news theme does](https://github.com/WordPress/wporg-news-2021/blob/trunk/source/wp-content/themes/wporg-news-2021/sass/base/_elements.scss#L2).

![Kapture 2022-08-03 at 16 10 17](https://user-images.githubusercontent.com/1017872/182522442-ab2a43be-e32f-4718-871b-d363789b835e.gif)

Testing:
1. Build the CSS and replace the corresponding stylesheet in a locally running instance of the [wporg-main-2022 repo](https://github.com/WordPress/wporg-main-2022)
2. Ensure the navigation links in the header and footer have no underline unless hovered or focused