### PR TITLE
Fix issue with horizontal slider next button.

### DIFF
--- a/mu-plugins/blocks/horizontal-slider/src/block.js
+++ b/mu-plugins/blocks/horizontal-slider/src/block.js
@@ -36,7 +36,6 @@ const SET_WIDTH = CARD_WIDTH * 3;
  */
 function Block( { items, title } ) {
 	const outerRef = useRef();
-	const [ scrollLeftPos, setScrollLeftPos ] = useState( 0 );
 	const [ canPrevious, setCanPrevious ] = useState( false );
 	const [ canNext, setCanNext ] = useState( true );
 
@@ -54,28 +53,29 @@ function Block( { items, title } ) {
 		if ( ! canPrevious ) {
 			return;
 		}
-		setScrollLeftPos( outerRef.current.scrollLeft - SET_WIDTH );
+		scrollContainer( outerRef.current.scrollLeft - SET_WIDTH );
 	};
 
 	const handleNext = () => {
 		if ( ! canNext ) {
 			return;
 		}
-		setScrollLeftPos( outerRef.current.scrollLeft + SET_WIDTH );
-	};
 
-	useEffect( () => {
-		scrollContainer( scrollLeftPos );
-	}, [ scrollLeftPos ] );
+		scrollContainer( outerRef.current.scrollLeft + SET_WIDTH );
+	};
 
 	useEffect( () => {
 		if ( ! outerRef.current ) {
 			return;
 		}
 
+		const { paddingLeft, paddingRight } = window.getComputedStyle( outerRef.current );
+		const innerContainerWidth =
+			outerRef.current.clientWidth - parseFloat( paddingLeft ) - parseFloat( paddingRight );
+
 		const handleScrollEvent = () => {
 			setCanPrevious( outerRef.current.scrollLeft > 0 );
-			setCanNext( totalContainerWidth - outerRef.current.scrollLeft > outerRef.current.offsetWidth );
+			setCanNext( totalContainerWidth - outerRef.current.scrollLeft > innerContainerWidth );
 		};
 
 		handleScrollEvent();

--- a/mu-plugins/blocks/horizontal-slider/src/block.js
+++ b/mu-plugins/blocks/horizontal-slider/src/block.js
@@ -40,7 +40,7 @@ function Block( { items, title } ) {
 	const [ canNext, setCanNext ] = useState( true );
 
 	// Calculate to total width of the content
-	const totalContainerWidth = items.length * ( CARD_WIDTH + CARD_GAP ) - CARD_GAP;
+	const innerContainerWidth = items.length * ( CARD_WIDTH + CARD_GAP ) - CARD_GAP;
 
 	const scrollContainer = ( pos ) => {
 		outerRef.current.scrollTo( {
@@ -70,12 +70,12 @@ function Block( { items, title } ) {
 		}
 
 		const { paddingLeft, paddingRight } = window.getComputedStyle( outerRef.current );
-		const innerContainerWidth =
+		const outerContainerWidth =
 			outerRef.current.clientWidth - parseFloat( paddingLeft ) - parseFloat( paddingRight );
 
 		const handleScrollEvent = () => {
 			setCanPrevious( outerRef.current.scrollLeft > 0 );
-			setCanNext( totalContainerWidth - outerRef.current.scrollLeft > innerContainerWidth );
+			setCanNext( innerContainerWidth - outerRef.current.scrollLeft > outerContainerWidth );
 		};
 
 		handleScrollEvent();


### PR DESCRIPTION
@adamwoodnz noticed an issue where the next and previous buttons were active but nothing happened when they were clicked. This was happening because the `scrollLeftPos` value was only updated on button clicks (by design) and the new & previous values were the same, never triggering the `useEffect` that scrolls the container.

**So for example:**
- User scrolls to end of the container, by clicking "next" button,`scrollLeftPos = 300`. 
- User would navigate back with a gesture (not clicking the button), still `scrollLeftPos = 300`.
- User would click the button, new position `scrollLeftPos = 300`. 

`useEffect` doesn't get triggered.

The approach here is to just remove the `useEffect` and update the scroll position on every click. I think this is best since the component doesn't try to _remember_ positioning but lets the browser and `scrollLeft` be the source of truth.

This also fixes a secondary issue where the "next" button was being greyed out a few pixels too early.

## Screenshots

| Before | After |
| --- | --- |
| ![Screen Capture on 2022-10-18 at 14-31-06](https://user-images.githubusercontent.com/1657336/196343717-9fa6404a-f3e6-4628-ae5d-8ae78534df93.gif) | ![Screen Capture on 2022-10-18 at 14-29-39](https://user-images.githubusercontent.com/1657336/196343723-f1897928-8e3f-4cd9-a48f-86f4c54cff8f.gif) |
| ![Screen Capture on 2022-10-18 at 14-34-06](https://user-images.githubusercontent.com/1657336/196343999-3cdadcc8-aa98-4b87-9a1b-0b5905a1a193.gif) |  ![Screen Capture on 2022-10-18 at 14-35-19](https://user-images.githubusercontent.com/1657336/196344126-022645f5-59aa-462f-9fd1-404ed8fc4bd0.gif) |



