### PR TITLE
Header: Update navigation menu

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -393,37 +393,54 @@ function is_rosetta_site() {
 function get_global_menu_items() {
 	$global_items = array(
 		array(
-			'title' => esc_html_x( 'Plugins', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/plugins/',
-			'type'  => 'custom',
+			'title'   => esc_html_x( 'News', 'Menu item title', 'wporg' ),
+			'url'     => 'https://wordpress.org/news/',
+			'type'    => 'custom',
 		),
-
 		array(
-			'title' => esc_html_x( 'Themes', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/themes/',
-			'type'  => 'custom',
-		),
-
-		array(
-			'title' => esc_html_x( 'Patterns', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/patterns/',
-			'type'  => 'custom',
-		),
-
-		array(
-			'title' => esc_html_x( 'Learn', 'Menu item title', 'wporg' ),
-			'url'   => 'https://learn.wordpress.org/',
-			'type'  => 'custom',
-		),
-
-		array(
-			'title' => esc_html_x( 'Support', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/support/',
-			'type'  => 'custom',
-
+			'title'   => esc_html_x( 'Download & Extend', 'Menu item title', 'wporg' ),
+			'url'     => 'https://wordpress.org/download/',
+			'type'    => 'custom',
 			'submenu' => array(
 				array(
-					'title' => esc_html_x( 'Documentation', 'Menu item title', 'wporg' ),
+					'title' => esc_html_x( 'Themes', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/themes/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Patterns', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/patterns/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Plugins', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/plugins/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Openverse', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/openverse/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Mobile', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/mobile/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Hosting', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/hosting/',
+					'type'  => 'custom',
+				),
+			),
+		),
+		array(
+			'title'   => esc_html_x( 'Learn', 'Menu item title', 'wporg' ),
+			'url'     => 'https://learn.wordpress.org/',
+			'type'    => 'custom',
+			'submenu' => array(
+				array(
+					'title' => esc_html_x( 'Support', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/support/',
 					'type'  => 'custom',
 				),
@@ -432,27 +449,43 @@ function get_global_menu_items() {
 					'url'   => 'https://wordpress.org/support/forums/',
 					'type'  => 'custom',
 				),
+				array(
+					'title' => esc_html_x( 'WordPress.tv', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.tv/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Developers', 'Menu item title', 'wporg' ),
+					'url'   => 'https://developer.wordpress.org/',
+					'type'  => 'custom',
+				),
 			),
 		),
-
 		array(
-			'title'   => esc_html_x( 'News', 'Menu item title', 'wporg' ),
-			'url'     => 'https://wordpress.org/news/',
+			'title'   => esc_html_x( 'Community', 'Menu item title', 'wporg' ),
+			'url'     => 'https://make.wordpress.org/',
 			'type'    => 'custom',
-		),
-
-		array(
-			'title' => esc_html_x( 'About', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/about/',
-			'type'  => 'custom',
-		),
-
-		array(
-			'title' => esc_html_x( 'Get Involved', 'Menu item title', 'wporg' ),
-			'url'   => 'https://make.wordpress.org/',
-			'type'  => 'custom',
-
 			'submenu' => array(
+				array(
+					'title' => esc_html_x( 'WordCamp', 'Menu item title', 'wporg' ),
+					'url'   => 'https://central.wordcamp.org/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Meetups', 'Menu item title', 'wporg' ),
+					'url'   => 'https://www.meetup.com/pro/wordpress/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Photo Directory', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/photos/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Job Board', 'Menu item title', 'wporg' ),
+					'url'   => 'https://jobs.wordpress.net/',
+					'type'  => 'custom',
+				),
 				array(
 					'title' => esc_html_x( 'Five for the Future', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/five-for-the-future/',
@@ -460,29 +493,27 @@ function get_global_menu_items() {
 				),
 			),
 		),
-
 		array(
-			'title' => esc_html_x( 'Showcase', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/showcase/',
-			'type'  => 'custom',
-		),
-
-		array(
-			'title' => esc_html_x( 'Mobile', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/mobile/',
-			'type'  => 'custom',
-		),
-
-		array(
-			'title' => esc_html_x( 'Hosting', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/hosting/',
-			'type'  => 'custom',
-		),
-
-		array(
-			'title' => esc_html_x( 'Openverse', 'Menu item title', 'wporg' ),
-			'url'   => 'https://wordpress.org/openverse/',
-			'type'  => 'custom',
+			'title'   => esc_html_x( 'About', 'Menu item title', 'wporg' ),
+			'url'     => 'https://wordpress.org/about/',
+			'type'    => 'custom',
+			'submenu' => array(
+				array(
+					'title' => esc_html_x( 'Showcase', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/showcase/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Gutenberg', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/gutenberg/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Enterprise', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/enterprise/',
+					'type'  => 'custom',
+				),
+			),
 		),
 	);
 

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -76,18 +76,11 @@ function recursive_menu( $menu_item, $top_level = true ) {
 <!-- wp:group {"tagName":"header","align":"full","className":"<?php echo esc_attr( $container_class ); ?>"} -->
 <header class="wp-block-group alignfull <?php echo esc_attr( $container_class ); ?>">
 	<!-- wp:html -->
-	<!-- The design calls for two logos, a small "mark" on mobile/tablet, and the full logo for desktops. -->
-		<figure class="wp-block-image global-header__wporg-logo-mark">
-			<a href="<?php echo esc_url( get_home_url() ); ?>">
-				<?php require __DIR__ . '/images/w-mark.svg'; ?>
-			</a>
-		</figure>
-
-		<figure class="wp-block-image global-header__wporg-logo-full">
-			<a href="<?php echo esc_url( get_home_url() ); ?>">
-				<?php require __DIR__ . '/images/wporg-logo.svg'; ?>
-			</a>
-		</figure>
+	<figure class="wp-block-image global-header__wporg-logo-mark">
+		<a href="<?php echo esc_url( get_home_url() ); ?>">
+			<?php require __DIR__ . '/images/w-mark.svg'; ?>
+		</a>
+	</figure>
 	<!-- /wp:html -->
 
 	<?php if ( ! empty( $locale_title ) ) : ?>

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -3,19 +3,9 @@
 		margin-bottom: 0;
 	}
 
-	& .global-header__wporg-logo-full svg,
 	& .global-header__wporg-logo-mark svg {
 		height: 100%;
 		width: auto;
-	}
-
-	& .global-header__wporg-logo-full {
-		display: none;
-		padding: 0 calc(var(--wp--style--block-gap) / 2);
-
-		@media (--desktop-wide) {
-			display: inline;
-		}
 	}
 
 	& .wp-block-image.global-header__wporg-logo-mark {
@@ -29,10 +19,6 @@
 		@media (--tablet) {
 			flex-basis: auto;
 			flex-shrink: 0;
-		}
-
-		@media (--desktop-wide) {
-			display: none;
 		}
 	}
 


### PR DESCRIPTION
Fixes #251. This updates the nav menu to match the menu here: https://github.com/WordPress/wporg-mu-plugins/issues/251#issuecomment-1228545353

Additionally, the full logo (:w: WordPress) has been removed, and now only the "W" logo is used.

| Mobile | Desktop |
|--------|----------|
| ![Screen Shot 2022-08-30 at 17 57 29](https://user-images.githubusercontent.com/541093/187551788-df4af4d8-52a2-4e95-8a8e-506b7acb9be7.png) | ![Screen Shot 2022-08-30 at 18 06 28](https://user-images.githubusercontent.com/541093/187552192-0227a022-cfad-4e3c-836a-0c4c4ce31d5f.png) |

This does not apply to Rosetta sites, as they control their site menu in wp-admin.

@critterverse There's a note about changing the font size of submenu items, but I think that was before more submenus were added - is that still necessary here?

**To test**

1. Build the CSS: `npm run build`
2. Look at the nav menu
3. Use a sandbox to make sure the current item highlighting is working
