### PR TITLE
Prompt to reset the Meetup API authentication tokens, as we can't do it automatically.

### DIFF
--- a/mu-plugins/utilities/class-meetup-client.php
+++ b/mu-plugins/utilities/class-meetup-client.php
@@ -49,6 +49,9 @@ class Meetup_Client extends API_Client {
 	 * }
 	 */
 	public function __construct( array $settings = array() ) {
+		// Define the OAuth client first, such that it can be used in the parent constructor callbacks.
+		$this->oauth_client = new Meetup_OAuth2_Client;
+
 		parent::__construct( array(
 			/*
 			 * Response codes that should break the request loop.
@@ -88,8 +91,6 @@ class Meetup_Client extends API_Client {
 
 		add_action( 'api_client_tenacious_remote_request_attempt', array( $this, 'maybe_reset_oauth_token' ) );
 		add_action( 'api_client_handle_error_response', array( $this, 'maybe_reset_oauth_token' ) );
-
-		$this->oauth_client = new Meetup_OAuth2_Client;
 
 		if ( ! empty( $this->oauth_client->error->get_error_messages() ) ) {
 			$this->error = $this->merge_errors( $this->error, $this->oauth_client->error );


### PR DESCRIPTION
At some point in the past while debugging a Meetup API issue, I was forced to change how the authentication reset process works, I'm unsure what the issue was, but it likely pre-dated the files being canonicalised here.

Recently (likely after the meetup.com password was changed) the events api ceased to import meetup events, throwing the following warning:
```
E_USER_WARNING:
   Official_WordPress_Events::handle_error_response error for [make.wordpress.org](http://make.wordpress.org/):
   HTTP Code: 400 Message: Bad Request
   Body: {"error_description":"Unknown or previously used refresh_token","error":"invalid_grant"}
```

It seems like running the request with these changes, and re-authenticating the oAuth applications has restored the meetup.com ingestion.

The changes in this PR have been sitting in my development environment since ~May 2022, so I don't recall the exact reasoning behind it, other than it was likely to resolve this same error.
It looks like the main thing is that it attempts to check the `refresh_token` is valid and errors out if not, where as currently it seems to assume that the refresh_token will never be invalid. I think.

_This is a PR for now as I wanted to get the code off my hands and somewhere for others; I haven't fully tested and reviewed these changes to verify it does exactly what I think it does_