### PR TITLE
Update horizontal slider and image to be more accessible.

### DIFF
--- a/mu-plugins/blocks/horizontal-slider/postcss/style.pcss
+++ b/mu-plugins/blocks/horizontal-slider/postcss/style.pcss
@@ -78,6 +78,7 @@ button[disabled]::after {
 	gap: 12px;
 	padding-bottom: 24px;
 	padding-top: 6px;
+	list-style: none;
 
 	/* So item focus states are not clipped */
 	margin-left: -4px;

--- a/mu-plugins/blocks/horizontal-slider/src/block.js
+++ b/mu-plugins/blocks/horizontal-slider/src/block.js
@@ -95,13 +95,9 @@ function Block( { items, title } ) {
 	const height = width * aspectRatio;
 
 	return (
-		<div aria-labelledby="sliderHeading">
+		<div>
 			<div className="horizontal-slider-header">
-				<span>
-					<h3 id="sliderHeading" className="horizontal-slider-title">
-						{ title }
-					</h3>
-				</span>
+				<h3 className="horizontal-slider-title">{ title }</h3>
 				{ ( canNext || canPrevious ) && (
 					<span className="horizontal-slider-controls">
 						<Handle

--- a/mu-plugins/blocks/horizontal-slider/src/block.js
+++ b/mu-plugins/blocks/horizontal-slider/src/block.js
@@ -129,7 +129,7 @@ function Block( { items, title } ) {
 							isReady={ true }
 							tagProps={ {
 								'aria-controls': item.title,
-								'aria-selected': 'true',
+								'aria-selected': false,
 								role: 'tab',
 							} }
 						/>

--- a/mu-plugins/blocks/horizontal-slider/src/block.js
+++ b/mu-plugins/blocks/horizontal-slider/src/block.js
@@ -95,10 +95,12 @@ function Block( { items, title } ) {
 	const height = width * aspectRatio;
 
 	return (
-		<div>
+		<div aria-labelledby="sliderHeading">
 			<div className="horizontal-slider-header">
 				<span>
-					<h3 className="horizontal-slider-title">{ title }</h3>
+					<h3 id="sliderHeading" className="horizontal-slider-title">
+						{ title }
+					</h3>
 				</span>
 				{ ( canNext || canPrevious ) && (
 					<span className="horizontal-slider-controls">
@@ -115,19 +117,25 @@ function Block( { items, title } ) {
 					</span>
 				) }
 			</div>
-			<div className="horizontal-slider-wrapper" ref={ outerRef }>
+			<ul className="horizontal-slider-wrapper" ref={ outerRef } role="tablist">
 				{ items.map( ( item ) => (
-					<ScreenShot
-						key={ item.title }
-						{ ...item }
-						width={ `${ width }px` }
-						height={ `${ height }px` }
-						aspectRatio={ aspectRatio }
-						queryString={ `?vpw=${ initialWidth * 10 }&vph=${ initialHeight * 10 }` }
-						isReady={ true }
-					/>
+					<li key={ item.title } role="presentation">
+						<ScreenShot
+							{ ...item }
+							width={ `${ width }px` }
+							height={ `${ height }px` }
+							aspectRatio={ aspectRatio }
+							queryString={ `?vpw=${ initialWidth * 10 }&vph=${ initialHeight * 10 }` }
+							isReady={ true }
+							tagProps={ {
+								'aria-controls': item.title,
+								'aria-selected': 'true',
+								role: 'tab',
+							} }
+						/>
+					</li>
 				) ) }
-			</div>
+			</ul>
 		</div>
 	);
 }

--- a/mu-plugins/blocks/horizontal-slider/src/block.js
+++ b/mu-plugins/blocks/horizontal-slider/src/block.js
@@ -123,7 +123,7 @@ function Block( { items, title } ) {
 							aspectRatio={ aspectRatio }
 							queryString={ `?vpw=${ initialWidth * 10 }&vph=${ initialHeight * 10 }` }
 							isReady={ true }
-							tagProps={ {
+							anchorTagProps={ {
 								'aria-controls': item.title,
 								'aria-selected': false,
 								role: 'tab',

--- a/mu-plugins/blocks/screenshot-preview/src/block.js
+++ b/mu-plugins/blocks/screenshot-preview/src/block.js
@@ -13,14 +13,14 @@ import ScreenShot from './screenshot';
 /**
  *
  * @param {Object} props
- * @param {string} props.link        Url for anchor tag.
- * @param {string} props.previewLink Url used for the screenshot preview.
- * @param {string} props.caption     Text for screen readers.
- * @param {string} props.height      Initial height for the preview, include unit.
- * @param {string} props.width       Desired with of the preview element, include unit.
- * @param {number} props.aspectRatio Aspect ratio for the preview element.
- * @param {string} props.queryString Arguments passed to screenshot service.
- * @param {Object} props.anchorTagProps    HTMLAnchorElement attributes to be added to the block anchor tag.
+ * @param {string} props.link           Url for anchor tag.
+ * @param {string} props.previewLink    Url used for the screenshot preview.
+ * @param {string} props.caption        Text for screen readers.
+ * @param {string} props.height         Initial height for the preview, include unit.
+ * @param {string} props.width          Desired with of the preview element, include unit.
+ * @param {number} props.aspectRatio    Aspect ratio for the preview element.
+ * @param {string} props.queryString    Arguments passed to screenshot service.
+ * @param {Object} props.anchorTagProps HTMLAnchorElement attributes to be added to the block anchor tag.
  *
  * @return {Object} React element
  */
@@ -32,7 +32,7 @@ function Block( {
 	width = '100%',
 	aspectRatio = 2 / 3,
 	queryString = '?vpw=1200&vph=800',
-	tagProps = {},
+	anchorTagProps = {},
 } ) {
 	const wrapperRef = useRef();
 	const [ frameHeight, setFrameHeight ] = useState( height );
@@ -70,7 +70,7 @@ function Block( {
 				width: width,
 			} }
 			href={ link }
-			{ ...tagProps }
+			{ ...anchorTagProps }
 		>
 			<ScreenShot queryString={ queryString } src={ previewLink } isReady={ shouldLoad } alt={ caption } />
 		</a>

--- a/mu-plugins/blocks/screenshot-preview/src/block.js
+++ b/mu-plugins/blocks/screenshot-preview/src/block.js
@@ -20,7 +20,7 @@ import ScreenShot from './screenshot';
  * @param {string} props.width       Desired with of the preview element, include unit.
  * @param {number} props.aspectRatio Aspect ratio for the preview element.
  * @param {string} props.queryString Arguments passed to screenshot service.
- * @param {Object} props.tagProps    Props added to block tag.
+ * @param {Object} props.anchorTagProps    HTMLAnchorElement attributes to be added to the block anchor tag.
  *
  * @return {Object} React element
  */

--- a/mu-plugins/blocks/screenshot-preview/src/block.js
+++ b/mu-plugins/blocks/screenshot-preview/src/block.js
@@ -20,6 +20,7 @@ import ScreenShot from './screenshot';
  * @param {string} props.width       Desired with of the preview element, include unit.
  * @param {number} props.aspectRatio Aspect ratio for the preview element.
  * @param {string} props.queryString Arguments passed to screenshot service.
+ * @param {Object} props.tagProps    Props added to block tag.
  *
  * @return {Object} React element
  */
@@ -31,6 +32,7 @@ function Block( {
 	width = '100%',
 	aspectRatio = 2 / 3,
 	queryString = '?vpw=1200&vph=800',
+	tagProps = {},
 } ) {
 	const wrapperRef = useRef();
 	const [ frameHeight, setFrameHeight ] = useState( height );
@@ -68,9 +70,9 @@ function Block( {
 				width: width,
 			} }
 			href={ link }
+			{ ...tagProps }
 		>
-			{ caption && <span className="screen-reader-text">{ caption }</span> }
-			<ScreenShot queryString={ queryString } src={ previewLink } isReady={ shouldLoad } />
+			<ScreenShot queryString={ queryString } src={ previewLink } isReady={ shouldLoad } alt={ caption } />
 		</a>
 	);
 }

--- a/mu-plugins/blocks/screenshot-preview/src/screenshot.js
+++ b/mu-plugins/blocks/screenshot-preview/src/screenshot.js
@@ -42,13 +42,14 @@ function useInterval( callback, delay ) {
  * we need to do some custom handling.
  *
  * @param {Object}  props
+ * @param {string}  props.alt         Alternate text for image.
  * @param {string}  props.queryString Arguments that are passed to mShots.
  * @param {string}  props.src         The url of the screenshot.
  * @param {boolean} props.isReady     Whether we should start try to show the image.
  *
  * @return {Object} React component
  */
-function ScreenShotImg( { queryString, src, isReady = false } ) {
+function ScreenShotImg( { alt = '', queryString, src, isReady = false } ) {
 	const fullUrl = `https://s0.wp.com/mshots/v1/${ encodeURIComponent( src ) }${ queryString }`;
 
 	const [ attempts, setAttempts ] = useState( 0 );
@@ -112,7 +113,7 @@ function ScreenShotImg( { queryString, src, isReady = false } ) {
 		return <div className="wporg-screenshot wporg-screenshot__has-error">{ __( 'error', 'wporg' ) }</div>;
 	}
 
-	return <img src={ base64Img } alt="" />;
+	return <img src={ base64Img } alt={ alt } />;
 }
 
 export default ScreenShotImg;


### PR DESCRIPTION
This PR updates the `horizontal-slider` & the `screenshot-preview` block based on feedback from the #accessibility wordpress.org slack channel:
https://wordpress.slack.com/archives/C02RP4X03/p1665538949143739

It still doesn't leave us with a perfect `tablist` implementation because there is a lack of content to be used for describing style variations: (https://wordpress.slack.com/archives/C02RP4X03/p1665538927860869)

Additionally, the tabs are dynamically created in `wporg-themes`. Long term, the tabs (thumbnails), should be moved out of the `wporg-themes` javascript and added to this control for better control. While this component was originally supposed to be just a horizontal slider, we probably want to extend it to handle the thumbnails if new theme directory designs work similarly.

**Example of HTML output:**
```
<ul role="tablist">
	<li role="presentation">
		<a class="wporg-screenshot-card" 
			href="https://wp-themes.com/twentytwentytwo" 
			aria-controls="Default" 
			aria-selected="false" 
			role="tab">
			<img src={...} alt="blue style variation">
		</a>
	</li>
</ul>
```
I wanted to change out `<a>` for a `<button>` but too many default styles interfere and based on [Advanced ARIA tip #1: Tabs in web apps](https://www.marcozehe.de/advanced-aria-tip-1-tabs-in-web-apps/), it isn't completely necessary, although probably a more ideal.

