### PR TITLE
Header: Fix visible focus styles

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
@@ -11,7 +11,6 @@
 		padding: 10px 19px;
 		border-radius: 2px;
 		font-weight: 700;
-		border: 1px dashed transparent;
 
 		&:hover {
 			cursor: pointer;
@@ -24,8 +23,10 @@
 		}
 
 		&:focus,
+		&:focus-visible,
 		&:focus-within {
-			border-color: var(--wp--preset--color--white);
+			outline: 1px dashed currentcolor;
+			outline-offset: -2px;
 		}
 	}
 
@@ -68,8 +69,10 @@
 
 			&:hover,
 			&:focus,
-			&:focus-within {
+			&:focus-visible {
 				background-color: unset;
+				text-decoration: none;
+				outline: none;
 			}
 		}
 	}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -38,6 +38,11 @@
 			padding-bottom: 16px;
 			padding-top: 16px;
 		}
+
+		&:focus-visible {
+			outline: 1px dashed currentcolor;
+			outline-offset: -2px;
+		}
 	}
 
 	&.global-header__has-locale-title .global-header__wporg-logo-mark {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -17,13 +17,27 @@
 
 	& .wp-block-navigation__responsive-container-open {
 		display: flex; /* Gutenberg has the button hardcoded to hide at 600px, but we need it to wait until `--tablet`. */
+		padding-right: calc(var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
 
 		@media (--tablet) {
 			display: none;
 		}
 
-		&:hover {
+		&:hover,
+		&:focus {
 			background-color: var(--wp-global-header--background-color--hover);
+		}
+
+		&:focus-visible {
+			outline: 1px dashed currentcolor;
+			outline-offset: -2px;
+		}
+	}
+
+	& .wp-block-navigation__responsive-container-close {
+		&:focus-visible {
+			outline: 1px dashed currentcolor;
+			outline-offset: -2px;
 		}
 	}
 
@@ -107,15 +121,20 @@
 		}
 
 		& .wp-block-navigation-item a,
-		& .global-header__overflow-menu > button {
+		& .wp-block-navigation-submenu__toggle {
 			padding-left: var(--wp--style--block-gap);
 			padding-top: calc(var(--wp--style--block-gap) / 2);
 			padding-bottom: calc(var(--wp--style--block-gap) / 2);
 			padding-right: var(--wp--style--block-gap);
 
 			&:hover,
-			&:focus-within {
+			&:focus {
 				background-color: var(--wp-global-header--background-color--hover);
+			}
+
+			&:focus-visible {
+				outline: 1px dashed currentcolor;
+				outline-offset: -2px;
 			}
 
 			@media (--tablet) {
@@ -128,6 +147,17 @@
 			@media (--short-screen) {
 				padding-bottom: calc(18px - var(--active-menu-item-border-height, 0px));
 				padding-top: 18px;
+			}
+		}
+
+		& .wp-block-navigation-submenu__toggle {
+
+			@media (--tablet) {
+				padding-left: calc(var(--wp--style--block-gap) / 2);
+				padding-right: calc(var(--wp--style--block-gap) / 2);
+				height: auto;
+				width: auto;
+				line-height: inherit;
 			}
 		}
 
@@ -176,9 +206,6 @@
 				margin: 0;
 				padding-left: var(--wp--style--block-gap);
 				padding-right: var(--wp--style--block-gap);
-				height: auto;
-				width: auto;
-				line-height: inherit;
 			}
 		}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -28,8 +28,9 @@
 			background-position: center;
 		}
 
-		&:focus {
-			outline: 1px dotted currentcolor;
+		&:focus-visible {
+			outline: 1px dashed currentcolor;
+			outline-offset: -2px;
 		}
 	}
 
@@ -46,7 +47,8 @@
 			background-position: center;
 		}
 
-		&:hover {
+		&:hover,
+		&:focus {
 			background-color: var(--wp-global-header--background-color--hover);
 		}
 
@@ -119,10 +121,6 @@
 				color: #6a6a6a;
 				opacity: 1;
 			}
-
-			&:focus {
-				outline: revert;
-			}
 		}
 
 		& .wp-block-search__button {
@@ -141,10 +139,6 @@
 					min-width: 20px;
 					width: 20px;
 				}
-			}
-
-			&:focus {
-				outline: revert;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #249 — This makes the focus state consistent across all header items, using the dashed outline style. The outline is inset slightly to prevent it being cut off or invisible against the background. Additionally, the spacing around the dropdown arrow has been increased so that it can be a larger click/touch target (fixes #261).

I've opted to use `focus-visible` so that the browser heuristics can show this only when a user is keyboard-navigating, not when the item is clicked on (hover/active state works for that case).

**Screenshots**

#249 has some before screenshots. 

|   | Black on White | White on Black |
|---|----------------|----------------|
| Top level focus | <img alt="menu-top-level" src="https://user-images.githubusercontent.com/541093/188208407-17eb1888-d245-4561-8a0c-58d207781e49.png"> | <img alt="dark-menu-top-level" src="https://user-images.githubusercontent.com/541093/188208400-fbf73a7e-2e40-4b53-bbff-c8284436529e.png"> |
| Arrow focus | <img alt="menu-arrow" src="https://user-images.githubusercontent.com/541093/188208401-39fe9f20-3952-46f1-8fb6-3ddc0abf1528.png"> | <img alt="dark-menu-arrow" src="https://user-images.githubusercontent.com/541093/188208398-ab30dfdd-2f65-4809-94fe-708294202bfc.png"> |
| Submenu focus | <img alt="menu-second-level" src="https://user-images.githubusercontent.com/541093/188208404-558c7716-2eaa-46f2-a7e6-e2721a4be802.png"> | <img width="436" alt="dark-menu-second-level" src="https://user-images.githubusercontent.com/541093/188209191-28be814f-2d27-4ce6-ab94-b52146c174d8.png"> |
| Get WP | <img alt="menu-get-wp" src="https://user-images.githubusercontent.com/541093/188208402-2ecec3a3-4d2e-47aa-b9a1-03463a72a96e.png"> | <img alt="dark-menu-get-wp" src="https://user-images.githubusercontent.com/541093/188209504-c33abca9-6bff-4461-ab59-03f7ea1a5849.png"> |
| Search button | <img alt="menu-search" src="https://user-images.githubusercontent.com/541093/188208403-20bdc901-8d0a-4563-8a84-042b495a1e76.png"> | <img alt="dark-menu-search" src="https://user-images.githubusercontent.com/541093/188209512-2790e81b-ab89-4168-a47f-f54bb049912e.png"> |

**To test**

- Try on pages with the different header variations, the outline color should always match the text color to ensure contrast
- Navigate through the menu with a keyboard
