### PR TITLE
Allow for content filtering before we retrieve that content.

### DIFF
--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -36,7 +36,9 @@ function init() {
  * @return string Returns the block markup.
  */
 function render( $attributes, $content, $block ) {
-	$items = get_headings( get_the_content() );
+	$post = get_post();
+	$post_content = apply_filters( 'the_content', get_the_content( $post ), $post );
+	$items = get_headings( $post_content );
 	if ( ! $items ) {
 		return '';
 	}
@@ -69,8 +71,8 @@ function render( $attributes, $content, $block ) {
 	// Use the parsed headings & IDs to inject IDs into the post content.
 	add_filter(
 		'the_content',
-		function( $content ) use ( $items ) {
-			return inject_ids_into_headings( $content, $items );
+		function() use ( $items, $post_content ) {
+			return inject_ids_into_headings( $post_content, $items );
 		},
 		5 // Run early, before special character handling, so the items match.
 	);

--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -37,7 +37,7 @@ function init() {
  */
 function render( $attributes, $content, $block ) {
 	$post = get_post();
-	$post_content = apply_filters( 'the_content', get_the_content( $post ), $post );
+	$post_content = apply_filters( 'the_content', get_the_content( $post ) );
 	$items = get_headings( $post_content );
 	if ( ! $items ) {
 		return '';

--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -36,7 +36,10 @@ function init() {
  * @return string Returns the block markup.
  */
 function render( $attributes, $content, $block ) {
-	$post = get_post();
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+	$post = get_post( $block->context['postId'] );
 	$post_content = apply_filters( 'the_content', get_the_content( $post ) );
 	$items = get_headings( $post_content );
 	if ( ! $items ) {

--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -71,8 +71,8 @@ function render( $attributes, $content, $block ) {
 	// Use the parsed headings & IDs to inject IDs into the post content.
 	add_filter(
 		'the_content',
-		function() use ( $items, $post_content ) {
-			return inject_ids_into_headings( $post_content, $items );
+		function( $content ) use ( $items ) {
+			return inject_ids_into_headings( $content, $items );
 		},
 		5 // Run early, before special character handling, so the items match.
 	);

--- a/mu-plugins/blocks/table-of-contents/src/block.json
+++ b/mu-plugins/blocks/table-of-contents/src/block.json
@@ -8,6 +8,7 @@
 	"keywords": [ "document outline", "summary" ],
 	"textdomain": "wporg",
 	"attributes": {},
+	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,
 		"color": {


### PR DESCRIPTION
Currently, if we have a template full of blocks and no post-content in [wporg-developer](https://github.com/WordPress/wporg-developer/blob/trunk/source/wp-content/themes/wporg-developer-2023/patterns/single.php). As a result, we have to inject the blocks into the `the_content` (i think :)). 

However, filtering the content in the theme seems to be done too late. @dd32 suggested that the best strategy is to do the following:

`$content = apply_filters( 'the_content', get_the_content( $post ), $post );`

This does in fact seem to work.

