### PR TITLE
Try: Override callout shortcodes in favor of the notice block

### DIFF
--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -6,7 +6,8 @@
 
 namespace WordPressdotorg\MU_Plugins\Notice;
 
-add_action( 'init', __NAMESPACE__ . '\init' );
+// Run after `WPorg_Handbook_Callout_Boxes` registers the shortcodes.
+add_action( 'init', __NAMESPACE__ . '\init', 11 );
 
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
@@ -17,4 +18,47 @@ add_action( 'init', __NAMESPACE__ . '\init' );
  */
 function init() {
 	register_block_type( __DIR__ . '/build' );
+
+	foreach ( [ 'info', 'tip', 'alert', 'tutorial', 'warning' ] as $shortcode ) {
+		remove_shortcode( $shortcode );
+		add_shortcode( $shortcode, __NAMESPACE__ . '\render_shortcode' );
+	}
+}
+
+/**
+ * Display the callout shortcodes using the notice block.
+ *
+ * @param array|string $attr    Shortcode attributes array or empty string.
+ * @param string       $content Shortcode content.
+ * @param string       $tag     Shortcode name.
+ *
+ * @return string Shortcode output as HTML markup.
+ */
+function render_shortcode( $attr, $content = '', $tag ) {
+	$shortcode_mapping = array(
+		'info'     => 'info',
+		'tip'      => 'tip',
+		'alert'    => 'alert',
+		'tutorial' => 'tip',
+		'warning'  => 'warning',
+	);
+
+	$type = $shortcode_mapping[ $tag ] ?: 'tip';
+
+	// Sanitize message content.
+	$content = wp_kses_post( $content );
+	// Temporarily disable o2 processing while formatting content.
+	add_filter( 'o2_process_the_content', '__return_false', 1 );
+	$content = apply_filters( 'the_content', $content );
+	remove_filter( 'o2_process_the_content', '__return_false', 1 );
+
+	$block_markup = <<<EOT
+<!-- wp:wporg/notice {"type":"$type"} -->
+<div class="wp-block-wporg-notice is-{$type}-notice">
+<div class="wp-block-wporg-notice__icon"></div>
+<div class="wp-block-wporg-notice__content">$content</div></div>
+<!-- /wp:wporg/notice -->
+EOT;
+
+	return do_blocks( $block_markup );
 }

--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -52,13 +52,21 @@ function render_shortcode( $attr, $content = '', $tag ) {
 	$content = apply_filters( 'the_content', $content );
 	remove_filter( 'o2_process_the_content', '__return_false', 1 );
 
+	// Create a unique placeholder for the content.
+	// Directly processing `$content` with `do_blocks` can lead to buggy layouts on make.wp.org.
+	// See https://github.com/WordPress/wporg-mu-plugins/pull/337#issuecomment-1819992059.
+	$placeholder = '<!-- CONTENT_PLACEHOLDER -->';
+
 	$block_markup = <<<EOT
 <!-- wp:wporg/notice {"type":"$type"} -->
 <div class="wp-block-wporg-notice is-{$type}-notice">
 <div class="wp-block-wporg-notice__icon"></div>
-<div class="wp-block-wporg-notice__content">$content</div></div>
+<div class="wp-block-wporg-notice__content">$placeholder</div></div>
 <!-- /wp:wporg/notice -->
 EOT;
 
-	return do_blocks( $block_markup );
+	$processed_markup = do_blocks( $block_markup );
+	$final_markup = str_replace( $placeholder, $content, $processed_markup );
+
+	return $final_markup;
 }

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -1,17 +1,17 @@
 .wp-block-wporg-notice {
-	--wp--custom--wporg-notice--color--background: var(--wp--preset--color--acid-green-3);
-	--wp--custom--wporg-notice--color--text: var(--wp--preset--color--charcoal-1);
+	--wp--custom--wporg-notice--color--background: var(--wp--preset--color--acid-green-3, #e2ffed);
+	--wp--custom--wporg-notice--color--text: var(--wp--preset--color--charcoal-1, #1e1e1e);
 
 	&.is-info-notice {
-		--wp--custom--wporg-notice--color--background: var(--wp--preset--color--blueberry-4);
+		--wp--custom--wporg-notice--color--background: var(--wp--preset--color--blueberry-4, #eff2ff);
 	}
 
 	&.is-alert-notice {
-		--wp--custom--wporg-notice--color--background: var(--wp--preset--color--lemon-3);
+		--wp--custom--wporg-notice--color--background: var(--wp--preset--color--lemon-3, #fffdd6);
 	}
 
 	&.is-warning-notice {
-		--wp--custom--wporg-notice--color--background: var(--wp--preset--color--pomegrade-3);
+		--wp--custom--wporg-notice--color--background: var(--wp--preset--color--pomegrade-3, #ffe9de);
 	}
 
 	display: grid;
@@ -33,6 +33,10 @@
 		margin-block-end: 0;
 	}
 
+	& br:first-child {
+		display: none;
+	}
+
 	& a:link,
 	& a:visited,
 	& a:hover,
@@ -43,7 +47,7 @@
 
 	&.alignleft,
 	&.alignright {
-		max-width: calc(var(--wp--style--global--content-size) * 0.66);
+		max-width: calc(var(--wp--style--global--content-size, 680px) * 0.66);
 	}
 }
 

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -38,14 +38,6 @@
 		display: none;
 	}
 
-	& a:link,
-	& a:visited,
-	& a:hover,
-	& a:active,
-	& a:focus {
-		color: var(--wp--custom--wporg-notice--color--text);
-	}
-
 	&.alignleft,
 	&.alignright {
 		max-width: calc(var(--wp--style--global--content-size, 680px) * 0.66);

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -20,6 +20,7 @@
 	padding: 1.25em;
 	color: var(--wp--custom--wporg-notice--color--text);
 	background-color: var(--wp--custom--wporg-notice--color--background);
+	border-radius: 2px;
 
 	& > * {
 		align-self: start;

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -62,8 +62,9 @@
 
 	background-image: url(../src/icon/library/tip.svg);
 	background-repeat: no-repeat;
-	background-position: center;
+	background-position: top;
 	background-size: 24px 24px;
+	margin-top: 1px;
 }
 
 .is-info-notice .wp-block-wporg-notice__icon {
@@ -80,4 +81,5 @@
 
 .wp-block-wporg-notice__content {
 	align-self: center;
+	font-size: var(--wp--preset--font-size--small);
 }


### PR DESCRIPTION
Closes https://github.com/WordPress/wporg-developer/issues/315

Remove the existing "callout" shortcodes, and replace them with the Notice block.

![docs-tip](https://user-images.githubusercontent.com/541093/218193722-2d00050d-1e78-4f68-9ae9-2bfe157cd482.png)

![docs-alert-info](https://user-images.githubusercontent.com/541093/218193716-1690b37f-e2bb-46f2-8282-9c2fff6e09b8.png)

Some of the shortcode content can be very long
![docs-long-info](https://user-images.githubusercontent.com/541093/218193720-689fb3fc-15f2-4750-921c-f30aba1bb50e.png)

This shortcode is also used on classic themes, since it's part of the handbook code. I've updated the CSS to include fallbacks for the custom properties, so it should still work. For example, on make/core's handbook.

![make-info](https://user-images.githubusercontent.com/541093/218193723-260405ea-dadf-46dc-be06-ce9c5dbc1cf3.png)

Is the sanitization + fitlering necessary? I grabbed it from [the existing callout shortcode](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/plugins/handbook/inc/callout-boxes.php#L116).