### PR TITLE
Add Table of Contents block

### DIFF
--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -6,7 +6,7 @@
  * @package wporg
  */
 
-namespace WordPressdotorg\Theme\Documentation_2022\Dynamic_ToC_Block;
+namespace WordPressdotorg\MU_Plugins\Dynamic_ToC_Block;
 
 add_action( 'init', __NAMESPACE__ . '\init' );
 

--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Block Name: Dynamic Table of Contents
+ * Description: A dynamic list of headings in the current page.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Documentation_2022\Dynamic_ToC_Block;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		__DIR__ . '/build',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	$items = get_headings( get_the_content() );
+	if ( ! $items ) {
+		return '';
+	}
+
+	$content  = '<h2 class="has-charcoal-1-color has-text-color has-inter-font-family has-large-font-size" style="margin-top:0px">';
+	$content .= __( 'In this article', 'wporg' );
+	$content .= '</h2>';
+	$content .= '<ul>';
+
+	$last_item = false;
+
+	foreach ( $items as $item ) {
+		if ( $last_item ) {
+			if ( $last_item < $item['level'] ) {
+				$content .= "\n<ul>\n";
+			} elseif ( $last_item > $item['level'] ) {
+				$content .= "\n</ul></li>\n";
+			} else {
+				$content .= "</li>\n";
+			}
+		}
+
+		$last_item = $item['level'];
+
+		$content .= '<li><a href="#' . esc_attr( $item['id'] ) . '">' . wp_strip_all_tags( $item['title'] ) . '</a>';
+	}
+
+	$content .= "</ul>\n";
+
+	// Use the parsed headings & IDs to inject IDs into the post content.
+	add_filter(
+		'the_content',
+		function( $content ) use ( $items ) {
+			return inject_ids_into_headings( $content, $items );
+		},
+		5 // Run early, before special character handling, so the items match.
+	);
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$content
+	);
+}
+
+/**
+ * Get headings from a content string.
+ *
+ * @param string $content The post content.
+ *
+ * @return array A list of heading objects.
+ */
+function get_headings( $content ) {
+	$tag = 'h(?P<level>[1-4])';
+	preg_match_all( "/(?P<tag><{$tag}(?P<attrs>[^>]*)>)(?P<title>.*?)(<\/{$tag}>)/iJ", $content, $matches, PREG_SET_ORDER );
+
+	foreach ( $matches as $i => $item ) {
+		// Set an ID property to prevent warnings later.
+		$matches[ $i ]['id'] = '';
+
+		// Remove heading if there is no plain text.
+		if ( empty( trim( wp_strip_all_tags( $item['title'] ) ) ) ) {
+			unset( $matches[ $i ] );
+		}
+	}
+
+	if ( count( $matches ) < 2 ) {
+		return array();
+	}
+
+	$reserved_ids = (array) apply_filters(
+		'handbooks_reserved_ids',
+		array(
+			'main',
+			'masthead',
+			'menu-header',
+			'page',
+			'primary',
+			'secondary',
+			'secondary-content',
+			'site-navigation',
+			'wordpress-org',
+			'wp-toolbar',
+			'wpadminbar',
+			'wporg-footer',
+			'wporg-header',
+		)
+	);
+
+	// Generate IDs for the headings.
+	foreach ( $matches as $i => $item ) {
+		$used_ids            = array_filter( wp_list_pluck( $matches, 'id' ) );
+		$matches[ $i ]['id'] = get_id_for_item( $item, array_merge( $reserved_ids, $used_ids ) );
+	}
+
+	return $matches;
+}
+
+/**
+ * Generate an ID for a given HTML element, use the tags `id` attribute if set.
+ *
+ * @param array    $item     A single heading item.
+ * @param string[] $used_ids The list of existing IDs plus reserved IDs.
+ *
+ * @return string A unique ID.
+ */
+function get_id_for_item( $item, $used_ids ) {
+	if ( ! empty( $item['id'] ) ) {
+		return $item['id'];
+	}
+
+	// Check to see if the item already had a non-empty ID, else generate one from the title.
+	if ( preg_match( '/id=(["\'])(?P<id>[^"\']+)\\1/', $item['attrs'], $m ) ) {
+		$id = $m['id'];
+	} else {
+		$id = sanitize_title( $item['title'] );
+	}
+
+	// Append unique suffix if anchor ID isn't unique in the document.
+	$count   = 2;
+	$orig_id = $id;
+	while ( in_array( $id, $used_ids, true ) && $count < 50 ) {
+		$id = $orig_id . '-' . $count;
+		$count++;
+	}
+
+	return $id;
+}
+
+/**
+ * Replace the headings in a content string with headings including the ID attribute.
+ *
+ * @param string $content The post content.
+ * @param array  $items   The headings as parsed from the content, plus unique IDs.
+ */
+function inject_ids_into_headings( $content, $items ) {
+	$matches      = [];
+	$replacements = [];
+
+	foreach ( $items as $item ) {
+		$matches[]   = $item[0];
+		$tag         = 'h' . $item['level'];
+		$id          = $item['id'];
+		$title       = wp_strip_all_tags( $item['title'] );
+		$extra_attrs = $item['attrs'];
+		$class_name  = 'is-toc-heading';
+
+		if ( $extra_attrs ) {
+			// Strip all IDs from the heading attributes (including empty), we'll replace it with one below.
+			$extra_attrs = trim( preg_replace( '/id=(["\'])[^"\']*\\1/i', '', $extra_attrs ) );
+
+			// Extract any classes present, we're adding our own attribute.
+			if ( preg_match( '/class=(["\'])(?P<class>[^"\']+)\\1/i', $extra_attrs, $m ) ) {
+				$extra_attrs = str_replace( $m[0], '', $extra_attrs );
+				$class_name .= ' ' . $m['class'];
+			}
+		}
+
+		$replacements[] = sprintf(
+			'<%1$s id="%2$s" class="%3$s" tabindex="-1" %4$s><a href="#%2$s">%5$s</a></%1$s>',
+			$tag,
+			$id,
+			$class_name,
+			$extra_attrs,
+			$title
+		);
+	}
+
+	if ( $replacements ) {
+		if ( count( array_unique( $matches ) ) !== count( $matches ) ) {
+			foreach ( $matches as $i => $match ) {
+				$content = preg_replace( '/' . preg_quote( $match, '/' ) . '/', $replacements[ $i ], $content, 1 );
+			}
+		} else {
+			$content = str_replace( $matches, $replacements, $content );
+		}
+	}
+
+	return $content;
+}

