### PR TITLE
ScreenShot Block: Remove spinner and prefer text for loading.

### DIFF
--- a/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
+++ b/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
@@ -1,6 +1,6 @@
 
 :root {
-	--wp-screenshot-theme-color: #007cba;
+	__wp-screenshot-theme-color: #007cba;
 }
 
 .wporg-screenshot-card {
@@ -26,9 +26,15 @@
 	height: 100%;
 }
 
-.wporg-screenshot--has-error,
-.wporg-screenshot--has-error:hover {
+.wporg-screenshot__has-error,
+.wporg-screenshot__has-error:hover {
 	font-size: 10px;
+	color: #aaa;
+	text-decoration: none;
+}
+
+.wporg-screenshot__loading,
+.wporg-screenshot__loading:hover {
 	color: #aaa;
 	text-decoration: none;
 }

--- a/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
+++ b/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
@@ -1,6 +1,6 @@
 
 :root {
-	__wp-screenshot-theme-color: #007cba;
+	--wp-screenshot-theme-color: #007cba;
 }
 
 .wporg-screenshot-card {

--- a/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
+++ b/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
@@ -33,8 +33,7 @@
 	text-decoration: none;
 }
 
-.wporg-screenshot__loading,
-.wporg-screenshot__loading:hover {
+.wporg-screenshot__loading {
 	color: #aaa;
 	text-decoration: none;
 }

--- a/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
+++ b/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
@@ -34,6 +34,6 @@
 }
 
 .wporg-screenshot__loading {
-	color: #aaa;
+	color: #767676;
 	text-decoration: none;
 }

--- a/mu-plugins/blocks/screenshot-preview/src/screenshot.js
+++ b/mu-plugins/blocks/screenshot-preview/src/screenshot.js
@@ -4,7 +4,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
 
 /**
  * Module constants
@@ -105,15 +104,11 @@ function ScreenShotImg( { src, isReady = false } ) {
 	}
 
 	if ( isLoading ) {
-		return (
-			<div className="wporg-screenshot">
-				<Spinner />
-			</div>
-		);
+		return <div className="wporg-screenshot wporg-screenshot__loading">{ __( 'Loading …', 'wporg' ) }</div>;
 	}
 
 	if ( hasError || hasAborted ) {
-		return <div className="wporg-screenshot wporg-screenshot--has-error">{ __( 'error', 'wporg' ) }</div>;
+		return <div className="wporg-screenshot wporg-screenshot__has-error">{ __( 'error', 'wporg' ) }</div>;
 	}
 
 	return <img src={ base64Img } alt="" />;


### PR DESCRIPTION
The block currently imports 1 component from `@wordpress/components`: `<Spinner />`.

By including that component, we inherit more dependencies that are queued by the `wordpress/components` library. Since that component is not really nedded, this PR removes it and replaces it with text. We save roughly `1.2mbs` by removing it.

# Screnshot
| Before | After |
| --- | --- |
| <img width="720" alt="Screen Shot 2022-08-04 at 3 22 52 PM" src="https://user-images.githubusercontent.com/1657336/182777586-7abc2fb1-57ab-4479-9b07-8d0482227df1.png"> | <img width="670" alt="Screen Shot 2022-08-04 at 3 16 39 PM" src="https://user-images.githubusercontent.com/1657336/182776482-39b16ae7-6d05-48cd-abba-3d0cb4f1b59a.png">| 



