### PR TITLE
Block: Multisite Latest Posts: Move view script to footer

### DIFF
--- a/mu-plugins/blocks/multisite-latest-posts/multisite-latest-posts.php
+++ b/mu-plugins/blocks/multisite-latest-posts/multisite-latest-posts.php
@@ -17,5 +17,8 @@ namespace WordPressdotorg\MU_Plugins\Multisite_Latest_Posts;
  */
 function multisite_latest_posts_block_init() {
 	register_block_type( __DIR__ . '/build' );
+
+	// Move the view script to the "footer" group so it prints at the end of the page.
+	wp_script_add_data( 'wporg-multisite-latest-posts-view-script', 'group', 1 );
 }
 add_action( 'init', __NAMESPACE__ . '\multisite_latest_posts_block_init' );


### PR DESCRIPTION
See https://github.com/WordPress/wporg-main-2022/issues/45

This updates the view script registered by the block code to be displayed in the footer of the page instead of the head.

**To test**

1. View a page with this block
2. View source
3. The script should be at the end of the page (search for `wporg-multisite-latest-posts-view-script-js`)