--- a/mu-plugins/blocks/table-of-contents/postcss/style.pcss
+++ b/mu-plugins/blocks/table-of-contents/postcss/style.pcss
@@ -1,0 +1,53 @@
+@media (min-width: 890px) {
+	/* stylelint-disable selector-id-pattern */
+	#wp--skip-link--target {
+		scroll-margin-top: var(--wp-local-header-offset, 0);
+	}
+
+	.is-toc-heading {
+		scroll-margin-top: var(--wp-local-header-offset, 0);
+	}
+}
+
+.is-toc-heading {
+	& a {
+		--local--icon-size: 24px;
+		display: inline-block;
+		color: inherit;
+		text-decoration: none !important;
+		padding-right: calc(var(--local--icon-size) + 0.1em);
+
+		&::after {
+			content: "";
+			display: inline-block;
+			opacity: 0;
+			margin-right: calc(var(--local--icon-size) -1} - 0.1em);
+			width: calc(var(--local--icon-size) + 0.1em);
+			height: var(--local--icon-size);
+			text-decoration: none !important;
+			vertical-align: baseline;
+
+			/* stylelint-disable-next-line function-url-quotes */
+			background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.083 17.639H8.444a5.194 5.194 0 1 1 0-10.389H10.084v1.5H8.443a3.694 3.694 0 0 0 0 7.389H10.084v1.5ZM13.917 7.25h1.639a5.194 5.194 0 0 1 0 10.39H13.915v-1.5H15.557a3.694 3.694 0 0 0 0-7.39H13.915v-1.5Zm-4.584 6.084h5.334v-1.5H9.333v1.5Z' fill='%233858E9'/%3E%3C/svg%3E%0A");
+			background-position: right center;
+			background-repeat: no-repeat;
+			background-size: contain;
+		}
+	}
+
+	&:focus a::after,
+	& a:focus::after,
+	& a:hover::after {
+		opacity: 1;
+	}
+
+	&:focus,
+	&:focus-visible {
+		outline: none;
+	}
+
+	&:target {
+		padding-left: 8px;
+		border-left: 2px solid var(--wp--preset--color--blueberry-1);
+	}
+}

--- a/mu-plugins/blocks/table-of-contents/src/block.json
+++ b/mu-plugins/blocks/table-of-contents/src/block.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/table-of-contents",
+	"title": "Dynamic Table of Contents",
+	"category": "layout",
+	"description": "A dynamic list of headings in the current page.",
+	"keywords": [ "document outline", "summary" ],
+	"textdomain": "wporg",
+	"attributes": {},
+	"supports": {
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
+	"style": "file:./style.css"
+}

