### PR TITLE
Fix the padding and font size on the search field

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -50,6 +50,7 @@ html {
 	--wp--custom--alignment--edge-spacing: clamp(24px, calc(100vw / 18), 80px);
 	--wp--custom--body--typography--line-height: 1.9;
 	--wp--custom--margin--vertical: 30px;
+	--wp--custom--margin--horizontal: 30px;
 	--wp--custom--form--padding: calc(0.5 * var(--wp--custom--margin--horizontal));
 	--wp--style--block-gap: 24px;
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -106,12 +106,16 @@
 
 		& .wp-block-search__input {
 			-webkit-appearance: none; /* Remove duplicate magnifying glass icon on Safari-mobile. */
+			margin: 0;
 			padding: var(--wp--custom--form--padding);
 			box-shadow: none;
 			border: none;
+			font-size: var(--wp--preset--font-size--normal);
+			line-height: 1.5;
 
 			@media (--tablet) {
 				padding: calc(var(--wp--custom--form--padding) * 0.5) var(--wp--custom--form--padding);
+				font-size: var(--wp--preset--font-size--small);
 			}
 
 			&::placeholder {


### PR DESCRIPTION
There were some visual differences in the search bar for block-based themes vs classic themes. In the classic themes, the variable used for padding was undefined, so it had no padding. I'm not totally sure why the font sizes were different, but I've set them specifically for desktop and mobile, so new changes shouldn't creep in.

Fixes #285 

| Homepage | News | Patterns |
|------------|-------|----------|
| <img width="444" alt="" src="https://user-images.githubusercontent.com/541093/192059052-6f001266-bc36-40b9-92b5-0f94f722fbb4.png"> | <img width="455" alt="" src="https://user-images.githubusercontent.com/541093/192058917-ac164575-fdbf-4157-a4a5-02fc3fea2c8e.png"> | <img width="391" alt="" src="https://user-images.githubusercontent.com/541093/192058916-a3312b47-3b9d-4a7a-b252-6db824d46fd5.png"> |
| <img width="494" alt="" src="https://user-images.githubusercontent.com/541093/192059096-b5f3329a-4c3b-4623-babd-11f57a2724e0.png"> | <img width="497" alt="" src="https://user-images.githubusercontent.com/541093/192058915-02480db3-8257-494d-9545-806d3d24fee5.png"> | <img width="492" alt="" src="https://user-images.githubusercontent.com/541093/192058913-4db07baf-b54f-4344-92ea-4cd3147b9cdd.png"> |

(PRing since it's late friday, anyone can review/merge, otherwise I'll deploy monday morning)

