### PR TITLE
Header: Simplify the admin bar and style to match global header

### DIFF
--- a/mu-plugins/blocks/global-header-footer/admin-bar.php
+++ b/mu-plugins/blocks/global-header-footer/admin-bar.php
@@ -17,7 +17,6 @@ add_filter( 'show_admin_bar', __NAMESPACE__ . '\should_show_admin_bar' );
  * @return bool
  */
 function should_show_admin_bar( $show_admin_bar ) {
-	// @todo Don't enable on the login page.
 	return true;
 }
 

--- a/mu-plugins/blocks/global-header-footer/admin-bar.php
+++ b/mu-plugins/blocks/global-header-footer/admin-bar.php
@@ -67,6 +67,8 @@ function filter_admin_bar_links( $wp_admin_bar ) {
 				$ab_item->parent = 'edit-actions';
 				$wp_admin_bar->remove_node( $ab_item->id );
 				$edit_items[] = $ab_item;
+			} else if ( preg_match( '/blog-\d+/', $ab_item->parent ) ) {
+				$wp_admin_bar->remove_node( $ab_item->id );
 			}
 		}
 

--- a/mu-plugins/blocks/global-header-footer/admin-bar.php
+++ b/mu-plugins/blocks/global-header-footer/admin-bar.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace WordPressdotorg\MU_Plugins\Global_Header_Footer;
+
+use Rosetta_Sites, WP_Post, WP_REST_Server, WP_Theme_JSON_Resolver;
+
+defined( 'WPINC' ) || die();
+
+/* Actions & filters */
+add_action( 'admin_bar_menu', __NAMESPACE__ . '\filter_admin_bar_links', 500 ); // 500 to run after all items are added to the menu.
+add_filter( 'show_admin_bar', __NAMESPACE__ . '\should_show_admin_bar' );
+
+/**
+ * Always show the admin bar.
+ *
+ * @param bool $show_admin_bar Whether the admin bar should be shown.
+ * @return bool
+ */
+function should_show_admin_bar( $show_admin_bar ) {
+	// @todo Don't enable on the login page.
+	return true;
+}
+
+/**
+ * Filter the admin bar links to simplify the frontend view.
+ *
+ * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance, passed by reference.
+ */
+function filter_admin_bar_links( $wp_admin_bar ) {
+	// Only change the admin bar on the frontend.
+	if ( is_admin() ) {
+		return;
+	}
+
+	if ( is_user_logged_in() ) {
+		// Remove all items in these submenus.
+		$parent_remove_list = [ 'wp-logo-external', 'wp-logo', 'site-name', 'appearance' ];
+
+		// Remove all these items (includes the top-level items from the parent list).
+		$remove_list = array_merge(
+			$parent_remove_list,
+			[ 'comments', 'stats', 'search', 'my-sites', 'admin-bar-likes-widget' ]
+		);
+
+		// Empty array so we can reverse it to keep the correct order.
+		$edit_items = [];
+
+		foreach ( $wp_admin_bar->get_nodes() as $ab_item ) {
+			if ( in_array( $ab_item->parent, $parent_remove_list ) ) {
+				$wp_admin_bar->remove_node( $ab_item->id );
+			} else if ( in_array( $ab_item->id, $remove_list ) ) {
+				$wp_admin_bar->remove_node( $ab_item->id );
+			} else if ( 'my-sites' === $ab_item->parent ) {
+				// Move items in "My Sites" into user's dropdown.
+				$ab_item->parent = 'my-account';
+				if ( empty( $ab_item->meta['class'] ) ) {
+					$ab_item->meta['class'] = 'ab-sub-secondary';
+				}
+				$wp_admin_bar->add_node( $ab_item );
+			} else if ( in_array( $ab_item->id, [ 'edit-profile', 'logout' ] ) ) {
+				// Move "Edit Profile" and "Logout" to a new group at the end of the dropdown.
+				$ab_item->parent = 'my-account-actions';
+				$wp_admin_bar->add_node( $ab_item );
+			} else if ( in_array( $ab_item->id, [ 'edit', 'site-editor', 'customize' ] ) ) {
+				// Move "Edit [object]", "Customize", and "Edit Site" (if exist) to list to be
+				// added to a new dropdown later.
+				$ab_item->parent = 'edit-actions';
+				$wp_admin_bar->remove_node( $ab_item->id );
+				$edit_items[] = $ab_item;
+			}
+		}
+
+		// Reverse the list to preserve order.
+		$edit_items = array_reverse( $edit_items );
+		if ( 1 === count( $edit_items ) ) {
+			// Only one item, let it be the top level item.
+			$edit_items[0]->parent = false;
+			$wp_admin_bar->add_node( $edit_items[0] );
+		} else if ( count( $edit_items ) > 1 ) {
+			// If many, add a new top level "Edit" to hold them.
+			$wp_admin_bar->add_node(
+				array(
+					'id' => 'edit-actions',
+					'title' => __( 'Edit', 'wporg' ),
+					'parent' => false,
+					'href' => false,
+				)
+			);
+
+			foreach ( $edit_items as $ab_item ) {
+				$wp_admin_bar->add_node( $ab_item );
+			}
+		}
+
+		// Add this group after all the manipulation so that it's at the end.
+		$wp_admin_bar->add_node(
+			array(
+				'id' => 'my-account-actions',
+				'title' => false,
+				'parent' => 'my-account',
+				'href' => false,
+				'group' => true,
+				'meta' => [ 'class' => 'ab-sub-secondary' ],
+			)
+		);
+	} else {
+		// Remove everything but Register & Log In
+		foreach ( $wp_admin_bar->get_nodes() as $ab_item ) {
+			if ( ! in_array( $ab_item->id, array( 'top-secondary', 'register', 'log-in' ) ) ) {
+				$wp_admin_bar->remove_node( $ab_item->id );
+			}
+		}
+
+		// Add log in link if it doesn't exist.
+		$log_in = $wp_admin_bar->get_node( 'log-in' );
+		if ( ! $log_in ) {
+			$args = array(
+				'id' => 'log-in',
+				'title' => __( 'Log In', 'wporg' ),
+				'parent' => 'top-secondary',
+				'href' => wp_login_url(),
+			);
+			$wp_admin_bar->add_node( $args );
+		}
+
+		// Add register link if it doesn't exist.
+		$register = $wp_admin_bar->get_node( 'register' );
+		if ( ! $register ) {
+			$args = array(
+				'id' => 'register',
+				'title' => __( 'Register', 'wporg' ),
+				'parent' => 'top-secondary',
+				'href' => wp_registration_url(),
+			);
+			$wp_admin_bar->add_node( $args );
+		}
+	}
+}

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -6,6 +6,8 @@ use Rosetta_Sites, WP_Post, WP_REST_Server, WP_Theme_JSON_Resolver;
 
 defined( 'WPINC' ) || die();
 
