### PR TITLE
Header: Add alerts banner

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -734,6 +734,23 @@ function get_download_url() {
 }
 
 /**
+ * Render a banner that other plugins can add alerts to.
+ */
+function render_header_alert_banner() {
+	$markup = '';
+	$alerts = apply_filters( 'wporg_global_header_alert_markup', '' );
+
+	if ( $alerts ) {
+		$markup = sprintf(
+			'<div class="global-header__alert-banner">%s</div>',
+			$alerts
+		);
+	}
+
+	return $markup;
+}
+
+/**
  * Render the global footer via a REST request.
  *
  * @return string

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\MU_Plugins\Global_Header_Footer\Header;
 
-use function WordPressdotorg\MU_Plugins\Global_Header_Footer\{ get_home_url, get_download_url, get_container_classes };
+use function WordPressdotorg\MU_Plugins\Global_Header_Footer\{ get_home_url, get_download_url, get_container_classes, render_header_alert_banner };
 
 defined( 'WPINC' ) || die();
 
@@ -123,3 +123,5 @@ function recursive_menu( $menu_item, $top_level = true ) {
 		</a>
 	</div> <!-- /wp:group -->
 </header> <!-- /wp:group -->
+
+<?php echo wp_kses_post( render_header_alert_banner() ); ?>

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -40,6 +40,7 @@ html {
  */
 
 .global-header,
+.global-header__alert-banner,
 .global-footer,
 #wpadminbar {
 	--wp--preset--font-family--eb-garamond: "EB Garamond", serif;
@@ -110,6 +111,7 @@ html {
 }
 
 .wp-block-group.global-header,
+.global-header__alert-banner,
 .wp-block-group.global-footer {
 	--active-menu-item-border-height: 4px;
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -90,6 +90,39 @@ html {
 	}
 }
 
+.global-header__alert-banner {
+	--wp-global-header--link-color: #3e58e1;
+
+	background-color: #eff2ff;
+	color: #1e1e1e;
+	font-size: 12px;
+	line-height: 1.2;
+	text-align: center;
+	margin: 0;
+	padding: 10px 20px;
+
+	& p {
+		color: inherit; /* Override some Classic themes. */
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	& a:hover,
+	& a:focus {
+
+		/* !important is needed because the build process wraps some of the selectors in `_common.pcss` in an
+		 * `:is()` pseudo-class, which increases their specificity.
+		 */
+		color: var(--wp-global-header--link-color) !important;
+	}
+}
+
 /*
  * Gutenberg Patches
  *

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -94,7 +94,7 @@ html {
 	--wp-global-header--link-color: #3e58e1;
 
 	background-color: #eff2ff;
-	color: #1e1e1e;
+	color: var(--wp--preset--color--charcoal-1);
 	font-size: 12px;
 	line-height: 1.2;
 	text-align: center;


### PR DESCRIPTION
This adds a banner under the header for any messages that need to be presented to the user. For example, https://github.com/WordPress/wporg-two-factor/ will remove capabilities from Committers who haven't enabled 2FA, and needs to inform them why that's been done and how they can enable it.

You can test with something like:

```php
add_filter( 'wporg_global_header_alert_markup', function() {
	return '<p>Your account requires two-factor authentication, which adds an extra layer of protection against hackers. You cannot make any changes to this site until you <a href="#">enable it</a> </p>.';
} );
```

<hr />

![Screenshot 2022-12-20 at 9 30 20 AM](https://user-images.githubusercontent.com/484068/208729381-fa2c75da-c739-4a33-8f86-4785f7be3448.png)
<hr />

![Screenshot 2022-12-20 at 9 31 17 AM](https://user-images.githubusercontent.com/484068/208729515-d63b4abc-d145-4d27-8c5e-418e81b9ba6f.png)
<hr />

![Screenshot 2022-12-20 at 9 31 47 AM](https://user-images.githubusercontent.com/484068/208729593-cb0b6f16-472c-47d8-9eb9-a34cf8f6359f.png)
<hr />

![Screenshot 2022-12-20 at 9 32 25 AM](https://user-images.githubusercontent.com/484068/208729721-288d2be0-d187-48bc-89ee-866827bbdcf6.png)