--- a/mu-plugins/blocks/table-of-contents/src/index.js
+++ b/mu-plugins/blocks/table-of-contents/src/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+function Edit() {
+	return <div { ...useBlockProps() }>Table of contents</div>;
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/mu-plugins/blocks/table-of-contents/src/view.js
+++ b/mu-plugins/blocks/table-of-contents/src/view.js
@@ -1,0 +1,83 @@
+/**
+ * This is the calculated value of the admin bar + header height + local nav bar.
+ */
+const FIXED_HEADER_HEIGHT = 179;
+
+/**
+ * Get the value of a CSS custom property.
+ *
+ * @param {string}      name    Custom property name
+ * @param {HTMLElement} element The element to use when calculating the custom property, defaults to body.
+ *
+ * @return {*} A number value if the property was in pixels, otherwise the value as seen in CSS.
+ */
+function getCustomPropValue( name, element = document.body ) {
+	const value = window.getComputedStyle( element ).getPropertyValue( name );
+	if ( 'px' === value.slice( -2 ) ) {
+		return Number( value.replace( 'px', '' ) );
+	}
+	return value;
+}
+
+function onScroll() {
+	const container = document.querySelector( '.wp-block-wporg-table-of-contents' );
+	if ( ! container ) {
+		return;
+	}
+
+	// Only run the scroll code if the sidebar is fixed.
+	const sidebarContainer = container.parentNode;
+	if ( ! sidebarContainer || ! sidebarContainer.classList.contains( 'is-fixed-sidebar' ) ) {
+		return;
+	}
+
+	const mainEl = document.getElementById( 'wp--skip-link--target' );
+	const footerStart = mainEl.offsetTop + mainEl.offsetHeight;
+
+	const gap = getCustomPropValue( '--wp--preset--spacing--edge-space' );
+	const viewportYOffset = window
+		.getComputedStyle( document.documentElement )
+		.getPropertyValue( 'margin-top' )
+		.replace( 'px', '' );
+
+	// This value needs to take account the margin on `html`.
+	const scrollPosition = window.scrollY - viewportYOffset;
+
+	if ( ! sidebarContainer.classList.contains( 'is-bottom-sidebar' ) ) {
+		// The pixel location of the bottom of the sidebar, relative to the top of the page.
+		const sidebarBottom = scrollPosition + sidebarContainer.offsetHeight + sidebarContainer.offsetTop;
+
+		// Is the sidebar bottom crashing into the footer?
+		if ( footerStart - gap < sidebarBottom ) {
+			sidebarContainer.classList.add( 'is-bottom-sidebar' );
+			// Bottom sidebar is absolutely positioned, so we need to set the top relative to the page origin.
+			sidebarContainer.style.setProperty(
+				'top',
+				// Starting from the footer Y position, subtract the sidebar height and gap/margins, and add
+				// the viewport offset. This ensures the sidebar doesn't jump when the class is switched.
+				`${ footerStart - sidebarContainer.clientHeight - gap * 2 + viewportYOffset * 1 }px`
+			);
+		}
+	} else if ( footerStart - sidebarContainer.offsetHeight - FIXED_HEADER_HEIGHT - gap * 2 > scrollPosition ) {
+		// If the scroll position is higher than the top of the sidebar, switch back to just a fixed sidebar.
+		sidebarContainer.classList.remove( 'is-bottom-sidebar' );
+		sidebarContainer.style.removeProperty( 'top' );
+	}
+}
+
+function init() {
+	const container = document.querySelector( '.wp-block-wporg-table-of-contents' );
+
+	if ( container ) {
+		const viewHeight = window.innerHeight - FIXED_HEADER_HEIGHT;
+		// If the table of contents sidebar is shorter than the view area, apply the
+		// class so that it's fixed and scrolls with the page content.
+		if ( container.parentNode?.offsetHeight < viewHeight ) {
+			container.parentNode.classList.add( 'is-fixed-sidebar' );
+			onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).
+			window.addEventListener( 'scroll', onScroll );
+		}
+	}
+}
+
+window.addEventListener( 'load', init );

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/blocks/language-suggest/language-suggest.php';
 require_once __DIR__ . '/blocks/latest-news/latest-news.php';
 require_once __DIR__ . '/blocks/screenshot-preview/block.php';
 require_once __DIR__ . '/blocks/site-breadcrumbs/index.php';
+require_once __DIR__ . '/blocks/table-of-contents/index.php';
 require_once __DIR__ . '/global-fonts/index.php';
 require_once __DIR__ . '/plugin-tweaks/index.php';
 require_once __DIR__ . '/rest-api/index.php';


### PR DESCRIPTION
This PR moves the Table of Contents block from Documentation into wporg-mu-plugins. It will also be needed on the Developer site (see https://github.com/WordPress/wporg-developer/issues/161, https://github.com/WordPress/wporg-developer/issues/160, https://github.com/WordPress/wporg-developer/issues/162). 

By default, this block searches the post content for any headings, then renders them in a list, styled to match the redesign. For example, added to a Block Editor Handbook page:

![default-toc](https://user-images.githubusercontent.com/541093/213032949-dd2772f4-e32f-49af-bb81-ed009462e23a.png)

This can be styled in the theme to pull it into a sidebar (not done in the block because the sidebar also contains a search box).

![toc](https://user-images.githubusercontent.com/541093/213032357-f3fdf20b-2da1-4cf7-8697-3aadf90d60fb.png)

The link indicator appears on hover, and all headings are clickable anchor links.

![toc-hover](https://user-images.githubusercontent.com/541093/213032355-7a00c800-7533-4e0e-bc7f-18e996584685.png)

**To test:**

Try adding this to a page template, it should filter the content on the page automatically.

Or try with a PR for handbooks: https://github.com/WordPress/wporg-developer/pull/169