+require_once __DIR__ . '/admin-bar.php';
+
 add_action( 'init', __NAMESPACE__ . '\register_block_types' );
 add_action( 'admin_bar_init', __NAMESPACE__ . '\remove_admin_bar_callback', 15 );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -40,7 +40,8 @@ html {
  */
 
 .global-header,
-.global-footer {
+.global-footer,
+#wpadminbar {
 	--wp--preset--font-family--eb-garamond: "EB Garamond", serif;
 	--wp--preset--font-family--inter: "Inter", sans-serif;
 	--wp--preset--font-size--small: 14px;
@@ -56,6 +57,7 @@ html {
 	--wp--preset--color--charcoal-1: #1e1e1e;
 	--wp--preset--color--charcoal-5: #1c2024; /* charcoal-5 is only used in the header (hovers), it's not used in the parent/child themes. */
 	--wp--preset--color--charcoal-2: #23282d;
+	--wp--preset--color--charcoal-3: #40464d; /* Used only in the admin bar. */
 	--wp--preset--color--white: #fff;
 	--wp--preset--color--deep-blueberry: #213fd4;
 	--wp--preset--color--blueberry-1: #3858e9;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/admin-bar.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/admin-bar.pcss
@@ -1,0 +1,174 @@
+#wpadminbar {
+	--wporg-admin-bar--background-color: var(--wp--preset--color--charcoal-5);
+	--wporg-admin-bar--background-color--hover: var(--wp--preset--color--charcoal-2);
+
+	--wporg-admin-bar--link-color: var(--wp--preset--color--white);
+	--wporg-admin-bar--link-color--active: var(--wp--preset--color--blueberry-2);
+	--wporg-admin-bar--separator: var(--wp--preset--color--charcoal-3);
+
+	background-color: var(--wp--preset--color--charcoal-5);
+	color: var(--wp--preset--color--white);
+
+	& * {
+		font-family: var(--wp--preset--font-family--inter);
+	}
+}
+
+/**
+ * CSS from original core Sass files.
+ * See https://github.com/WordPress/wordpress-develop/blob/21ebdbcb745405de350f9dc570420b19c2b632d4/src/wp-admin/css/colors/_admin.scss#L379-L530.
+ */
+
+#wpadminbar .ab-item,
+#wpadminbar a.ab-item,
+#wpadminbar > #wp-toolbar span.ab-label,
+#wpadminbar > #wp-toolbar span.noticon {
+	color: var(--wporg-admin-bar--link-color);
+}
+
+#wpadminbar .ab-icon,
+#wpadminbar .ab-icon::before,
+#wpadminbar .ab-item::before,
+#wpadminbar .ab-item::after {
+	color: var(--wporg-admin-bar--link-color);
+}
+
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item,
+#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus,
+#wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
+#wpadminbar.nojs .ab-top-menu > li.menupop:hover > .ab-item,
+#wpadminbar .ab-top-menu > li.menupop.hover > .ab-item {
+	color: var(--wporg-admin-bar--link-color--active);
+	background: var(--wporg-admin-bar--background-color--hover);
+}
+
+#wpadminbar:not(.mobile) > #wp-toolbar li:hover span.ab-label,
+#wpadminbar:not(.mobile) > #wp-toolbar li.hover span.ab-label,
+#wpadminbar:not(.mobile) > #wp-toolbar a:focus span.ab-label {
+	color: var(--wporg-admin-bar--link-color--active);
+}
+
+#wpadminbar:not(.mobile) li:hover .ab-icon::before,
+#wpadminbar:not(.mobile) li:hover .ab-item::before,
+#wpadminbar:not(.mobile) li:hover .ab-item::after {
+	color: var(--wporg-admin-bar--link-color--active);
+}
+
+
+/* Admin Bar: submenu */
+#wpadminbar .menupop .ab-sub-wrapper {
+	background: var(--wporg-admin-bar--background-color--hover);
+}
+
+#wpadminbar .quicklinks .menupop ul.ab-sub-secondary,
+#wpadminbar .quicklinks .menupop ul.ab-sub-secondary .ab-submenu {
+	background: var(--wporg-admin-bar--background-color--hover);
+}
+
+#wpadminbar .quicklinks .menupop ul.ab-sub-secondary {
+	border-top: 1px solid var(--wporg-admin-bar--separator);
+}
+
+#wpadminbar .ab-submenu .ab-item,
+#wpadminbar .quicklinks .menupop ul li a,
+#wpadminbar .quicklinks .menupop.hover ul li a,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li a {
+	color: var(--wporg-admin-bar--link-color);
+}
+
+#wpadminbar .quicklinks li .blavatar,
+#wpadminbar .menupop .menupop > .ab-item::before {
+	color: var(--wporg-admin-bar--link-color);
+}
+
+#wpadminbar .quicklinks .menupop ul li a:hover,
+#wpadminbar .quicklinks .menupop ul li a:focus,
+#wpadminbar .quicklinks .menupop ul li a:hover strong,
+#wpadminbar .quicklinks .menupop ul li a:focus strong,
+#wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a,
+#wpadminbar .quicklinks .menupop.hover ul li a:hover,
+#wpadminbar .quicklinks .menupop.hover ul li a:focus,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li a:hover,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li a:focus,
+#wpadminbar li:hover .ab-icon::before,
+#wpadminbar li:hover .ab-item::before,
+#wpadminbar li a:focus .ab-icon::before,
+#wpadminbar li .ab-item:focus::before,
+#wpadminbar li .ab-item:focus .ab-icon::before,
+#wpadminbar li.hover .ab-icon::before,
+#wpadminbar li.hover .ab-item::before {
+	color: var(--wporg-admin-bar--link-color--active);
+}
+
+#wpadminbar .quicklinks li a:hover .blavatar,
+#wpadminbar .quicklinks li a:focus .blavatar,
+#wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a .blavatar,
+#wpadminbar .menupop .menupop > .ab-item:hover::before,
+#wpadminbar.mobile .quicklinks .ab-icon::before,
+#wpadminbar.mobile .quicklinks .ab-item::before {
+	color: var(--wporg-admin-bar--link-color--active);
+}
+
+#wpadminbar.mobile .quicklinks .hover .ab-icon::before,
+#wpadminbar.mobile .quicklinks .hover .ab-item::before {
+	color: var(--wporg-admin-bar--link-color);
+}
+
+#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item .wp-admin-bar-arrow::before {
+	top: 3px;
+}
+
+#wpadminbar .ab-sub-wrapper .ab-item::before {
+	content: "" !important;
+}
+
+
+/* Admin Bar: my account */
+#wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
+	border-color: transparent;
+	background-color: transparent;
+}
+
+@media screen and (min-width: 783px) {
+	#wpadminbar #wp-admin-bar-user-info {
+		min-height: 64px;
+		margin-bottom: 0;
+	}
+}
+
+#wpadminbar #wp-admin-bar-user-info .avatar {
+	top: 0;
+}
+
+#wpadminbar #wp-admin-bar-user-info .display-name {
+	color: var(--wporg-admin-bar--link-color);
+}
+
+#wpadminbar #wp-admin-bar-user-info a:hover .display-name {
+	color: var(--wporg-admin-bar--link-color--active);
+}
+
+#wpadminbar #wp-admin-bar-user-info .username {
+	color: var(--wporg-admin-bar--link-color);
+	opacity: 0.66;
+}
+
+@media screen and (max-width: 782px) {
+	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper .ab-item {
+		padding-left: 30px;
+	}
+
+	#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item .wp-admin-bar-arrow::before {
+		top: 8px;
+	}
+
+	#wpadminbar li#wp-admin-bar-log-in,
+	#wpadminbar li#wp-admin-bar-register {
+		display: block;
+
+		& a {
+			padding-left: 0.5em;
+			padding-right: 0.5em;
+		}
+	}
+}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/admin-bar.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/admin-bar.pcss
@@ -196,3 +196,9 @@
 		padding: 6px 30px;
 	}
 }
