### PR TITLE
Table of contents block: Include the top margin in fixed sidebar detection

### DIFF
--- a/mu-plugins/blocks/table-of-contents/src/view.js
+++ b/mu-plugins/blocks/table-of-contents/src/view.js
@@ -67,12 +67,19 @@ function onScroll() {
 
 function init() {
 	const container = document.querySelector( '.wp-block-wporg-table-of-contents' );
+	// Margin offset from the top of the sidebar.
+	const gap = getCustomPropValue( '--wp--preset--spacing--edge-space' );
 
 	if ( container ) {
+		// Usable viewport height.
 		const viewHeight = window.innerHeight - FIXED_HEADER_HEIGHT;
+		// Get the height of the sidebar, plus the top margin and 50px for the
+		// "Back to top" link, which isn't visible until `is-fixed-sidebar` is
+		// added, therefore not included in the parentNode.offsetHeight value.
+		const sidebarHeight = container.parentNode?.offsetHeight + gap + 50;
 		// If the table of contents sidebar is shorter than the view area, apply the
 		// class so that it's fixed and scrolls with the page content.
-		if ( container.parentNode?.offsetHeight < viewHeight ) {
+		if ( sidebarHeight < viewHeight ) {
 			container.parentNode.classList.add( 'is-fixed-sidebar' );
 			onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).
 			window.addEventListener( 'scroll', onScroll );


### PR DESCRIPTION
Fixes #333. The math to determine when the sidebar is fixed vs static was not including the top margin & space needed for the "Back to top" link, so as long as the viewport had enough space for the blue box + search, the fixed sidebar would be triggered. This meant that on screens within ~100px of the sidebar, it would incorrectly trigger and the bottom of the ToC would be offscreen.

**To test**

1. Try on both developer and documentation
2. Find a page with a ToC that fits on one page, and shrink your browser so the bottom of the screen hits in the pink area:
    ![Screen Shot 2023-02-09 at 15 29 02](https://user-images.githubusercontent.com/541093/217930059-a226b594-2392-4a06-b79b-4c0f43e21c5d.png)
3. The sidebar should not be fixed, it stays aligned to the top content when scrolling the page
4. Expand your viewport to beyond the pink area and reload
5. The ToC should fit on screen, so when you scroll the page it stays visible on screen
6. Ensure footer collision still works by scrolling to the bottom of the page
7. The ToC should not overlap the footer content
