### PR TITLE
Preload required font subsets for rosetta sites

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -338,8 +338,10 @@ function render_global_header( $attributes = array() ) {
 
 	// Preload the menu font.
 	if ( is_callable( 'global_fonts_preload' ) ) {
-		if ( ! is_rosetta_site() ) {
-			global_fonts_preload( 'Inter', 'latin' );
+		/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext.  */
+		$subsets = explode( ',', _x( 'Latin', 'Global menu font subsets, comma separated', 'wporg' ) );
+		foreach ( $subsets as $subset ) {
+			global_fonts_preload( 'Inter', $subset );
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -339,10 +339,8 @@ function render_global_header( $attributes = array() ) {
 	// Preload the menu font.
 	if ( is_callable( 'global_fonts_preload' ) ) {
 		/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext.  */
-		$subsets = explode( ',', _x( 'latin', 'Global menu font subsets, comma separated', 'wporg' ) );
-		foreach ( $subsets as $subset ) {
-			global_fonts_preload( 'Inter', $subset );
-		}
+		$subsets = _x( 'latin', 'Global menu font subsets, comma separated', 'wporg' );
+		global_fonts_preload( 'Inter', $subsets );
 	}
 
 	// The mobile Get WordPress button needs to be in both menus.

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -339,7 +339,7 @@ function render_global_header( $attributes = array() ) {
 	// Preload the menu font.
 	if ( is_callable( 'global_fonts_preload' ) ) {
 		/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext.  */
-		$subsets = explode( ',', _x( 'Latin', 'Global menu font subsets, comma separated', 'wporg' ) );
+		$subsets = explode( ',', _x( 'latin', 'Global menu font subsets, comma separated', 'wporg' ) );
 		foreach ( $subsets as $subset ) {
 			global_fonts_preload( 'Inter', $subset );
 		}


### PR DESCRIPTION
Fixes #293 

**Note**: This PR should either merge to `fix/prevent-preloading-latin-ext-unless-necessary`, or to `trunk` after that one has been merged to trunk.