+
+/* Scroll the "My Sites" list if there are many sites */
+#wp-admin-bar-my-sites-list {
+	max-height: 50vh;
+	overflow: scroll;
+}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/admin-bar.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/admin-bar.pcss
@@ -114,12 +114,24 @@
 	color: var(--wporg-admin-bar--link-color);
 }
 
+#wpadminbar .quicklinks .menupop ul li .ab-item,
+#wpadminbar .quicklinks .menupop ul li a strong,
+#wpadminbar .quicklinks .menupop.hover ul li .ab-item,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li .ab-item {
+	line-height: 2.46; /* × 13px */
+	height: 32px;
+}
+
 #wpadminbar .ab-top-secondary .menupop .menupop > .ab-item .wp-admin-bar-arrow::before {
 	top: 3px;
 }
 
-#wpadminbar .ab-sub-wrapper .ab-item::before {
+#wpadminbar .ab-sub-wrapper #wp-admin-bar-edit-actions-default .ab-item::before {
 	content: "" !important;
+}
+
+#wpadminbar .quicklinks li .blavatar {
+	display: none;
 }
 
 
@@ -154,12 +166,18 @@
 }
 
 @media screen and (max-width: 782px) {
+	#wpadminbar .quicklinks .menupop ul.ab-sub-secondary {
+		padding-bottom: 6px;
+	}
+
 	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper .ab-item {
 		padding-left: 30px;
+		padding-top: 6px;
+		padding-bottom: 6px;
 	}
 
 	#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item .wp-admin-bar-arrow::before {
