### PR TITLE
Add a way to preload fonts

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -336,6 +336,11 @@ function render_global_header( $attributes = array() ) {
 		$show_search  = true;
 	}
 
+	// Preload the menu font.
+	if ( is_callable( 'global_fonts_preload' ) ) {
+		global_fonts_preload( 'Inter' );
+	}
+
 	// The mobile Get WordPress button needs to be in both menus.
 	$menu_items[] = array(
 		'title'   => esc_html_x( 'Get WordPress', 'Menu item title', 'wporg' ),

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -338,7 +338,9 @@ function render_global_header( $attributes = array() ) {
 
 	// Preload the menu font.
 	if ( is_callable( 'global_fonts_preload' ) ) {
-		global_fonts_preload( 'Inter latin' );
+		if ( ! is_rosetta_site() ) {
+			global_fonts_preload( 'Inter latin' );
+		}
 	}
 
 	// The mobile Get WordPress button needs to be in both menus.

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -338,7 +338,7 @@ function render_global_header( $attributes = array() ) {
 
 	// Preload the menu font.
 	if ( is_callable( 'global_fonts_preload' ) ) {
-		global_fonts_preload( 'Inter' );
+		global_fonts_preload( 'Inter latin' );
 	}
 
 	// The mobile Get WordPress button needs to be in both menus.

--- a/mu-plugins/global-fonts/README.md
+++ b/mu-plugins/global-fonts/README.md
@@ -20,10 +20,10 @@ wp_register_style(
 );
 ```
 
-If you wish to have one (or more) fonts preloaded automatically, you can add the `preload` style data.
+If you wish to have one (or more) fonts preloaded automatically, you can call the global function `global_fonts_preload()`.
 
 For example, to preload Inter in normal and italic:
 
 ```php
-wp_style_add_data( 'wporg-global-fonts', 'preload', [ 'Inter', 'Inter italic' ] );
+global_fonts_preload( [ 'Inter', 'Inter italic' ] );
 ```

--- a/mu-plugins/global-fonts/README.md
+++ b/mu-plugins/global-fonts/README.md
@@ -19,3 +19,11 @@ wp_register_style(
 	$css_version
 );
 ```
+
+If you wish to have one (or more) fonts preloaded automatically, you can add the `preload` style data.
+
+For example, to preload Inter in normal and italic:
+
+```php
+wp_style_add_data( 'wporg-global-fonts', 'preload', [ 'Inter', 'Inter italic' ] );
+```

--- a/mu-plugins/global-fonts/README.md
+++ b/mu-plugins/global-fonts/README.md
@@ -22,8 +22,8 @@ wp_register_style(
 
 If you wish to have one (or more) fonts preloaded automatically, you can call the global function `global_fonts_preload()`.
 
-For example, to preload Inter in normal and italic:
+For example, to preload Inter Latin in normal and italic:
 
 ```php
-global_fonts_preload( [ 'Inter', 'Inter italic' ] );
+global_fonts_preload( [ 'Inter Latin', 'Inter Latin italic' ] );
 ```

--- a/mu-plugins/global-fonts/helper-functions.php
+++ b/mu-plugins/global-fonts/helper-functions.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Specify a font to be preloaded.
+ *
+ * @param array|string $font_faces The font(s) to preload.
+ * @return bool If the font will be preloaded.
+ */
+function global_fonts_preload( $font_faces ) {
+	return WordPressdotorg\MU_Plugins\Global_Fonts\preload_font( $font_faces );
+}

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -6,6 +6,9 @@
 
 namespace WordPressdotorg\MU_Plugins\Global_Fonts;
 
+// Include helper functions that exist in global-scope.
+include __DIR__ . '/helper-functions.php';
+
 add_filter( 'init', __NAMESPACE__ . '\register_style', 1 );
 add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\relative_to_absolute_urls' );
 add_filter( 'wp_preload_resources', __NAMESPACE__ . '\maybe_preload_font' );

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -84,16 +84,16 @@ function maybe_preload_font( $preload ) {
 	}
 
 	foreach ( (array) $style->extra['preload'] as $font_face ) {
-		$font = get_font_details( $font_face );
-		if ( ! $font ) {
+		$font_url = get_font_url( $font_face );
+		if ( ! $font_url ) {
 			continue;
 		}
 
 		$preload[] = [
-			'href'        => $font['url'],
+			'href'        => $font_url,
 			'as'          => 'font',
 			'crossorigin' => 'crossorigin',
-			'type'        => $font['type'],
+			'type'        => 'font/woff2',
 		];
 	}
 
@@ -103,28 +103,16 @@ function maybe_preload_font( $preload ) {
 /**
  * Return the details about a specific font face.
  */
-function get_font_details( $font ) {
-	switch ( $font ) {
-		case 'Inter':
-			return [
-				'url' => plugins_url( 'Inter/Inter.woff2?v=3.19', __FILE__ ),
-				'type' => 'font/woff2'
-			];
-		case 'Inter italic':
-			return [
-				'url' => plugins_url( 'Inter/Inter-Italic.woff2?v=3.19', __FILE__ ),
-				'type' => 'font/woff2'
-			];
-		case 'EB Garamond':
-			return [
-				'url' => plugins_url( 'EB-Garamond/EB-Garamond.woff2?v=0.017', __FILE__ ),
-				'type' => 'font/woff2'
-			];
-		case 'EB Garamond italic':
-			return [
-				'url' => plugins_url( 'EB-Garamond/EB-Garamond-Italic.woff2?v=0.017', __FILE__ ),
-				'type' => 'font/woff2'
-			];
+function get_font_url( $font ) {
+	switch ( strtolower( $font ) ) {
+		case 'inter':
+			return plugins_url( 'Inter/Inter.woff2?v=3.19', __FILE__ );
+		case 'inter italic':
+			return plugins_url( 'Inter/Inter-Italic.woff2?v=3.19', __FILE__ );
+		case 'eb garamond':
+			return plugins_url( 'EB-Garamond/EB-Garamond.woff2?v=0.017', __FILE__ );
+		case 'eb garamond italic':
+			return plugins_url( 'EB-Garamond/EB-Garamond-Italic.woff2?v=0.017', __FILE__ );
 	}
 
 	return false;

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -8,6 +8,7 @@ namespace WordPressdotorg\MU_Plugins\Global_Fonts;
 
 add_filter( 'init', __NAMESPACE__ . '\register_style', 1 );
 add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\relative_to_absolute_urls' );
+add_filter( 'wp_preload_resources', __NAMESPACE__ . '\maybe_preload_font' );
 
 /**
  * Register stylesheet with font-family declarations.
@@ -45,4 +46,61 @@ function relative_to_absolute_urls( $editor_settings ) {
 	}
 
 	return $editor_settings;
+}
+
+/**
+ * Add any fonts specified for preloading to the WordPress preload stack.
+ */
+function maybe_preload_font( $preload ) {
+	$style = wp_styles()->query( 'wporg-global-fonts' );
+
+	if ( ! $style || empty( $style->extra['preload'] ) ) {
+		return $preload;
+	}
+
+	foreach ( (array) $style->extra['preload'] as $font_face ) {
+		$font = get_font_details( $font_face );
+		if ( ! $font ) {
+			continue;
+		}
+
+		$preload[] = [
+			'href'        => $font['url'],
+			'as'          => 'font',
+			'crossorigin' => 'crossorigin',
+			'type'        => $font['type'],
+		];
+	}
+
+	return $preload;
+}
+
+/**
+ * Return the details about a specific font face.
+ */
+function get_font_details( $font ) {
+	switch ( $font ) {
+		case 'Inter':
+			return [
+				'url' => plugins_url( 'Inter/Inter.woff2?v=3.19', __FILE__ ),
+				'type' => 'font/woff2'
+			];
+		case 'Inter italic':
+			return [
+				'url' => plugins_url( 'Inter/Inter-Italic.woff2?v=3.19', __FILE__ ),
+				'type' => 'font/woff2'
+			];
+		case 'EB Garamond':
+			return [
+				'url' => plugins_url( 'EB-Garamond/EB-Garamond.woff2?v=0.017', __FILE__ ),
+				'type' => 'font/woff2'
+			];
+		case 'EB Garamond italic':
+			return [
+				'url' => plugins_url( 'EB-Garamond/EB-Garamond-Italic.woff2?v=0.017', __FILE__ ),
+				'type' => 'font/woff2'
+			];
+	}
+
+	return false;
 }

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -49,6 +49,31 @@ function relative_to_absolute_urls( $editor_settings ) {
 }
 
 /**
+ * Specify a font to be preloaded.
+ *
+ * @param array|string $font_faces The font(s) to preload.
+ * @return bool If the font will be preloaded.
+ */
+function preload_font( $font_faces ) {
+	$style = wp_styles()->query( 'wporg-global-fonts' );
+	if ( ! $style ) {
+		return false;
+	}
+
+	if ( ! is_array( $font_faces ) ) {
+		$font_faces = [ $font_faces ];
+	}
+
+	$preload = $style->extra['preload'] ?? [];
+	$preload = array_merge( $preload, $font_faces );
+	$preload = array_unique( $preload );
+
+	wp_style_add_data( 'wporg-global-fonts', 'preload', $preload );
+
+	return true;
+}
+
+/**
  * Add any fonts specified for preloading to the WordPress preload stack.
  */
 function maybe_preload_font( $preload ) {

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -87,17 +87,19 @@ function maybe_preload_font( $preload ) {
 	}
 
 	foreach ( (array) $style->extra['preload'] as $font_face ) {
-		$font_url = get_font_url( $font_face );
-		if ( ! $font_url ) {
+		$font_urls = get_font_urls( $font_face );
+		if ( ! $font_urls ) {
 			continue;
 		}
 
-		$preload[] = [
-			'href'        => $font_url,
-			'as'          => 'font',
-			'crossorigin' => 'crossorigin',
-			'type'        => 'font/woff2',
-		];
+		foreach ( $font_urls as $font_url ) {
+			$preload[] = [
+				'href'        => $font_url,
+				'as'          => 'font',
+				'crossorigin' => 'crossorigin',
+				'type'        => 'font/woff2',
+			];
+		}
 	}
 
 	return $preload;
@@ -106,16 +108,36 @@ function maybe_preload_font( $preload ) {
 /**
  * Return the details about a specific font face.
  */
-function get_font_url( $font ) {
+function get_font_urls( $font ) {
 	switch ( strtolower( $font ) ) {
-		case 'inter':
-			return plugins_url( 'Inter/Inter.woff2?v=3.19', __FILE__ );
-		case 'inter italic':
-			return plugins_url( 'Inter/Inter-Italic.woff2?v=3.19', __FILE__ );
-		case 'eb garamond':
-			return plugins_url( 'EB-Garamond/EB-Garamond.woff2?v=0.017', __FILE__ );
-		case 'eb garamond italic':
-			return plugins_url( 'EB-Garamond/EB-Garamond-Italic.woff2?v=0.017', __FILE__ );
+		case 'inter arrows':
+			return [ plugins_url( 'Inter/Inter-arrows.woff2', __FILE__ ) ];
+		case 'inter cyrillic':
+			return [ plugins_url( 'Inter/Inter-cyrillic.woff2', __FILE__ ), plugins_url( 'Inter/Inter-cyrillic-ext.woff2', __FILE__ ) ];
+		case 'inter greek':
+			return [ plugins_url( 'Inter/Inter-greek.woff2', __FILE__ ), plugins_url( 'Inter/Inter-greek-ext.woff2', __FILE__ ) ];
+		case 'inter latin':
+			return [ plugins_url( 'Inter/Inter-latin.woff2', __FILE__ ), plugins_url( 'Inter/Inter-latin-ext.woff2', __FILE__ ) ];
+		case 'inter vietnamese':
+			return [ plugins_url( 'Inter/Inter-vietnamese.woff2', __FILE__ ) ];
+		case 'eb garamond arrows':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-arrows.woff2', __FILE__ ) ];
+		case 'eb garamond cyrillic':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-cyrillic.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-cyrillic-ext.woff2', __FILE__ ) ];
+		case 'eb garamond greek':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-greek.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-greek-ext.woff2', __FILE__ ) ];
+		case 'eb garamond latin':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-latin.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-latin-ext.woff2', __FILE__ ) ];
+		case 'eb garamond vietnamese':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-vietnamese.woff2', __FILE__ ) ];
+		case 'eb garamond cyrillic italic':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-Italic-cyrillic.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-Italic-cyrillic-ext.woff2', __FILE__ ) ];
+		case 'eb garamond greek italic':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-Italic-greek.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-Italic-greek-ext.woff2', __FILE__ ) ];
+		case 'eb garamond latin italic':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-Italic-latin.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-Italic-latin-ext.woff2', __FILE__ ) ];
+		case 'eb garamond vietnamese italic':
+			return [ plugins_url( 'EB-Garamond/EBGaramond-Italic-vietnamese.woff2', __FILE__ ) ];
 	}
 
 	return false;


### PR DESCRIPTION
This PR attempts to add the ability to preload fonts when required, for example:
```php
/* wp_style_add_data( 'wporg-global-fonts', 'preload', [ 'Inter', 'Inter italic' ] ); */
global_fonts_preload( [ 'Inter', 'Inter italic' ] );
```

See https://github.com/WordPress/wporg-main-2022/issues/92

The way I see this working, would be that a theme would include the CSS as a dependency of their stylesheet, and then, conditionally specify preload when required.

Downsides of this approach:
 - There are multiple places the font is hard-coded
 - ~Subsequent calls to `wp_style_add_data()` specifying additional fonts for preload will overwrite previous ones specified~
 - It's not automatically detected as to whether the font is used and automatically preloaded, the theme/plugin/etc has to do that for us.
 - ~The font face list is case-sensitive, currently.~