### PR TITLE
Screenshot-Preview: Add in a css loader.

### DIFF
--- a/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
+++ b/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
@@ -49,7 +49,8 @@
 	height: 100%;
 }
 
-.wporg-screenshot-loader span {
+.wporg-screenshot-loader::after {
+	content: "";
 	display: inline-block;
 	box-sizing: border-box;
 	height: 24px;

--- a/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
+++ b/mu-plugins/blocks/screenshot-preview/postcss/style.pcss
@@ -1,4 +1,3 @@
-
 :root {
 	--wp-screenshot-theme-color: #007cba;
 }
@@ -43,7 +42,31 @@
 	text-decoration: none;
 }
 
-.wporg-screenshot__loading {
-	color: #767676;
-	text-decoration: none;
+.wporg-screenshot-loader {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+}
+
+.wporg-screenshot-loader span {
+	display: inline-block;
+	box-sizing: border-box;
+	height: 24px;
+	width: 24px;
+	border: 2px solid;
+	border-color: #ddd #ddd #0073aa;
+	border-radius: 50%;
+
+	animation: rotate-360 1.4s linear infinite;
+}
+
+@keyframes rotate-360 {
+	0% {
+		transform: rotate(0deg);
+	}
+
+	100% {
+		transform: rotate(360deg);
+	}
 }

--- a/mu-plugins/blocks/screenshot-preview/src/screenshot.js
+++ b/mu-plugins/blocks/screenshot-preview/src/screenshot.js
@@ -105,7 +105,11 @@ function ScreenShotImg( { queryString, src, isReady = false } ) {
 	}
 
 	if ( isLoading ) {
-		return <div className="wporg-screenshot wporg-screenshot__loading">{ __( 'Loading …', 'wporg' ) }</div>;
+		return (
+			<div className="wporg-screenshot wporg-screenshot-loader">
+				<span />
+			</div>
+		);
 	}
 
 	if ( hasError || hasAborted ) {

--- a/mu-plugins/blocks/screenshot-preview/src/screenshot.js
+++ b/mu-plugins/blocks/screenshot-preview/src/screenshot.js
@@ -105,11 +105,7 @@ function ScreenShotImg( { queryString, src, isReady = false } ) {
 	}
 
 	if ( isLoading ) {
-		return (
-			<div className="wporg-screenshot wporg-screenshot-loader">
-				<span />
-			</div>
-		);
+		return <div className="wporg-screenshot wporg-screenshot-loader" />;
 	}
 
 	if ( hasError || hasAborted ) {


### PR DESCRIPTION
See: https://meta.trac.wordpress.org/ticket/6059#comment:18

This PR adds a CSS loader to the ScreenShot preview block. Since we are still choosing to keep the theme page light and exclude extra `@wordpress` dependencies, I chose to attempt to recreate the `@wordpress/components/Spinner` component.

When the theme directory undergoes _blockification_, we should lean towards using more `@wordpress` controls, but until then it think this is a fair approach.

## Screenshots
<img width="584" alt="Screen Shot 2022-10-12 at 9 20 25 AM" src="https://user-images.githubusercontent.com/1657336/195224399-ff3e8a67-9cc4-4a00-9a16-4084ca278ee3.png">

### Comparing of the two loaders
**Left**: This implementation
**Right**: `@wordpress/components/spinner`
<img width="227" alt="Screen Shot 2022-10-12 at  9 28 51 AM" src="https://user-images.githubusercontent.com/1657336/195224397-94056530-0a20-4a41-87cf-9cb35a82c631.png">
The circle outline width is not reproducible with CSS. It can either be thicker or thinner than the `<svg/>`.
