### PR TITLE
Header: Duplicate parent menu items in submenu for clarity.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -405,6 +405,11 @@ function get_global_menu_items() {
 			'type'    => 'custom',
 			'submenu' => array(
 				array(
+					'title' => esc_html_x( 'Get WordPress', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/download/',
+					'type'  => 'custom',
+				),
+				array(
 					'title' => esc_html_x( 'Themes', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/themes/',
 					'type'  => 'custom',
@@ -442,6 +447,11 @@ function get_global_menu_items() {
 			'type'    => 'custom',
 			'submenu' => array(
 				array(
+					'title' => esc_html_x( 'Learn WordPress', 'Menu item title', 'wporg' ),
+					'url'   => 'https://learn.wordpress.org/',
+					'type'  => 'custom',
+				),
+				array(
 					'title' => esc_html_x( 'Support', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/support/',
 					'type'  => 'custom',
@@ -468,6 +478,11 @@ function get_global_menu_items() {
 			'url'     => 'https://make.wordpress.org/',
 			'type'    => 'custom',
 			'submenu' => array(
+				array(
+					'title' => esc_html_x( 'Make WordPress', 'Menu item title', 'wporg' ),
+					'url'   => 'https://make.wordpress.org/',
+					'type'  => 'custom',
+				),
 				array(
 					'title' => esc_html_x( 'WordCamp', 'Menu item title', 'wporg' ),
 					'url'   => 'https://central.wordcamp.org/',
@@ -500,6 +515,11 @@ function get_global_menu_items() {
 			'url'     => 'https://wordpress.org/about/',
 			'type'    => 'custom',
 			'submenu' => array(
+				array(
+					'title' => esc_html_x( 'About WordPress', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/about/',
+					'type'  => 'custom',
+				),
 				array(
 					'title' => esc_html_x( 'Showcase', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/showcase/',


### PR DESCRIPTION
Fixes #264

This screenshot shows all the submenus active at once, just to make it easy to see all the new items. It production, though, it will still only show 1 submenu at a time, and they'll have the same width etc that they do now.

![Screen Shot 2022-09-13 at 4 46 58 PM](https://user-images.githubusercontent.com/484068/190028838-a2cebc4a-a664-4d3a-92ef-c27388f004ff.png)
