### PR TITLE
ScreenShot Block: Only enqueue for themes.

### DIFF
--- a/mu-plugins/blocks/screenshot-preview/block.php
+++ b/mu-plugins/blocks/screenshot-preview/block.php
@@ -51,7 +51,7 @@ function register_assets() {
 
 	$block_info = require $deps_path;
 
-	if ( ! is_admin() ) {
+	if ( ! is_admin() && get_current_blog_id() === WPORG_THEME_DIRECTORY_BLOGID ) {
 		wp_enqueue_script(
 			'wporg-screenshot-preview',
 			plugin_dir_url( __FILE__ ) . 'build/index.js',

--- a/mu-plugins/blocks/screenshot-preview/block.php
+++ b/mu-plugins/blocks/screenshot-preview/block.php
@@ -51,7 +51,7 @@ function register_assets() {
 
 	$block_info = require $deps_path;
 
-	if ( ! is_admin() && function_exists( 'wporg_themes_init' ) {
+	if ( ! is_admin() && function_exists( 'wporg_themes_init' ) ) {
 		wp_enqueue_script(
 			'wporg-screenshot-preview',
 			plugin_dir_url( __FILE__ ) . 'build/index.js',

--- a/mu-plugins/blocks/screenshot-preview/block.php
+++ b/mu-plugins/blocks/screenshot-preview/block.php
@@ -51,7 +51,7 @@ function register_assets() {
 
 	$block_info = require $deps_path;
 
-	if ( ! is_admin() && get_current_blog_id() === WPORG_THEME_DIRECTORY_BLOGID ) {
+	if ( ! is_admin() && function_exists( 'wporg_themes_init' ) {
 		wp_enqueue_script(
 			'wporg-screenshot-preview',
 			plugin_dir_url( __FILE__ ) . 'build/index.js',


### PR DESCRIPTION
Fixes #237.

The screenshot block assets are being loaded on every page. Ideally, we only want to load on pages that contain the block. Currently, this block does not register a block for the block editor seeing that it was built only to work on the themes page where we have a Backbone.js managed single-page web app. As a short-term measure, this PR only loads the assets if we are on the theme's blog. In the future, we can fully implement the block editor view and use a better way to enqueue/dequeue assets.