### PR TITLE
Check for reference before removing event.

### DIFF
--- a/mu-plugins/blocks/horizontal-slider/src/block.js
+++ b/mu-plugins/blocks/horizontal-slider/src/block.js
@@ -83,7 +83,9 @@ function Block( { items, title } ) {
 		outerRef.current.addEventListener( 'scroll', handleScrollEvent );
 
 		return () => {
-			outerRef.current.removeEventListener( 'scroll', handleScrollEvent );
+			if ( outerRef.current ) {
+				outerRef.current.removeEventListener( 'scroll', handleScrollEvent );
+			}
 		};
 	}, [ outerRef ] );
 

--- a/mu-plugins/blocks/horizontal-slider/src/block.js
+++ b/mu-plugins/blocks/horizontal-slider/src/block.js
@@ -83,9 +83,7 @@ function Block( { items, title } ) {
 		outerRef.current.addEventListener( 'scroll', handleScrollEvent );
 
 		return () => {
-			if ( outerRef.current ) {
-				outerRef.current.removeEventListener( 'scroll', handleScrollEvent );
-			}
+			outerRef.current?.removeEventListener( 'scroll', handleScrollEvent );
 		};
 	}, [ outerRef ] );
 


### PR DESCRIPTION
Fixes: #343

This PR checks to make sure the element reference exists before trying to remove the event listener.


## How to Test
1. Apply to Sandbox
2. See #343 for steps

- Expect to see no console.log errors
- Expect to only have to click once to return.