### PR TITLE
Block: Site Breadcrumbs: Update the default link color.

### DIFF
--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -3,10 +3,9 @@
 	align-items: center;
 
 	& a {
-		color: inherit;
+		color: var(--wp--preset--color--charcoal-1);
 
 		&:hover {
-			opacity: 0.7;
 			text-decoration-line: underline;
 		}
 	}


### PR DESCRIPTION
Fixes #312 — This removes the opacity on hover, and sets up the charcoal-1 color as the default link color. If a link color is set on a container (like in Documentation), that overrides the color set in the CSS here (as expected).

| Default | Hover |
|-----|----|
| <img width="347" alt="blue-default" src="https://user-images.githubusercontent.com/541093/207416682-ae9ef230-4ec5-449c-a9f6-47073f08f265.png"> | <img width="350" alt="blue-hover" src="https://user-images.githubusercontent.com/541093/207416685-cbdca9ab-1699-4e4a-b7ae-673f05eec8ff.png"> |
| <img width="386" alt="white-default" src="https://user-images.githubusercontent.com/541093/207416687-af1d85ad-dd84-41a7-8246-57b5a9394776.png"> | <img width="411" alt="white-hover" src="https://user-images.githubusercontent.com/541093/207416689-86830d5e-a085-47ae-8815-1fe78ed67e1d.png"> |
