### PR TITLE
Add new Meta Block to control page description

### DIFF
--- a/mu-plugins/blocks/meta-block/index.php
+++ b/mu-plugins/blocks/meta-block/index.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Block Name: Meta Block
+ * Description: A server-side dynamic block to set meta fields for SEO.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\MU_Plugins\Meta_Block;
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function meta_block_init() {
+	register_block_type(
+		__DIR__ . '/build',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\meta_block_init' );
+
+
+/**
+ * Callback to render block content. In this case, there is no content, but a
+ * filter is added to override the default page description (if the description
+ * attribute exists).
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $attributes['description'] ) ) {
+		return '';
+	}
+
+	add_filter(
+		'jetpack_open_graph_tags',
+		function( $tags ) use ( $attributes ) {
+			$tags['og:description']      = $attributes['description'];
+			$tags['twitter:description'] = $attributes['description'];
+			$tags['description']         = $attributes['description'];
+
+			return $tags;
+		},
+		20 // This should run after anything in the theme.
+	);
+
+	return '';
+}

--- a/mu-plugins/blocks/meta-block/src/block.json
+++ b/mu-plugins/blocks/meta-block/src/block.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/meta-block",
+	"version": "0.1.0",
+	"title": "Meta Block",
+	"category": "design",
+	"icon": "networking",
+	"description": "A server-side dynamic block to set meta fields for SEO.",
+	"textdomain": "wporg",
+	"attributes": {
+		"description": {
+			"type": "string"
+		}
+	},
+	"editorScript": "file:./index.js"
+}

--- a/mu-plugins/blocks/meta-block/src/block.json
+++ b/mu-plugins/blocks/meta-block/src/block.json
@@ -13,5 +13,9 @@
 			"type": "string"
 		}
 	},
+	"supports": {
+		"html": false,
+		"multiple": false
+	},
 	"editorScript": "file:./index.js"
 }

--- a/mu-plugins/blocks/meta-block/src/edit.js
+++ b/mu-plugins/blocks/meta-block/src/edit.js
@@ -4,8 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextareaControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 export default function Edit( { attributes, setAttributes } ) {
+	const excerpt = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ) );
+	const { editPost } = useDispatch( 'core/editor' );
 	const { description } = attributes;
 	const style = {
 		border: '1px dashed #757575',
@@ -22,8 +25,11 @@ export default function Edit( { attributes, setAttributes } ) {
 					<TextareaControl
 						label={ __( 'Page description', 'wporg' ) }
 						help={ __( 'Shown in search results and in social media embeds.', 'wporg' ) }
-						value={ description }
-						onChange={ ( value ) => setAttributes( { description: value } ) }
+						value={ description || excerpt }
+						onChange={ ( value ) => {
+							setAttributes( { description: value } );
+							editPost( { excerpt: value } );
+						} }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/mu-plugins/blocks/meta-block/src/edit.js
+++ b/mu-plugins/blocks/meta-block/src/edit.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextareaControl } from '@wordpress/components';
+
+export default function Edit( { attributes, setAttributes } ) {
+	const { description } = attributes;
+	const style = {
+		border: '1px dashed #757575',
+		color: '#757575',
+		padding: '1em',
+		textAlign: 'center',
+		fontStyle: 'italic',
+	};
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'wporg' ) }>
+					<TextareaControl
+						label={ __( 'Page description', 'wporg' ) }
+						help={ __( 'Shown in search results and in social media embeds.', 'wporg' ) }
+						value={ description }
+						onChange={ ( value ) => setAttributes( { description: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<p { ...useBlockProps() } style={ style }>
+				{ __( 'Nothing to see here.', 'wporg' ) }
+			</p>
+		</>
+	);
+}

--- a/mu-plugins/blocks/meta-block/src/index.js
+++ b/mu-plugins/blocks/meta-block/src/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -9,6 +9,7 @@
 require_once __DIR__ . '/helpers/helpers.php';
 require_once __DIR__ . '/blocks/global-header-footer/blocks.php';
 require_once __DIR__ . '/blocks/language-suggest/language-suggest.php';
+require_once __DIR__ . '/blocks/meta-block/index.php';
 require_once __DIR__ . '/blocks/multisite-latest-posts/multisite-latest-posts.php';
 require_once __DIR__ . '/blocks/screenshot-preview/block.php';
 require_once __DIR__ . '/global-fonts/index.php';


### PR DESCRIPTION
I saw this comment in https://github.com/WordPress/wporg-main-2022/issues/79

> maybe the solution to this is to have a special block in the post/pattern that specifies the meta description.

and decided to give it a shot. I've got a dynamic block with a description attribute. When rendering on the frontend, it returns an empty string, but sets up a filter on `jetpack_open_graph_tags` to set the description to the one from its attributes. This works for setting the page descriptions, but unfortunately doesn't work as well for the embed excerpt, since the block isn't rendered there.

I tried getting around that by updating the excerpt directly when this attribute is changed, but that will only happen when someone edits the content in the editor, not via the pattern code.

Example of the block in a pattern:

```
<!-- wp:wporg/meta-block {"description":"Download WordPress today, and get started on creating your website with one of the most powerful, popular, and customizable platforms in the world."} /-->
```

When viewed in the editor, it's just a placeholder:
<img width="848" alt="Screen Shot 2022-08-25 at 4 46 20 PM" src="https://user-images.githubusercontent.com/541093/186765585-64bf1372-b3d6-427b-8439-81a37c13dcc4.png">

The description itself is in the sidebar:
<img width="290" alt="Screen Shot 2022-08-25 at 4 46 41 PM" src="https://user-images.githubusercontent.com/541093/186765719-be73d5f3-72d9-4a02-9051-f7f1ff042d3c.png">

And it does correctly inject the description into the page:
<img width="1162" alt="Screen Shot 2022-08-25 at 4 47 51 PM" src="https://user-images.githubusercontent.com/541093/186765846-4733568f-4426-4b7c-a368-c85bf642a782.png">

We could move the text field into the main content of the editor, but I wanted to keep text inputs out of the WYSIWYG section.

This could be expanded if we need to set other meta information per page, like title, etc.

**To test**

- Build the branch
- Insert a Meta Block into your page, or copy the block code above into a template
- View the page source
- The `<meta name="description"` and other description meta should use the string from your block

Try visiting the embed page, `your-url/embed/` — if you set the description on the block in the editor, your description should appear in the embed.