### PR TITLE
Add dark black header and footer variation

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -1028,6 +1028,9 @@ function get_container_classes( $color_scheme ) {
 		case 'black-on-white':
 			$classes .= ' has-charcoal-2-color has-white-background-color';
 			break;
+		case 'white-on-dark-black':			
+			$classes .= ' has-white-color has-charcoal-1-background-color';
+			break;
 		case 'white-on-black':
 		default:
 			$classes .= ' has-white-color has-charcoal-2-background-color';

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -308,7 +308,7 @@
 	& .wp-block-navigation__container {
 
 		@media (--tablet) {
-			background: var(--wp-global-header--background-color);
+			background: inherit;
 		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/src/footer/block.json
+++ b/mu-plugins/blocks/global-header-footer/src/footer/block.json
@@ -9,7 +9,12 @@
 		"style": {
 			"type": "string",
 			"default": "white-on-black",
-			"enum": [ "white-on-black", "black-on-white", "white-on-blue" ]
+			"enum": [ 
+				"white-on-black",
+				"white-on-dark-black",
+				"black-on-white",
+				"white-on-blue"
+			]
 		}
 	},
 	"textdomain": "wporg",

--- a/mu-plugins/blocks/global-header-footer/src/footer/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/footer/index.js
@@ -14,7 +14,7 @@ import metadata from './block.json';
 
 const variations = [
 	{ label: __( 'White on charcoal-1', 'wporg' ), value: 'white-on-dark-black' },
-	{ label: __( 'White on charcoal-2 (default)', 'wporg' ), value: 'white-on-black' },		
+	{ label: __( 'White on charcoal-2 (default)', 'wporg' ), value: 'white-on-black' },
 	{ label: __( 'White on blueberry-1', 'wporg' ), value: 'white-on-blue' },
 	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
 ];

--- a/mu-plugins/blocks/global-header-footer/src/footer/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/footer/index.js
@@ -14,7 +14,7 @@ import metadata from './block.json';
 
 const variations = [
 	{ label: __( 'White on black (default)', 'wporg' ), value: 'white-on-black' },
-	{ label: __( 'White on dark black', 'wporg' ), value: 'white-on-black-dark' },
+	{ label: __( 'White on dark black', 'wporg' ), value: 'white-on-dark-black' },
 	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
 	{ label: __( 'White on blue', 'wporg' ), value: 'white-on-blue' },
 ];

--- a/mu-plugins/blocks/global-header-footer/src/footer/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/footer/index.js
@@ -14,6 +14,7 @@ import metadata from './block.json';
 
 const variations = [
 	{ label: __( 'White on black (default)', 'wporg' ), value: 'white-on-black' },
+	{ label: __( 'White on dark black', 'wporg' ), value: 'white-on-black-dark' },
 	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
 	{ label: __( 'White on blue', 'wporg' ), value: 'white-on-blue' },
 ];

--- a/mu-plugins/blocks/global-header-footer/src/footer/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/footer/index.js
@@ -13,10 +13,10 @@ import { useBlockProps } from '@wordpress/block-editor';
 import metadata from './block.json';
 
 const variations = [
-	{ label: __( 'White on black (default)', 'wporg' ), value: 'white-on-black' },
-	{ label: __( 'White on dark black', 'wporg' ), value: 'white-on-dark-black' },
+	{ label: __( 'White on charcoal-1', 'wporg' ), value: 'white-on-dark-black' },
+	{ label: __( 'White on charcoal-2 (default)', 'wporg' ), value: 'white-on-black' },		
+	{ label: __( 'White on blueberry-1', 'wporg' ), value: 'white-on-blue' },
 	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
-	{ label: __( 'White on blue', 'wporg' ), value: 'white-on-blue' },
 ];
 
 const Edit = ( { attributes } ) => (

--- a/mu-plugins/blocks/global-header-footer/src/header/block.json
+++ b/mu-plugins/blocks/global-header-footer/src/header/block.json
@@ -9,7 +9,12 @@
 		"style": {
 			"type": "string",
 			"default": "white-on-black",
-			"enum": [ "white-on-black", "black-on-white", "white-on-blue" ]
+			"enum": [ 
+				"white-on-black",
+				"white-on-dark-black",
+				"black-on-white",
+				"white-on-blue"
+			]
 		}
 	},
 	"textdomain": "wporg",

--- a/mu-plugins/blocks/global-header-footer/src/header/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/header/index.js
@@ -14,7 +14,7 @@ import metadata from './block.json';
 
 const variations = [
 	{ label: __( 'White on charcoal-1', 'wporg' ), value: 'white-on-dark-black' },
-	{ label: __( 'White on charcoal-2 (default)', 'wporg' ), value: 'white-on-black' },		
+	{ label: __( 'White on charcoal-2 (default)', 'wporg' ), value: 'white-on-black' },
 	{ label: __( 'White on blueberry-1', 'wporg' ), value: 'white-on-blue' },
 	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
 ];

--- a/mu-plugins/blocks/global-header-footer/src/header/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/header/index.js
@@ -14,6 +14,7 @@ import metadata from './block.json';
 
 const variations = [
 	{ label: __( 'White on black (default)', 'wporg' ), value: 'white-on-black' },
+	{ label: __( 'White on dark black', 'wporg' ), value: 'white-on-dark-black' },
 	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
 	{ label: __( 'White on blue', 'wporg' ), value: 'white-on-blue' },
 ];

--- a/mu-plugins/blocks/global-header-footer/src/header/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/header/index.js
@@ -13,10 +13,10 @@ import { useBlockProps } from '@wordpress/block-editor';
 import metadata from './block.json';
 
 const variations = [
-	{ label: __( 'White on black (default)', 'wporg' ), value: 'white-on-black' },
-	{ label: __( 'White on dark black', 'wporg' ), value: 'white-on-dark-black' },
+	{ label: __( 'White on charcoal-1', 'wporg' ), value: 'white-on-dark-black' },
+	{ label: __( 'White on charcoal-2 (default)', 'wporg' ), value: 'white-on-black' },		
+	{ label: __( 'White on blueberry-1', 'wporg' ), value: 'white-on-blue' },
 	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
-	{ label: __( 'White on blue', 'wporg' ), value: 'white-on-blue' },
 ];
 
 const Edit = ( { attributes } ) => (


### PR DESCRIPTION
Currently, the header and footer blocks don't support the charcoal-1 color. This variation is needed for the Enterprise landing page.

To test:
- Open a page in the editor
- Add or edit the 'Global Header' and 'Global Footer' blocks
- Set the variation to 'White on dark black'
- Verify the header/footer blocks change color in the editor.
- Preview and verify the blocks change color on the front end.

<img width="302" alt="Screenshot 2022-12-08 at 12 44 33 PM" src="https://user-images.githubusercontent.com/7133400/206525480-563ee8bd-b970-4bfc-861b-58c9e9da88b7.png">
<img width="1757" alt="Screenshot 2022-12-08 at 12 39 38 PM" src="https://user-images.githubusercontent.com/7133400/206525483-626338df-351a-47a9-8c78-a954517288ec.png">

