### PR TITLE
Split out the *-ext subsets

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -339,7 +339,7 @@ function render_global_header( $attributes = array() ) {
 	// Preload the menu font.
 	if ( is_callable( 'global_fonts_preload' ) ) {
 		if ( ! is_rosetta_site() ) {
-			global_fonts_preload( 'Inter latin' );
+			global_fonts_preload( 'Inter', 'latin' );
 		}
 	}
 

--- a/mu-plugins/global-fonts/README.md
+++ b/mu-plugins/global-fonts/README.md
@@ -1,4 +1,4 @@
-# Global Fonts
+# Global Font Subsets
 
 Inter and EB Garamond are used across WordPress.org. This mu-plugin sets up local versions to load, rather than loading from Google fonts.
 
@@ -21,10 +21,16 @@ wp_register_style(
 );
 ```
 
-If you wish to have one (or more) fonts preloaded automatically, you can call the global function `global_fonts_preload()`.
+If you wish to have one (or more) font subsets preloaded automatically, you can call the global function `global_fonts_preload()`.
 
-For example, to preload Inter Latin in normal and italic:
+For example, to preload Inter Latin:
 
 ```php
-global_fonts_preload( [ 'Inter Latin', 'Inter Latin italic' ] );
+global_fonts_preload( 'Inter', 'Latin' );
+```
+
+or to also preload EB Garamond Italic Cyrillic:
+
+```php
+global_fonts_preload( 'Inter, EB Garamond Italic', 'Latin, Cyrillic' );
 ```

--- a/mu-plugins/global-fonts/README.md
+++ b/mu-plugins/global-fonts/README.md
@@ -23,13 +23,13 @@ wp_register_style(
 
 If you wish to have one (or more) font subsets preloaded automatically, you can call the global function `global_fonts_preload()`.
 
-For example, to preload Inter Latin:
+For example, to preload `Inter Latin`:
 
 ```php
 global_fonts_preload( 'Inter', 'Latin' );
 ```
 
-or to also preload EB Garamond Italic Cyrillic:
+to preload `Inter Latin`, `Inter Cyrillic`, `EB Garamond Italic Latin`, and `EB Garamond Italic Cyrillic`:
 
 ```php
 global_fonts_preload( 'Inter, EB Garamond Italic', 'Latin, Cyrillic' );

--- a/mu-plugins/global-fonts/helper-functions.php
+++ b/mu-plugins/global-fonts/helper-functions.php
@@ -3,9 +3,10 @@
 /**
  * Specify a font to be preloaded.
  *
- * @param array|string $font_faces The font(s) to preload.
+ * @param string $fonts The font(s) to preload.
+ * @param string $subsets The subset(s) to preload.
  * @return bool If the font will be preloaded.
  */
-function global_fonts_preload( $font_faces ) {
-	return WordPressdotorg\MU_Plugins\Global_Fonts\preload_font( $font_faces );
+function global_fonts_preload( $fonts, $subsets ) {
+	return WordPressdotorg\MU_Plugins\Global_Fonts\preload_font( $fonts, $subsets );
 }

--- a/mu-plugins/global-fonts/helper-functions.php
+++ b/mu-plugins/global-fonts/helper-functions.php
@@ -7,6 +7,6 @@
  * @param string $subsets The subset(s) to preload.
  * @return bool If the font will be preloaded.
  */
-function global_fonts_preload( $fonts, $subsets ) {
+function global_fonts_preload( $fonts, $subsets = '' ) {
 	return WordPressdotorg\MU_Plugins\Global_Fonts\preload_font( $fonts, $subsets );
 }

--- a/mu-plugins/global-fonts/helper-functions.php
+++ b/mu-plugins/global-fonts/helper-functions.php
@@ -3,9 +3,12 @@
 /**
  * Specify a font to be preloaded.
  *
- * @param string $fonts The font(s) to preload.
- * @param string $subsets The subset(s) to preload.
- * @return bool If the font will be preloaded.
+ * @see WordPressdotorg\MU_Plugins\Global_Fonts\preload_font.
+ *
+ * @param string $fonts   The font(s) to preload, comma-separated.
+ * @param string $subsets The subset(s) to preload, comma-separated.
+ *
+ * @return bool If the font has been added to the preload list.
  */
 function global_fonts_preload( $fonts, $subsets = '' ) {
 	return WordPressdotorg\MU_Plugins\Global_Fonts\preload_font( $fonts, $subsets );

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -123,23 +123,39 @@ function maybe_preload_font( $preload ) {
  * Return the details about a specific font face.
  */
 function get_font_url( $font, $subset ) {
-	$lower_font = strtolower( trim( $font ) );
+	$lower_font   = strtolower( trim( $font ) );
 	$lower_subset = strtolower( trim( $subset ) );
+
+	$valid_subsets = array( 'arrows', 'cyrillic-ext', 'cyrillic', 'greek-ext', 'greek', 'latin-ext', 'latin', 'vietnamese' );
+	if ( ! in_array( $lower_subset, $valid_subsets ) ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			trigger_error( sprintf( 'Requested font subset %s does not exist.', esc_html( $lower_subset ) ), E_USER_WARNING );
+		}
+		return false;
+	}
 
 	switch ( $lower_font ) {
 		case 'inter':
 			$font_folder = 'Inter/';
 			$font_file_name = 'Inter-';
-			return plugins_url( $font_folder . $font_file_name . $lower_subset . '.woff2', __FILE__ );
+			break;
 		case 'eb garamond':
 			$font_folder = 'EB-Garamond/';
 			$font_file_name = 'EBGaramond-';
-			return plugins_url( $font_folder . $font_file_name . $lower_subset . '.woff2', __FILE__ );
+			break;
 		case 'eb garamond italic':
 			$font_folder = 'EB-Garamond/';
 			$font_file_name = 'EBGaramond-Italic-';
 			return plugins_url( $font_folder . $font_file_name . $lower_subset . '.woff2', __FILE__ );
 	}
 
-	return false;
+	$filepath = $font_folder . $font_file_name . $lower_subset . '.woff2';
+	if ( ! file_exists( __DIR__ . '/' . $filepath ) ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			trigger_error( sprintf( 'Requested font file %s does not exist.', esc_html( $filepath ) ), E_USER_WARNING );
+		}
+		return false;
+	}
+
+	return plugins_url( $filepath, __FILE__ );
 }

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -146,7 +146,31 @@ function get_font_url( $font, $subset ) {
 		case 'eb garamond italic':
 			$font_folder = 'EB-Garamond/';
 			$font_file_name = 'EBGaramond-Italic-';
-			return plugins_url( $font_folder . $font_file_name . $lower_subset . '.woff2', __FILE__ );
+			break;
+		case 'ibm plex mono extralight':
+			$font_folder = 'IBMPlexMono/';
+			$font_file_name = 'IBMPlexMono-ExtraLight-';
+			break;
+		case 'ibm plex mono extralight italic':
+			$font_folder = 'IBMPlexMono/';
+			$font_file_name = 'IBMPlexMono-ExtraLightItalic-';
+			break;
+		case 'ibm plex mono':
+			$font_folder = 'IBMPlexMono/';
+			$font_file_name = 'IBMPlexMono-Regular-';
+			break;
+		case 'ibm plex mono italic':
+			$font_folder = 'IBMPlexMono/';
+			$font_file_name = 'IBMPlexMono-Italic-';
+			break;
+		case 'ibm plex mono bold':
+			$font_folder = 'IBMPlexMono/';
+			$font_file_name = 'IBMPlexMono-Bold-';
+			break;
+		case 'ibm plex mono bold italic':
+			$font_folder = 'IBMPlexMono/';
+			$font_file_name = 'IBMPlexMono-BoldItalic-';
+			break;
 	}
 
 	$filepath = $font_folder . $font_file_name . $lower_subset . '.woff2';

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -54,9 +54,15 @@ function relative_to_absolute_urls( $editor_settings ) {
 /**
  * Specify a font to be preloaded.
  *
- * @param string $fonts The font(s) to preload.
- * @param string $subsets The subset(s) to preload.
- * @return bool If the font will be preloaded.
+ * This adds the font name (optionally with style and weight) and subset to the
+ * preload list. No validation is done at this point, so this won't tell you if
+ * the font or subset is invalid. That check is done in `maybe_preload_font` by
+ * the `get_font_url` call.
+ *
+ * @param string $fonts   The font(s) to preload, comma-separated.
+ * @param string $subsets The subset(s) to preload, comma-separated.
+ *
+ * @return bool If the font has been added to the preload list.
  */
 function preload_font( $fonts, $subsets ) {
 	$style = wp_styles()->query( 'wporg-global-fonts' );

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -68,11 +68,13 @@ function preload_font( $fonts, $subsets ) {
 	$subsets = explode( ',', $subsets );
 
 	$preload = $style->extra['preload'] ?? [];
-	$new_preload = [
-		'fonts' => array_unique( $fonts ),
-		'subsets' => array_unique( $subsets ),
-	];
-	$preload = array_merge_recursive( $preload, $new_preload );
+
+	foreach ( $fonts as $font ) {
+		$new_preload = [
+			$font => $subsets,
+		];
+		$preload = array_merge_recursive( $preload, $new_preload );
+	}
 
 	wp_style_add_data( 'wporg-global-fonts', 'preload', $preload );
 
@@ -89,24 +91,29 @@ function maybe_preload_font( $preload ) {
 		return $preload;
 	}
 
-	$combined_fonts_subsets = array_combine( (array) $style->extra['preload']['fonts'], (array) $style->extra['preload']['subsets'] );
-
-	foreach ( $combined_fonts_subsets as $font => $subset ) {
-		if ( empty( $font ) || empty( $subset ) ) {
+	foreach ( (array) $style->extra['preload'] as $font => $subsets ) {
+		if ( empty( $font ) || empty( $subsets ) ) {
 			continue;
 		}
 
-		$font_url = get_font_url( $font, $subset );
-		if ( ! $font_url ) {
-			continue;
-		}
+		$subsets = array_unique( $subsets );
+		foreach ( $subsets as $subset ) {
+			if ( empty( $subset ) ) {
+				continue;
+			}
 
-		$preload[] = [
-			'href'        => $font_url,
-			'as'          => 'font',
-			'crossorigin' => 'crossorigin',
-			'type'        => 'font/woff2',
-		];
+			$font_url = get_font_url( $font, $subset );
+			if ( ! $font_url ) {
+				continue;
+			}
+
+			$preload[] = [
+				'href'        => $font_url,
+				'as'          => 'font',
+				'crossorigin' => 'crossorigin',
+				'type'        => 'font/woff2',
+			];
+		}
 	}
 
 	return $preload;

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -87,19 +87,17 @@ function maybe_preload_font( $preload ) {
 	}
 
 	foreach ( (array) $style->extra['preload'] as $font_face ) {
-		$font_urls = get_font_urls( $font_face );
-		if ( ! $font_urls ) {
+		$font_url = get_font_url( $font_face );
+		if ( ! $font_url ) {
 			continue;
 		}
 
-		foreach ( $font_urls as $font_url ) {
-			$preload[] = [
-				'href'        => $font_url,
-				'as'          => 'font',
-				'crossorigin' => 'crossorigin',
-				'type'        => 'font/woff2',
-			];
-		}
+		$preload[] = [
+			'href'        => $font_url,
+			'as'          => 'font',
+			'crossorigin' => 'crossorigin',
+			'type'        => 'font/woff2',
+		];
 	}
 
 	return $preload;
@@ -108,36 +106,57 @@ function maybe_preload_font( $preload ) {
 /**
  * Return the details about a specific font face.
  */
-function get_font_urls( $font ) {
+function get_font_url( $font ) {
 	switch ( strtolower( $font ) ) {
+		// inter
 		case 'inter arrows':
-			return [ plugins_url( 'Inter/Inter-arrows.woff2', __FILE__ ) ];
+			return plugins_url( 'Inter/Inter-arrows.woff2', __FILE__ );
 		case 'inter cyrillic':
-			return [ plugins_url( 'Inter/Inter-cyrillic.woff2', __FILE__ ), plugins_url( 'Inter/Inter-cyrillic-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'Inter/Inter-cyrillic.woff2', __FILE__ );
+		case 'inter cyrillic-ext':
+			return plugins_url( 'Inter/Inter-cyrillic-ext.woff2', __FILE__ );
 		case 'inter greek':
-			return [ plugins_url( 'Inter/Inter-greek.woff2', __FILE__ ), plugins_url( 'Inter/Inter-greek-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'Inter/Inter-greek.woff2', __FILE__ );
+		case 'inter greek-ext':
+			return plugins_url( 'Inter/Inter-greek-ext.woff2', __FILE__ );
 		case 'inter latin':
-			return [ plugins_url( 'Inter/Inter-latin.woff2', __FILE__ ), plugins_url( 'Inter/Inter-latin-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'Inter/Inter-latin.woff2', __FILE__ );
+		case 'inter latin-ext':
+			return plugins_url( 'Inter/Inter-latin-ext.woff2', __FILE__ );
 		case 'inter vietnamese':
-			return [ plugins_url( 'Inter/Inter-vietnamese.woff2', __FILE__ ) ];
+			return plugins_url( 'Inter/Inter-vietnamese.woff2', __FILE__ );
+		// eb garamond
 		case 'eb garamond arrows':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-arrows.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-arrows.woff2', __FILE__ );
 		case 'eb garamond cyrillic':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-cyrillic.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-cyrillic-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-cyrillic.woff2', __FILE__ );
+		case 'eb garamond cyrillic-ext':
+			return plugins_url( 'EB-Garamond/EBGaramond-cyrillic-ext.woff2', __FILE__ );
 		case 'eb garamond greek':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-greek.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-greek-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-greek.woff2', __FILE__ );
+		case 'eb garamond greek-ext':
+			return plugins_url( 'EB-Garamond/EBGaramond-greek-ext.woff2', __FILE__ );
 		case 'eb garamond latin':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-latin.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-latin-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-latin.woff2', __FILE__ );
+		case 'eb garamond latin-ext':
+			return plugins_url( 'EB-Garamond/EBGaramond-latin-ext.woff2', __FILE__ );
 		case 'eb garamond vietnamese':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-vietnamese.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-vietnamese.woff2', __FILE__ );
+		// // eb garamond italic
 		case 'eb garamond cyrillic italic':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-Italic-cyrillic.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-Italic-cyrillic-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-Italic-cyrillic.woff2', __FILE__ );
+		case 'eb garamond cyrillic-ext italic':
+			return plugins_url( 'EB-Garamond/EBGaramond-Italic-cyrillic-ext.woff2', __FILE__ );
 		case 'eb garamond greek italic':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-Italic-greek.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-Italic-greek-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-Italic-greek.woff2', __FILE__ );
+		case 'eb garamond greek-ext italic':
+			return plugins_url( 'EB-Garamond/EBGaramond-Italic-greek-ext.woff2', __FILE__ );
 		case 'eb garamond latin italic':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-Italic-latin.woff2', __FILE__ ), plugins_url( 'EB-Garamond/EBGaramond-Italic-latin-ext.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-Italic-latin.woff2', __FILE__ );
+		case 'eb garamond latin-ext italic':
+			return plugins_url( 'EB-Garamond/EBGaramond-Italic-latin-ext.woff2', __FILE__ );
 		case 'eb garamond vietnamese italic':
-			return [ plugins_url( 'EB-Garamond/EBGaramond-Italic-vietnamese.woff2', __FILE__ ) ];
+			return plugins_url( 'EB-Garamond/EBGaramond-Italic-vietnamese.woff2', __FILE__ );
 	}
 
 	return false;


### PR DESCRIPTION
Fixes #295  

On [wp.org](https://wordpress.org/), only necessary font subsets are preloaded. (`Inter-latin.woff2`, `EBGaramond-latin.woff2`, `EBGaramond-Italic-latin.woff2`)
<img width="817" alt="image" src="https://user-images.githubusercontent.com/18050944/197022756-bf2359f1-161f-4205-aeb8-c3a57b3a9839.png">
