### PR TITLE
Update Openverse URL in global header

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -433,7 +433,7 @@ function get_global_menu_items() {
 				),
 				array(
 					'title' => esc_html_x( 'Openverse', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/openverse/',
+					'url'   => 'https://openverse.org/',
 					'type'  => 'custom',
 				),
 				array(


### PR DESCRIPTION
Closes #339 

Updates the Openverse URL in the global header to https://openverse.org/, which avoids a 301 redirect.