### PR TITLE
Add link to Mercantile in About menu

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -542,6 +542,11 @@ function get_global_menu_items() {
 					'url'   => 'https://wordpress.org/enterprise/',
 					'type'  => 'custom',
 				),
+				array(
+					'title' => esc_html_x( 'WordPress Swag Store', 'Menu item title', 'wporg' ),
+					'url'   => 'https://mercantile.wordpress.org/',
+					'type'  => 'custom',
+				),
 			),
 		),
 	);


### PR DESCRIPTION
Closes #346 

Adds a link to the swag store in the About menu in the global header

### Screenshots

| Desktop | Mobile |
|-|-|
| ![Screen Shot 2023-02-27 at 11 55 33 AM](https://user-images.githubusercontent.com/1017872/221442521-cd01e051-f844-4500-baa7-23e61e40443e.jpg) | ![localhost_8888_about_(Samsung Galaxy S20 Ultra)](https://user-images.githubusercontent.com/1017872/221442529-b5ba0a99-ca34-4e97-8058-6eef80dc979d.png) |
