### PR TITLE
Truncate title without breaking words

### DIFF
--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -45,6 +45,12 @@ function render_block( $attributes, $content, $block ) {
 
 	$title = get_the_title();
 
+	// truncate title without breaking words for mobile devices
+	if( wp_is_mobile() && strlen( $title ) > 30) {
+		$title = explode( "\n", wordwrap( $title , 30));
+		$title = $title[0] . ' ...';
+	}
+
 	if ( is_home() ) {
 		$title = esc_html__( 'Archives', 'wporg' );
 	} elseif ( is_search() ) {


### PR DESCRIPTION
This PR tries to fix the broken breadcrumb appearing on mobile devices.
Related: https://github.com/WordPress/wporg-mu-plugins/pull/309, https://github.com/WordPress/wporg-showcase-2022/pull/96

## Screenshots
![Screen Shot 2022-12-09 at 11 08 11 AM](https://user-images.githubusercontent.com/18050944/206615486-8ecdbcf0-4ddc-4916-909c-880bdd398825.png)
