### PR TITLE
Don't call `render_global_header()` directly, call `do_blocks()` instead

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -255,7 +255,7 @@ function rest_render_global_header( $request ) {
 		return true;
 	}, 10, 2 );
 
-	return render_global_header();
+	return do_blocks( '<!-- wp:wporg/global-header /-->' );
 }
 
 /**
@@ -684,7 +684,7 @@ function rest_render_global_footer( $request ) {
 	 * Render the header but discard the markup, so that any header styles/scripts
 	 * required are then available for output in the footer.
 	 */
-	render_global_header();
+	do_blocks( '<!-- wp:wporg/global-header /-->' );
 
 	// Serve the request as HTML
 	add_filter( 'rest_pre_serve_request', function( $served, $result ) {
@@ -696,7 +696,7 @@ function rest_render_global_footer( $request ) {
 		return true;
 	}, 10, 2 );
 
-	return render_global_footer();
+	return do_blocks( '<!-- wp:wporg/global-footer /-->' );
 }
 
 /**


### PR DESCRIPTION
This resolves a PHP Notice triggered in the REST API Endpoints when rendering the header/footer.

In the REST API context, no attributes are being passed to `render_global_header()` causing a PHP Notice similar to the following:
```
E_NOTICE: Undefined index: style in blocks/global-header-footer/header.php:23
Undefined index: style
Source: GET https://wordpress.org/wp-json/global-header-footer/v1/header

E_NOTICE: Undefined index: style in blocks/global-header-footer/footer.php:16
Undefined index: style
Source: GET https://wordpress.org/wp-json/global-header-footer/v1/footer
```

Seems that by calling the default Block renderer, we'll end up with a closer-to-expected behaviour and less issues in future.

I think this change is safe to make, and tests fine to me. Triggered by #225