### PR TITLE
Header: Update spacing around logo, menus, buttons

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -52,7 +52,7 @@ html {
 	--wp--custom--margin--vertical: 30px;
 	--wp--custom--margin--horizontal: 30px;
 	--wp--custom--form--padding: calc(0.5 * var(--wp--custom--margin--horizontal));
-	--wp--style--block-gap: 24px;
+	--wp--style--block-gap: 20px;
 
 	/* This is a subset of the colors provided by `theme.json`, set here to prevent conflicts across other block themes. */
 	--wp--preset--color--charcoal-1: #1e1e1e;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -53,7 +53,7 @@ html {
 		& .wp-block-navigation__responsive-container-open {
 
 			/* Magic numbers to center the 24px icon in 60px height. */
-			padding: 18px var(--wp--style--block-gap) 18px;
+			padding: 18px 16px 18px;
 
 			@media (--tablet) {
 				padding-top: 37px;
@@ -83,9 +83,9 @@ html {
 		right: 0;
 		top: calc(-1 * var(--wp-global-header-height));
 		padding-top: 18px; /* Magic numbers to center the 24px icon in 60px height. */
-		padding-right: calc(var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
+		padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width));
 		padding-bottom: 18px; /* Magic numbers to center the 24px icon in 60px height. */
-		padding-left: var(--wp--style--block-gap);
+		padding-left: 16px;
 		background-color: var(--wp-global-header--background-color--hover);
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -12,9 +12,10 @@
 		flex-basis: 100%;
 		flex-shrink: 1;
 		text-align: left;
-		min-width: 73px;
+
+		/* Subtract the left padding from the first menu item. */
+		min-width: calc(80px - var(--wp--style--block-gap) / 2);
 		padding: 0;
-		padding-left: calc(var(--wp--style--block-gap) / 2);
 
 		@media (--tablet) {
 			flex-basis: auto;
@@ -26,7 +27,7 @@
 		display: inline-flex;
 		box-sizing: content-box;
 		height: 27px;
-		padding: 16px calc(var(--wp--style--block-gap) / 2);
+		padding: 16px var(--wp--style--block-gap);
 		color: var(--wp-global-header--text-color);
 
 		@media (--tablet) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -17,7 +17,7 @@
 
 	& .wp-block-navigation__responsive-container-open {
 		display: flex; /* Gutenberg has the button hardcoded to hide at 600px, but we need it to wait until `--tablet`. */
-		padding-right: calc(var(--wp--style--block-gap) + var(--wp--custom--alignment--scroll-bar-width));
+		padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width));
 
 		@media (--tablet) {
 			display: none;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -55,8 +55,8 @@
 	}
 
 	& .wp-block-navigation__responsive-container-close {
-		right: calc(73px + var(--wp--custom--alignment--scroll-bar-width));
-		padding-right: var(--wp--style--block-gap);
+		right: calc(56px + var(--wp--custom--alignment--scroll-bar-width));
+		padding-right: 16px;
 		background-color: var(--wp-global-header--background-color--hover);
 
 		@media (--tablet) {


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-mu-plugins/issues/301 — Adjust the spacing in the header to match the latest design iteration.

This PR only changes the header, I'll have another PR for the parent theme to adjust the subpage navigation bar (and then another PR for the child themes that re-implement it… If this changes again, we should figure out a better way of inheriting these styles).

**Screenshots**

|  | WordPress.org | Page with subnav |
|---|------|-------|
| 480px | ![black-480](https://user-images.githubusercontent.com/541093/202586024-a78525e8-204a-456c-8fc4-b64e4dcc9938.png) | ![white-480](https://user-images.githubusercontent.com/541093/202586034-59bf134b-a018-4ac6-9264-7ca12084d6e5.png) |
| 600px | ![black-600](https://user-images.githubusercontent.com/541093/202586026-b1817f12-64d5-4d11-9606-9951722aa499.png) | ![white-600](https://user-images.githubusercontent.com/541093/202586035-1f6e2746-e248-4ec1-bf17-aca8c1579dda.png) |
| 1200px | ![black-1200-tall](https://user-images.githubusercontent.com/541093/202586030-81c276a6-3959-4424-9baf-ee38ec032d05.png) | ![white-es-1200-tall](https://user-images.githubusercontent.com/541093/202586037-3c229257-5dd8-4022-a067-e417d51b8ffb.png) |