-		top: 8px;
+		top: 12px;
 	}
 
 	#wpadminbar li#wp-admin-bar-log-in,
@@ -170,5 +188,11 @@
 			padding-left: 0.5em;
 			padding-right: 0.5em;
 		}
+	}
+}
+
+@media screen and (max-width: 600px) {
+	#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper .ab-item {
+		padding: 6px 30px;
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/style.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/style.pcss
@@ -1,4 +1,5 @@
 @import "_common.pcss";
+@import "header/admin-bar.pcss";
 @import "header/header.pcss";
 @import "header/logos.pcss";
 @import "header/search.pcss";


### PR DESCRIPTION
Fixes #252. Simplify the admin bar content and style to match the global header. This also enables the admin bar across all sites - or it will, once we remove [mu-plugins/pub/wporg-no-adminbar-if-no-blogs.php](https://github.com/WordPress/wordpress.org/blob/c54eb93f3f27d02bba495f6a418db2316e9a03c6/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-no-adminbar-if-no-blogs.php).

For logged-in users…

- Remove the W logo & about menu, site name, comments, stats, likes widget, and search.
- Move My Sites dropdown content into the user profile dropdown
- Create a new "Edit" dropdown for "Edit (current object)", "Customize", and "Edit Site" — grouping these to consolidate the menu, but leaving them for fast access for site editors. These only show if relevant to the current site/page/user.
- The "+ New" menu stays as-is, and only shows if you have access to create content
- Shift the "Edit Profile" and "Logout" links to the end of the menu in their own group

For logged-out users…

- Remove all menu items, except Register & Log In
- Re-add Register and Log In if they don't exist

Finally, this styles the admin bar to match the new design library colors (which is why this is bundled as part of `global-header-footer`, so we can easily use those custom properties).

To do in other places:

- [x] Remove [mu-plugins/pub/wporg-no-adminbar-if-no-blogs.php](https://github.com/WordPress/wordpress.org/blob/c54eb93f3f27d02bba495f6a418db2316e9a03c6/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-no-adminbar-if-no-blogs.php), since the admin bar should be always visible
- [x] Remove [mu-plugins/pub/wporg-admin-bar.php](https://github.com/WordPress/wordpress.org/blob/c54eb93f3f27d02bba495f6a418db2316e9a03c6/wordpress.org/public_html/wp-content/mu-plugins/pub/wporg-admin-bar.php) as those link customizations are no longer needed
- [x] Update `mu-plugins/admin-bar-sandbox.php` to add the sandbox flag as a menu item (?)
- Anything else?

### Screenshots

|  | Mobile | Desktop |
|--------|--------|-------|
| Logged out |  ![450-loggedout](https://user-images.githubusercontent.com/541093/187489604-5b15aa9b-c2ad-4521-a0b0-bda1ee5ef299.png) | ![1320-logged-out](https://user-images.githubusercontent.com/541093/187489862-43454d5d-50cd-471a-9e09-e036d28bcae6.png) |
| Average user | ![450-avguser](https://user-images.githubusercontent.com/541093/187489471-d1880739-7f1c-4ca4-aebe-6583275222e8.png) | ![1320-avguser](https://user-images.githubusercontent.com/541093/187490187-49119f82-8ba6-4719-994f-319a838379dd.png) |
| Average user with Edit | ![450-avguser-w-edit](https://user-images.githubusercontent.com/541093/187490233-fce65e35-ce17-4aec-8463-8b69b06d62fd.png) | ![1020-avguser-w-edit](https://user-images.githubusercontent.com/541093/187490244-b8a177cb-fb6b-4d59-8531-a78231707b49.png) |
| Super admin | ![450-superadmin](https://user-images.githubusercontent.com/541093/187490329-0fe1678c-2e7d-4e48-b99c-fb5fc69be0bb.png) | ![1320-superadmin](https://user-images.githubusercontent.com/541093/187490331-5645b5cc-9483-4f74-b872-876d8b7b1815.png) |

Dropdown examples:

|     | Screenshot |
|---|------------|
| + New menu | <img width="50%" src="https://user-images.githubusercontent.com/541093/187490957-a5ac5cc4-7b8e-4e67-abde-5472da7a9760.png" /> |
| Edit menu | <img width="50%" src="https://user-images.githubusercontent.com/541093/187490950-adeffc35-ecd1-4658-9ea2-673115717283.png" /> |
| Average user | <img width="50%" src="https://user-images.githubusercontent.com/541093/187490949-355854bc-3017-49e5-8e03-0a5de5c895ba.png" /> |
| Network admin user | <img width="50%" src="https://user-images.githubusercontent.com/541093/187490955-c48a4517-97c4-43db-a815-42e6fa135ef5.png" /> |
| Forums | <img width="50%" src="https://user-images.githubusercontent.com/541093/187490951-0442e45f-d415-4868-9c37-a5dc046841bd.png" /> |

This applies to the rosetta sites, too (again with my super-admin user, plus rosetta adds a copy-post plugin).
![1320-superadmin-ja](https://user-images.githubusercontent.com/541093/187489827-5a8746f5-f2e0-4326-896a-e2878f5c52e3.png)

### How to test the changes in this Pull Request:

This ideally needs a sandbox to see the full extent of the changes, but you can test it locally.

If you test on a sandbox, you'll want to delete `/mu-plugins/pub/wporg-no-adminbar-if-no-blogs.php` first.

1. View any page
2. You should see the admin bar, whether logged in or not
3. Log in, you should see a simplified admin bar

I've checked on wordpress.org, rosetta, make.wordpress.org, and subsites; and quick checks on translate.w.org. The admin bar is not used on trac, planet, or codex.