### PR TITLE
Menu: Fix the search close button on desktop screens

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -90,11 +90,6 @@ html {
 	}
 }
 
-/* The classic themes don't use the same modal view, so the offset needs to be changed. */
-body.is-classic-theme .wp-block-group.global-header .wp-block-navigation__responsive-container-close {
-	top: var(--wp-admin--admin-bar--height, 0);
-}
-
 /*
  * Gutenberg Patches
  *

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -314,8 +314,7 @@
 }
 
 /* Gutenberg bug: Close button is not visible in Safari; override it locally */
-.global-header__navigation .is-menu-open,
-.global-header__search .is-menu-open {
+.global-header__navigation .is-menu-open {
 	overflow: visible;
 
 	& > div {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -8,10 +8,7 @@
 	}
 
 	& .wp-block-navigation__responsive-container {
-
-		@media (--tablet) {
-			overflow: visible;
-		}
+		overflow: visible;
 	}
 
 	& .wp-block-navigation__responsive-container-open,


### PR DESCRIPTION
Fixes #275.

Reverts some of 385f134f7c131d6ffaa6ec3e426079d5f24d70f2, and sets the search button to always be visible.

In 385f134f7c131d6ffaa6ec3e426079d5f24d70f2 I added some code that split classic theme and block theme styles, but that doesn't seem to be needed and is having an unexpected effect on the desktop search dropdown.