### PR TITLE
Allow passing blog id to latest news block.

### DIFF
--- a/mu-plugins/blocks/latest-news/latest-news.php
+++ b/mu-plugins/blocks/latest-news/latest-news.php
@@ -33,8 +33,10 @@ function render_block( $attributes ) {
 
 	// Check if we can switch to the News blog.
 	// @todo Prevent switch if Rosetta, Rosetta should use local posts.
-	if ( should_switch_to_blog() && defined( 'WPORG_NEWS_BLOGID' ) ) {
-		switch_to_blog( WPORG_NEWS_BLOGID );
+	if ( should_switch_to_blog() && ( defined( 'WPORG_NEWS_BLOGID' ) || isset( $attributes['blogId'] ) ) ) {
+		// Prefer the attribute blogId over the constant.
+		$blog_id = isset( $attributes['blogId'] ) ? $attributes['blogId'] : WPORG_NEWS_BLOGID;
+		switch_to_blog( $blog_id );
 		$blog_switched = true;
 	}
 

--- a/mu-plugins/blocks/latest-news/latest-news.php
+++ b/mu-plugins/blocks/latest-news/latest-news.php
@@ -33,10 +33,8 @@ function render_block( $attributes ) {
 
 	// Check if we can switch to the News blog.
 	// @todo Prevent switch if Rosetta, Rosetta should use local posts.
-	if ( should_switch_to_blog() && ( defined( 'WPORG_NEWS_BLOGID' ) || isset( $attributes['blogId'] ) ) ) {
-		// Prefer the attribute blogId over the constant.
-		$blog_id = isset( $attributes['blogId'] ) ? $attributes['blogId'] : WPORG_NEWS_BLOGID;
-		switch_to_blog( $blog_id );
+	if ( should_switch_to_blog() && ( isset( $attributes['blogId'] ) && 0 !== $attributes['blogId'] ) ) {
+		switch_to_blog( (int) $attributes['blogId'] );
 		$blog_switched = true;
 	}
 

--- a/mu-plugins/blocks/latest-news/src/block.json
+++ b/mu-plugins/blocks/latest-news/src/block.json
@@ -12,7 +12,8 @@
 	"style": "file:./style.css",
 	"attributes": {
 		"blogId": {
-			"type": "integer"
+			"type": "integer",
+			"default": 0
 		},
 		"perPage": {
 			"type": "integer",

--- a/mu-plugins/blocks/latest-news/src/block.json
+++ b/mu-plugins/blocks/latest-news/src/block.json
@@ -11,6 +11,9 @@
 	"editorScript": "file:./index.js",
 	"style": "file:./style.css",
 	"attributes": {
+		"blogId": {
+			"type": "integer"
+		},
 		"perPage": {
 			"type": "integer",
 			"default": 3

--- a/mu-plugins/blocks/latest-news/src/edit.js
+++ b/mu-plugins/blocks/latest-news/src/edit.js
@@ -34,6 +34,10 @@ export default function Edit( { attributes, setAttributes, name } ) {
 						label={ __( 'Blog ID', 'wporg' ) }
 						onChange={ onBlogIdChange }
 						value={ blogId }
+						help={ __(
+							'For example, 8 for wordpress.org/news, 719 for developer.wordpress.org/news',
+							'wporg'
+						) }
 					/>
 					<NumberControl
 						label={ __( 'Items To Show', 'wporg' ) }

--- a/mu-plugins/blocks/latest-news/src/edit.js
+++ b/mu-plugins/blocks/latest-news/src/edit.js
@@ -31,7 +31,7 @@ export default function Edit( { attributes, setAttributes, name } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'wporg' ) }>
 					<NumberControl
-						label={ __( 'Blog Id', 'wporg' ) }
+						label={ __( 'Blog ID', 'wporg' ) }
 						onChange={ onBlogIdChange }
 						value={ blogId }
 					/>

--- a/mu-plugins/blocks/latest-news/src/edit.js
+++ b/mu-plugins/blocks/latest-news/src/edit.js
@@ -21,14 +21,20 @@ import ServerSideRender from '@wordpress/server-side-render';
  * @return {WPElement} Element to render.
  */
 export default function Edit( { attributes, setAttributes, name } ) {
-	const { perPage } = attributes;
+	const { blogId, perPage } = attributes;
 
 	const onPerPageChange = ( value ) => setAttributes( { perPage: value * 1 } );
+	const onBlogIdChange = ( value ) => setAttributes( { blogId: Number( value ) } );
 
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'wporg' ) }>
+					<NumberControl
+						label={ __( 'Blog Id', 'wporg' ) }
+						onChange={ onBlogIdChange }
+						value={ blogId }
+					/>
 					<NumberControl
 						label={ __( 'Items To Show', 'wporg' ) }
 						onChange={ onPerPageChange }


### PR DESCRIPTION
For the redesign of developer.wordpress.org, we need to use this block but make requests to the developer news blog and not the news blog.

