### PR TITLE
Update footer CIP text for rosetta sites.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -20,7 +20,6 @@ $container_class = 'global-footer ' . get_container_classes( $color_scheme );
 $code_is_poetry_src = str_contains( $container_class, 'has-charcoal-2-color' ) ?
 	plugins_url( '/images/code-is-poetry-for-light-bg.svg', __FILE__ ) :
 	'https://s.w.org/style/images/code-is-poetry-for-dark-bg.svg';
-
 ?>
 
 
@@ -115,7 +114,7 @@ $code_is_poetry_src = str_contains( $container_class, 'has-charcoal-2-color' ) ?
 
 		<?php else : ?>
 			<!-- Use text so it can be translated. -->
-			<span class="global-footer__code_is_poetry">
+			<span class="global-footer__code_is_poetry <?php echo str_ends_with( $color_scheme , 'white' ) ? 'is-dark' : '' ;?>">
 				<?php echo esc_html( get_cip_text() ); ?>
 			</span>
 

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -115,7 +115,7 @@ $code_is_poetry_src = str_contains( $container_class, 'has-charcoal-2-color' ) ?
 
 		<?php else : ?>
 			<!-- Use text so it can be translated. -->
-			<span class="global-footer__code_is_poetry <?php echo str_ends_with( $color_scheme , 'white' ) ? 'is-dark' : '' ;?>">
+			<span class="global-footer__code_is_poetry">
 				<?php echo esc_html( get_cip_text() ); ?>
 			</span>
 

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -20,6 +20,7 @@ $container_class = 'global-footer ' . get_container_classes( $color_scheme );
 $code_is_poetry_src = str_contains( $container_class, 'has-charcoal-2-color' ) ?
 	plugins_url( '/images/code-is-poetry-for-light-bg.svg', __FILE__ ) :
 	'https://s.w.org/style/images/code-is-poetry-for-dark-bg.svg';
+
 ?>
 
 

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -115,7 +115,7 @@
 		margin-bottom: 0;
 		font-family: serif; /* MrsEaves doesn't support non-latin characters well. */
 		font-size: 20px;
-		color: rgba( 255,255,255,0.25 );
+		color: rgba(255, 255, 255, 0.25);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -115,13 +115,17 @@
 		margin-bottom: 0;
 		font-family: serif; /* MrsEaves doesn't support non-latin characters well. */
 		font-size: 20px;
-		color: #4f5357;
+		color: rgba( 255,255,255,0.25 );
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 
 		@media (--tablet) {
 			margin-top: 0;
 			text-align: center;
+		}
+
+		.is-dark {
+			color: #8f8f8f;
 		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -123,9 +123,11 @@
 			margin-top: 0;
 			text-align: center;
 		}
+	}
+}
 
-		.is-dark {
-			color: #8f8f8f;
-		}
+.wp-block-group.global-footer {
+	&.has-white-background-color span.global-footer__code_is_poetry {
+		color: #8f8f8f;
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/wporg-main-2022/issues/85

This PR updates the default `code_is_poetry` element so it renders better on backgrounds:

- Sets default color to `rgba(255,255,255,0.25)` since we have more dark-colored backgrounds
- Sets `is-dark` on element if background variation ends in `white`
