### PR TITLE
Blocks: Add the "Site Breadcrumbs" block from showcase

### DIFF
--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Block Name: Site Breadcrumbs
+ * Description: Display breadcrumbs of the site.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\MU_Plugins\Site_Breadcrumbs;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		__DIR__ . '/build',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_block',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render_block( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$breadcrumbs = array(
+		array(
+			'url'   => get_site_url(),
+			'title' => get_bloginfo( 'name', 'display' ),
+		),
+	);
+
+	$title = get_the_title();
+
+	if ( is_home() ) {
+		$title = esc_html__( 'Archives', 'wporg' );
+	} elseif ( is_search() ) {
+		$title = esc_html__( 'Results', 'wporg' );
+	} elseif ( is_category() ) {
+		$title = esc_html__( 'Categories', 'wporg' );
+	} elseif ( is_tag() ) {
+		$title = esc_html__( 'Tags', 'wporg' );
+	}
+
+	$breadcrumbs[] = array(
+		'url'   => false,
+		'title' => $title,
+	);
+
+	/**
+	 * Filters the breadcrumbs used on a given page.
+	 *
+	 * @param array    $breadcrumbs An array of breadcrumb links, in format [url => '', title => ''].
+	 * @param array    $attributes  Block attributes.
+	 * @param WP_Block $block       Block instance.
+	 */
+	$breadcrumbs = apply_filters( 'wporg_block_site_breadcrumbs', $breadcrumbs, $attributes, $block );
+
+	$content = '';
+	foreach ( $breadcrumbs as $i => $crumb ) {
+		// We can assume that the item without a URL is the current page.
+		if ( ! $crumb['url'] ) {
+			$content .= sprintf( '<span class="is-current-page">%s</span>', esc_html( $crumb['title'] ) );
+		} else {
+			$content .= sprintf( '<span><a href="%s">%s</a></span>', esc_url( $crumb['url'] ), esc_html( $crumb['title'] ) );
+		}
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf( '<div %s>%s</div>', $wrapper_attributes, $content );
+}

--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -36,10 +36,6 @@ function init() {
  * @return string Returns the block markup.
  */
 function render_block( $attributes, $content, $block ) {
-	if ( ! isset( $block->context['postId'] ) ) {
-		return '';
-	}
-
 	$breadcrumbs = array(
 		array(
 			'url'   => get_site_url(),

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -12,6 +12,7 @@
 	}
 
 	& > span:not(:first-child) {
+
 		/* This ensures that the square separator is reliably centered. */
 		display: flex;
 		align-items: center;

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -1,0 +1,31 @@
+.wp-block-wporg-site-breadcrumbs {
+	display: flex;
+	align-items: center;
+
+	& a {
+		color: inherit;
+
+		&:hover {
+			opacity: 0.7;
+			text-decoration-line: underline;
+		}
+	}
+
+	& > span:not(:first-child) {
+		/* This ensures that the square separator is reliably centered. */
+		display: flex;
+		align-items: center;
+		margin-top: 0;
+
+		&::before {
+			content: "/";
+			display: inline-block;
+			font-weight: 400;
+			margin: 0 0.5rem;
+		}
+	}
+
+	& .is-current-page {
+		font-weight: 700;
+	}
+}

--- a/mu-plugins/blocks/site-breadcrumbs/src/block.json
+++ b/mu-plugins/blocks/site-breadcrumbs/src/block.json
@@ -26,7 +26,6 @@
 		},
 		"multiple": false
 	},
-	"usesContext": [ "postId" ],
 	"editorScript": "file:./index.js",
 	"style": "file:./style.css"
 }

--- a/mu-plugins/blocks/site-breadcrumbs/src/block.json
+++ b/mu-plugins/blocks/site-breadcrumbs/src/block.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/site-breadcrumbs",
+	"version": "0.1.0",
+	"title": "Site Breadcrumbs",
+	"category": "design",
+	"icon": "",
+	"description": "Display breadcrumbs of the site.",
+	"textdomain": "wporg",
+	"attributes": {},
+	"supports": {
+		"align": true,
+		"html": false,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true
+		},
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"typography": {
+			"fontSize": true
+		},
+		"multiple": false
+	},
+	"usesContext": [ "postId" ],
+	"editorScript": "file:./index.js",
+	"style": "file:./style.css"
+}

--- a/mu-plugins/blocks/site-breadcrumbs/src/index.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/index.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+/**
+ * Add a fake preview for the editor.
+ */
+function Edit() {
+	return (
+		<div { ...useBlockProps() }>
+			<span>
+				<a href="#">Home</a> { /* eslint-disable-line jsx-a11y/anchor-is-valid */ }
+			</span>
+			<span className="is-current-page">Current Page</span>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/blocks/horizontal-slider/horizontal-slider.php';
 require_once __DIR__ . '/blocks/language-suggest/language-suggest.php';
 require_once __DIR__ . '/blocks/latest-news/latest-news.php';
 require_once __DIR__ . '/blocks/screenshot-preview/block.php';
+require_once __DIR__ . '/blocks/site-breadcrumbs/index.php';
 require_once __DIR__ . '/global-fonts/index.php';
 require_once __DIR__ . '/plugin-tweaks/index.php';
 require_once __DIR__ . '/rest-api/index.php';


### PR DESCRIPTION
Fixes #304 — This copies over the Site Breadcrumbs block from the showcase theme (https://github.com/WordPress/wporg-showcase-2022/pull/45) for use on all sites.

Editor view has a simple placeholder, just to get an idea of how the settings will apply (color, font, etc)
<img width="848" alt="" src="https://user-images.githubusercontent.com/541093/204399527-f2c549c3-f8e0-4fde-947b-3a7c4601d65c.png">

On the frontend, it looks the same as the current block in showcase.
<img width="660" alt="" src="https://user-images.githubusercontent.com/541093/204399549-8fbf19d0-ac63-485c-9d78-108920469a30.png">

The main difference is the addition of a `wporg_block_site_breadcrumbs` filter. This can be used in individual sites' `functions.php` to render slightly different breadcrumbs as needed, since the exact hierarchy changes in each site (for example, showcase only ever has two levels of breadcrumb, but [docs can have 3](https://github.com/WordPress/wporg-documentation-2022/issues/8))

**To test**

- Try this in combination with the showcase PR https://github.com/WordPress/wporg-showcase-2022/pull/65
- Or try using it in a template/page and make sure the customization options work