### PR TITLE
Add some stream tweaks

### DIFF
--- a/mu-plugins/plugin-tweaks/index.php
+++ b/mu-plugins/plugin-tweaks/index.php
@@ -10,3 +10,4 @@ namespace WordPressdotorg\MU_Plugins\Plugin_Tweaks;
 defined( 'WPINC' ) || die();
 
 require_once __DIR__ . '/wporg-internal-notes.php';
+require_once __DIR__ . '/stream.php';

--- a/mu-plugins/plugin-tweaks/stream.php
+++ b/mu-plugins/plugin-tweaks/stream.php
@@ -21,6 +21,7 @@ add_filter( 'wp_stream_is_record_excluded', __NAMESPACE__ . '\exclude_profile_up
  */
 function include_user_name_in_creation_log( $record ) {
 	if (
+		'users' === $record['connector'] &&
 		'users' === $record['context'] &&
 		'created' === $record['action']
 	) {
@@ -42,15 +43,14 @@ function include_user_name_in_creation_log( $record ) {
  */
 function exclude_profile_updates_as_part_of_user_creation( $exclude, $record ) {
 	if (
-		! $exclude &&
+		// Users are not logged in as part of registration.
+		! is_user_logged_in() &&
 		doing_action( 'profile_update' ) &&
 		defined( 'WPORG_LOGIN_REGISTER_BLOGID' ) &&
-		WPORG_LOGIN_REGISTER_BLOGID == $record['blog_id'] &&
+		WPORG_LOGIN_REGISTER_BLOGID === get_current_blog_id() &&
+		'users' === $record['connector'] &&
 		'profiles' === $record['context'] &&
-		'updated' === $record['action'] &&
-		// This is a sanity check, the user is stored in 'object_id', and 'user_id' is the user updating the data.
-		// If a user_id is set, this was not during a user registration.
-		! $record['user_id']
+		'updated' === $record['action']
 	) {
 		$exclude = true;
 	}

--- a/mu-plugins/plugin-tweaks/stream.php
+++ b/mu-plugins/plugin-tweaks/stream.php
@@ -9,14 +9,14 @@ defined( 'WPINC' ) || die();
  */
 add_filter( 'wp_stream_log_data', __NAMESPACE__ . '\include_user_name_in_creation_log' );
 add_filter( 'wp_stream_is_record_excluded', __NAMESPACE__ . '\exclude_profile_updates_as_part_of_user_creation', 10, 2 );
-add_filter( 'bbp_set_user_role', __NAMESPACE__ . '\bbp_set_user_role', 10, 2 );
+add_filter( 'bbp_set_user_role', __NAMESPACE__ . '\bbp_set_user_role', 10, 3 );
 
 /**
  * Log the bbPress forum role being changed.
  */
-function bbp_set_user_role( $new_role, $user_id ) {
+function bbp_set_user_role( $new_role, $user_id, $user ) {
 	if ( $new_role ) {
-		log( 'Forum role set to %s', compact( 'new_role' ), $user_id, 'bbpress', 'role', 'updated' );
+		log( "%s's forum role set to %s", [ $user->user_login, $new_role ], $user_id, 'bbpress', 'role', 'updated' );
 	}
 
 	return $new_role;

--- a/mu-plugins/plugin-tweaks/stream.php
+++ b/mu-plugins/plugin-tweaks/stream.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WordPressdotorg\MU_Plugins\Plugin_Tweaks\Stream;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_filter( 'wp_stream_record_array', __NAMESPACE__ . '\include_user_name_in_creation_log' );
+add_filter( 'wp_stream_is_record_excluded', __NAMESPACE__ . '\exclude_profile_updates_as_part_of_user_creation', 10, 2 );
+
+/**
+ * Stream by default logs new user registrations as 'New user registration' which doesn't come up in search-by-username.
+ *
+ * Suffix the message with the user_login.
+ *
+ * @param array $record
+ *
+ * @return array
+ */
+function include_user_name_in_creation_log( $record ) {
+	if (
+		'users' === $record['context'] &&
+		'created' === $record['action']
+	) {
+		$user = get_user_by( 'id', $record['object_id'] );
+		if ( $user && ! str_contains( $record['summary'], $user->user_login ) ) {
+			$record['summary'] .= ': ' . $user->user_login;
+		}
+	}
+
+	return $record;
+}
+
+/**
+ * Stream records 'profile updated' events during user registration, as we call `wp_update_user(). Avoid these.
+ *
+ * @param bool $exclude If this record should be excluded.
+ * @param array $record The record to insert.
+ * @return bool
+ */
+function exclude_profile_updates_as_part_of_user_creation( $exclude, $record ) {
+	if (
+		! $exclude &&
+		doing_action( 'profile_update' ) &&
+		defined( 'WPORG_LOGIN_REGISTER_BLOGID' ) &&
+		WPORG_LOGIN_REGISTER_BLOGID == $record['blog_id'] &&
+		'profiles' === $record['context'] &&
+		'updated' === $record['action'] &&
+		// This is a sanity check, the user is stored in 'object_id', and 'user_id' is the user updating the data.
+		// If a user_id is set, this was not during a user registration.
+		! $record['user_id']
+	) {
+		$exclude = true;
+	}
+
+	return $exclude;
+}

--- a/mu-plugins/plugin-tweaks/stream.php
+++ b/mu-plugins/plugin-tweaks/stream.php
@@ -9,18 +9,7 @@ defined( 'WPINC' ) || die();
  */
 add_filter( 'wp_stream_log_data', __NAMESPACE__ . '\include_user_name_in_creation_log' );
 add_filter( 'wp_stream_is_record_excluded', __NAMESPACE__ . '\exclude_profile_updates_as_part_of_user_creation', 10, 2 );
-add_filter( 'bbp_set_user_role', __NAMESPACE__ . '\bbp_set_user_role', 10, 3 );
-
-/**
- * Log the bbPress forum role being changed.
- */
-function bbp_set_user_role( $new_role, $user_id, $user ) {
-	if ( $new_role ) {
-		log( "%s's forum role set to %s", [ $user->user_login, $new_role ], $user_id, 'bbpress', 'role', 'updated' );
-	}
-
-	return $new_role;
-}
+add_filter( 'bbp_set_user_role', __NAMESPACE__ . '\log_forum_role_change', 10, 3 );
 
 /**
  * Stream by default logs new user registrations as 'New user registration' which doesn't come up in search-by-username.
@@ -69,6 +58,17 @@ function exclude_profile_updates_as_part_of_user_creation( $exclude, $record ) {
 	}
 
 	return $exclude;
+}
+
+/**
+ * Log the bbPress forum role being changed.
+ */
+function log_forum_role_change( $new_role, $user_id, $user ) {
+	if ( $new_role ) {
+		log( "%s's forum role set to %s", [ $user->user_login, $new_role ], $user_id, 'bbpress', 'role', 'updated' );
+	}
+
+	return $new_role;
 }
 
 /**

--- a/mu-plugins/plugin-tweaks/stream.php
+++ b/mu-plugins/plugin-tweaks/stream.php
@@ -7,7 +7,7 @@ defined( 'WPINC' ) || die();
 /**
  * Actions and filters.
  */
-add_filter( 'wp_stream_record_array', __NAMESPACE__ . '\include_user_name_in_creation_log' );
+add_filter( 'wp_stream_log_data', __NAMESPACE__ . '\include_user_name_in_creation_log' );
 add_filter( 'wp_stream_is_record_excluded', __NAMESPACE__ . '\exclude_profile_updates_as_part_of_user_creation', 10, 2 );
 add_filter( 'bbp_set_user_role', __NAMESPACE__ . '\bbp_set_user_role', 10, 2 );
 
@@ -38,8 +38,9 @@ function include_user_name_in_creation_log( $record ) {
 		'created' === $record['action']
 	) {
 		$user = get_user_by( 'id', $record['object_id'] );
-		if ( $user && ! str_contains( $record['summary'], $user->user_login ) ) {
-			$record['summary'] .= ': ' . $user->user_login;
+		if ( $user && ! str_contains( $record['message'], '%s' ) ) {
+			$record['message'] = 'New user registration: %s';
+			$record['args'] = [ 'user_login' => $user->user_login ];
 		}
 	}
 


### PR DESCRIPTION
This tweaks plugin does two things:
 - Adds the user login to the registration log message, this allows for searching for the username.
 - Skips logging multiple user profile update events as part of a user registration.