### PR TITLE
Table of Contents block: Use a custom filter for overriding the content.

### DIFF
--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -40,7 +40,9 @@ function render( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$items = get_headings( get_the_content() );
+	$post         = get_post( $block->context['postId'] );
+	$post_content = apply_filters( 'wporg_table_of_contents_post_content', get_the_content( null, false, $post ) );
+	$items        = get_headings( $post_content );
 	if ( ! $items ) {
 		return '';
 	}


### PR DESCRIPTION
Bring back a filter for the table of contents "content", so that dynamic blocks can be registered for the table of contents. See https://github.com/WordPress/wporg-mu-plugins/commit/401765062cb15e07527e81df8f6a18f582426c84, https://github.com/WordPress/wporg-mu-plugins/pull/332.

This new filter, `wporg_table_of_contents_post_content`, works exactly the same as `the_content` but has none of the extra baggage :) So the content passed through `get_headings` and then later in `inject_ids_into_headings` are both pre-block-parsing.

**To test**

- Make sure the table of contents still works on documentation articles, including ones with special characters like `/article/faq-my-site-was-hacked/`
- Apply the PR https://github.com/WordPress/wporg-developer/pull/210 to Developer, and make sure the table of contents still works on code reference & handbook pages
