### PR TITLE
Make the breadcrumb more readable.

### DIFF
--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -76,10 +76,7 @@ function render_block( $attributes, $content, $block ) {
 		if ( ! $crumb['url'] ) {
 			$content .= sprintf( '<span class="is-current-page">%s</span>', esc_html( $crumb['title'] ) );
 		} else {
-			$title = trim( $crumb['title'] );
-			$classes = '';
-
-			$content .= sprintf( '<span><a href="%1$s" class="%2$s" data-title="%3$s"><span>%3$s</span></a></span>', esc_url( $crumb['url'] ), $classes, esc_html( $title ) );
+			$content .= sprintf( '<span><a href="%1$s" class="%2$s" data-title="%3$s"><span>%3$s</span></a></span>', esc_url( $crumb['url'] ), esc_html( $crumb['title'] ) );
 		}
 	}
 

--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -76,7 +76,7 @@ function render_block( $attributes, $content, $block ) {
 		if ( ! $crumb['url'] ) {
 			$content .= sprintf( '<span class="is-current-page">%s</span>', esc_html( $crumb['title'] ) );
 		} else {
-			$content .= sprintf( '<span><a href="%1$s" class="%2$s" data-title="%3$s"><span>%3$s</span></a></span>', esc_url( $crumb['url'] ), esc_html( $crumb['title'] ) );
+			$content .= sprintf( '<span><a href="%1$s" data-title="%2$s"><span>%2$s</span></a></span>', esc_url( $crumb['url'] ), esc_html( $crumb['title'] ) );
 		}
 	}
 

--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -70,8 +70,6 @@ function render_block( $attributes, $content, $block ) {
 	$breadcrumbs = apply_filters( 'wporg_block_site_breadcrumbs', $breadcrumbs, $attributes, $block );
 
 	$content = '';
-	$count = count( $breadcrumbs );
-	$max_to_show = 4;
 	foreach ( $breadcrumbs as $i => $crumb ) {
 
 		// We can assume that the item without a URL is the current page.
@@ -81,12 +79,7 @@ function render_block( $attributes, $content, $block ) {
 			$title = trim( $crumb['title'] );
 			$classes = '';
 
-			// if the crumb is not the first or last, and there are more than 4 crumbs, truncate the title but still leave a total of 4
-			if ( $i > 0 && $i < $count - 1 && $count > $max_to_show && $i <= $count - $max_to_show ) {
-				$classes = 'truncated';
-			}
-
-			$content .= sprintf( '<span><a  href="%s" class="%s"><span>%s</span></a></span>', esc_url( $crumb['url'] ), $classes, esc_html( $title ) );
+			$content .= sprintf( '<span><a href="%1$s" class="%2$s" data-title="%3$s"><span>%3$s</span></a></span>', esc_url( $crumb['url'] ), $classes, esc_html( $title ) );
 		}
 	}
 

--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -70,12 +70,28 @@ function render_block( $attributes, $content, $block ) {
 	$breadcrumbs = apply_filters( 'wporg_block_site_breadcrumbs', $breadcrumbs, $attributes, $block );
 
 	$content = '';
+	$count = count( $breadcrumbs );
+	$max_to_show = 4;
+	$max_characters = 25;
 	foreach ( $breadcrumbs as $i => $crumb ) {
+
 		// We can assume that the item without a URL is the current page.
 		if ( ! $crumb['url'] ) {
 			$content .= sprintf( '<span class="is-current-page">%s</span>', esc_html( $crumb['title'] ) );
 		} else {
-			$content .= sprintf( '<span><a href="%s">%s</a></span>', esc_url( $crumb['url'] ), esc_html( $crumb['title'] ) );
+			$title = trim( $crumb['title'] );
+			$classes = '';
+
+			// if the crumb is not the first or last, and there are more than 4 crumbs, truncate the title but still leave a total of 4
+			if ( $i > 0 && $i < $count - 1 && $count > $max_to_show && $i <= $count - $max_to_show ) {
+				$classes = 'truncated';
+			}
+
+			if ( strlen( $title ) > $max_characters ) {
+				$classes = 'partially-truncated';
+			}
+
+			$content .= sprintf( '<span><a  href="%s" class="%s"><span>%s</span></a></span>', esc_url( $crumb['url'] ), $classes, esc_html( $title ) );
 		}
 	}
 

--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -72,7 +72,6 @@ function render_block( $attributes, $content, $block ) {
 	$content = '';
 	$count = count( $breadcrumbs );
 	$max_to_show = 4;
-	$max_characters = 25;
 	foreach ( $breadcrumbs as $i => $crumb ) {
 
 		// We can assume that the item without a URL is the current page.
@@ -85,10 +84,6 @@ function render_block( $attributes, $content, $block ) {
 			// if the crumb is not the first or last, and there are more than 4 crumbs, truncate the title but still leave a total of 4
 			if ( $i > 0 && $i < $count - 1 && $count > $max_to_show && $i <= $count - $max_to_show ) {
 				$classes = 'truncated';
-			}
-
-			if ( strlen( $title ) > $max_characters ) {
-				$classes = 'partially-truncated';
 			}
 
 			$content .= sprintf( '<span><a  href="%s" class="%s"><span>%s</span></a></span>', esc_url( $crumb['url'] ), $classes, esc_html( $title ) );

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -4,7 +4,7 @@
 	& span {
 		display: inline-block;
 
-		&.hidden {
+		&.is-hidden {
 			display: none;
 		}
 	}

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -76,3 +76,7 @@
 		width: auto;
 	}
 }
+
+html.no-js .wp-block-wporg-site-breadcrumbs span {
+	visibility: visible;
+}

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -1,6 +1,12 @@
 .wp-block-wporg-site-breadcrumbs {
+	white-space: nowrap;
+
 	& span {
 		display: inline-block;
+
+		&.hidden {
+			display: none;
+		}
 	}
 
 	& a {
@@ -10,60 +16,53 @@
 			text-decoration-line: underline;
 		}
 
-		@media (min-width: 800px) {
-
-			/* Show full crumb on interaction. */
-			&.truncated {
-				& span {
-					position: absolute;
-					opacity: 0;
-				}
-
-				&::before {
-					content: "...";
-				}
-
-				&:focus,
-				&:hover {
-					& span {
-						position: relative;
-						opacity: 1;
-					}
-
-					&::before {
-						display: none;
-					}
-				}
-			}
-
+		/* Show full crumb on interaction. */
+		&.truncated {
 			& span {
-				display: inline-block;
-				overflow-x: hidden;
-				white-space: nowrap;
-				max-width: 125px;
-				text-overflow: ellipsis;
-				vertical-align: middle;
+				position: absolute;
+				opacity: 0;
 			}
 
-			&:focus span,
-			&:hover span {
-				max-width: fit-content;
-				overflow-x: visible;
+			&::before {
+				content: "...";
 			}
+
+			&:focus::after,
+			&:hover::after {
+				background: var(--wp--preset--color--charcoal-1);
+				border-radius: 2px;
+				color: var(--wp--preset--color--white);
+				padding: 2px 4px;
+				position: absolute;
+				width: max-content;
+				left: -100%;
+				bottom: -40px;
+				font-size: var(--wp--preset--font-size--small);
+				content: attr(data-title);
+				z-index: 1000;
+			}
+		}
+
+		& span {
+			display: inline-block;
+			overflow-x: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			vertical-align: middle;
+		}
+
+		&:focus span,
+		&:hover span {
+			max-width: fit-content;
+			overflow-x: visible;
 		}
 	}
 
-	& > span:not(:last-child) {
-
-		/* This ensures that the square separator is reliably centered. */
-		margin-top: 0;
-
-		&::after {
-			content: "/";
-			display: inline-block;
-			font-weight: 400;
-			margin: 0 0.5rem;
-		}
+	& > span:not(:last-child)::after {
+		content: "/";
+		display: inline-block;
+		font-weight: 400;
+		margin: 0 0.5rem;
 	}
 
 	& .is-current-page {

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -33,6 +33,24 @@
 				}
 			}
 		}
+
+		&.partially-truncated {
+			& span {
+				display: inline-block;
+				overflow-x: hidden;
+				white-space: nowrap;
+				width: 100px;
+				text-overflow: ellipsis;
+				vertical-align: middle;
+				transition: width 400ms ease-in-out;
+			}
+
+			&:focus span,
+			&:hover span {
+				width: auto;
+				overflow-x: visible;
+			}
+		}
 	}
 
 	& > span:not(:last-child) {

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -17,7 +17,7 @@
 		}
 
 		/* Show full crumb on interaction. */
-		&.truncated {
+		&.is-truncated {
 			& span {
 				position: absolute;
 				opacity: 0;

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -4,9 +4,19 @@
 	& span {
 		display: inline-block;
 
+		/* Prevent visual flash on load */
+		&:not(:first-child) {
+			visibility: hidden;
+		}
+
 		&.is-hidden {
 			display: none;
 		}
+	}
+
+	/* After initial page load, show everything */
+	&.has-rendered span {
+		visibility: visible;
 	}
 
 	& a {

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -10,44 +10,44 @@
 			text-decoration-line: underline;
 		}
 
-		/* Show full crumb on interaction. */
-		&.truncated {
-			& span {
-				position: absolute;
-				opacity: 0;
-			}
+		@media (min-width: 800px) {
 
-			&::before {
-				content: "...";
-			}
-
-			&:focus,
-			&:hover {
+			/* Show full crumb on interaction. */
+			&.truncated {
 				& span {
-					position: relative;
-					opacity: 1;
+					position: absolute;
+					opacity: 0;
 				}
 
 				&::before {
-					display: none;
+					content: "...";
+				}
+
+				&:focus,
+				&:hover {
+					& span {
+						position: relative;
+						opacity: 1;
+					}
+
+					&::before {
+						display: none;
+					}
 				}
 			}
-		}
 
-		&.partially-truncated {
 			& span {
 				display: inline-block;
 				overflow-x: hidden;
 				white-space: nowrap;
-				width: 100px;
+				max-width: 125px;
 				text-overflow: ellipsis;
 				vertical-align: middle;
-				transition: width 400ms ease-in-out;
 			}
 
 			&:focus span,
 			&:hover span {
-				width: auto;
+				max-width: fit-content;
 				overflow-x: visible;
 			}
 		}

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -10,6 +10,7 @@
 	}
 
 	& a {
+		position: relative;
 		color: var(--wp--preset--color--charcoal-1);
 
 		&:hover {
@@ -35,7 +36,7 @@
 				padding: 2px 4px;
 				position: absolute;
 				width: max-content;
-				left: -100%;
+				left: 0;
 				bottom: -40px;
 				font-size: var(--wp--preset--font-size--small);
 				content: attr(data-title);

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -55,6 +55,10 @@
 
 	& .is-current-page {
 		font-weight: 700;
+
+		overflow-x: hidden;
+		text-overflow: ellipsis;
+		vertical-align: top;
 	}
 
 	/* If this is set to 1px, we can't calculate the elements natural width. */

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -56,4 +56,9 @@
 	& .is-current-page {
 		font-weight: 700;
 	}
+
+	/* If this is set to 1px, we can't calculate the elements natural width. */
+	& .screen-reader-text {
+		width: auto;
+	}
 }

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -1,6 +1,7 @@
 .wp-block-wporg-site-breadcrumbs {
-	display: flex;
-	align-items: center;
+	& span {
+		display: inline-block;
+	}
 
 	& a {
 		color: var(--wp--preset--color--charcoal-1);
@@ -8,16 +9,38 @@
 		&:hover {
 			text-decoration-line: underline;
 		}
+
+		/* Show full crumb on interaction. */
+		&.truncated {
+			& span {
+				position: absolute;
+				opacity: 0;
+			}
+
+			&::before {
+				content: "...";
+			}
+
+			&:focus,
+			&:hover {
+				& span {
+					position: relative;
+					opacity: 1;
+				}
+
+				&::before {
+					display: none;
+				}
+			}
+		}
 	}
 
-	& > span:not(:first-child) {
+	& > span:not(:last-child) {
 
 		/* This ensures that the square separator is reliably centered. */
-		display: flex;
-		align-items: center;
 		margin-top: 0;
 
-		&::before {
+		&::after {
 			content: "/";
 			display: inline-block;
 			font-weight: 400;

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -19,11 +19,6 @@
 
 		/* Show full crumb on interaction. */
 		&.is-truncated {
-			& span {
-				position: absolute;
-				opacity: 0;
-			}
-
 			&::before {
 				content: "...";
 			}
@@ -42,14 +37,6 @@
 				content: attr(data-title);
 				z-index: 1000;
 			}
-		}
-
-		& span {
-			display: inline-block;
-			overflow-x: hidden;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			vertical-align: middle;
 		}
 
 		&:focus span,

--- a/mu-plugins/blocks/site-breadcrumbs/src/block.json
+++ b/mu-plugins/blocks/site-breadcrumbs/src/block.json
@@ -27,5 +27,6 @@
 		"multiple": false
 	},
 	"editorScript": "file:./index.js",
-	"style": "file:./style.css"
+	"style": "file:./style.css",
+	"viewScript": "file:./view.js"
 }

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -63,19 +63,19 @@ const expandCrumbs = ( arr, container, breakpoint ) => {
 	}
 
 	/**
+	 * If there are hidden elements, show them first.
+	 */
+	const hiddenEls = arr.filter( ( crumb ) => crumb.classList.contains( 'hidden' ) );
+
+	if ( hiddenEls.length ) {
+		hiddenEls[ 0 ].classList.remove( 'hidden' );
+		return;
+	}
+
+	/**
 	 * Loop through right to left, expand
 	 */
 	for ( let i = arr.length - 1; i >= 0; i-- ) {
-		/**
-		 * If there are hidden elements, show them first.
-		 */
-		const hiddenEls = arr.filter( ( crumb ) => crumb.classList.contains( 'hidden' ) );
-
-		if ( hiddenEls.length ) {
-			hiddenEls[ 0 ].classList.remove( 'hidden' );
-			return;
-		}
-
 		const anchorElement = arr[ i ].firstChild;
 
 		// We don't need to do anything if the element is already expanded.

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -26,23 +26,24 @@ const getAvailableSpace = ( parent ) => {
  * @return {void}
  */
 const collapseCrumbs = ( arr, container, breakpoint ) => {
-	/**
-	 * Loop through left to right, truncate until space exceeds breakpoint.
-	 */
-	for ( let i = 0; i < arr.length; i++ ) {
-		if ( getAvailableSpace( container ) > breakpoint ) {
-			return;
-		}
+	// First, try to truncate the text
+	const allTruncated = () =>
+		arr.every( ( { firstChild: anchorElement } ) => anchorElement.classList.contains( 'is-truncated' ) );
 
-		const allTruncated =
-			arr.filter( ( crumb ) => crumb.firstChild.classList.contains( 'is-truncated' ) ).length === arr.length;
+	let index = 0;
+	while ( getAvailableSpace( container ) < breakpoint && ! allTruncated() ) {
+		arr[ index ].firstChild.classList.add( 'is-truncated' );
+		arr[ index ].firstChild.firstChild.classList.add( 'screen-reader-text' );
+		index++;
+	}
 
-		if ( allTruncated ) {
-			arr[ i ].classList.add( 'hidden' );
-		} else {
-			arr[ i ].firstChild.classList.add( 'is-truncated' );
-			arr[ i ].firstChild.firstChild.classList.add( 'screen-reader-text' );
-		}
+	// Second, hide the items if everything is truncated
+	const allHidden = () => arr.every( ( crumb ) => crumb.classList.contains( 'hidden' ) );
+
+	let index2 = 0;
+	while ( getAvailableSpace( container ) < breakpoint && ! allHidden() ) {
+		arr[ index2 ].classList.add( 'hidden' );
+		index2++;
 	}
 };
 

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -48,7 +48,7 @@ const allHidden = ( arr ) => arr.every( ( crumb ) => crumb.classList.contains( '
  * @return {void}
  */
 const collapseCrumbs = ( breadcrumbs, container, breakpoint ) => {
-	const middleCrumbs = arr.slice( 1, arr.length - 1 );
+	const middleCrumbs = breadcrumbs.slice( 1, breadcrumbs.length - 1 );
 
 	// First, try to truncate the text
 	let index = 0;
@@ -68,7 +68,7 @@ const collapseCrumbs = ( breadcrumbs, container, breakpoint ) => {
 	const remainingSpace = getAvailableSpace( container );
 	// if we truncated and hid all the items, truncate the last part
 	if ( remainingSpace < breakpoint ) {
-		const lastPart = arr[ arr.length - 1 ];
+		const lastPart = breadcrumbs[ breadcrumbs.length - 1 ];
 		const width = Math.max( 75, lastPart.getBoundingClientRect().width - breakpoint );
 		lastPart.style.width = `${ width }px`;
 	}

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -96,16 +96,19 @@ const expandCrumbs = ( arr, container, breakpoint, finalPartOriginalLength ) => 
 	const currentSpaceValue = getAvailableSpace( container );
 	let pixelToAllocate = Math.ceil( currentSpaceValue - breakpoint );
 
+	// If the last part has ellipses, expand it.
+	const lastPart = arr[ arr.length - 1 ];
+	const currWidth = parseInt( lastPart.style.width );
+
+	if ( currWidth < finalPartOriginalLength ) {
+		const newWidth = Math.min( currWidth + pixelToAllocate, finalPartOriginalLength );
+		lastPart.style.width = `${ newWidth }px`;
+		pixelToAllocate -= newWidth - currWidth;
+	}
+
 	// 20 is roughly the width of the ellipsis.
 	if ( pixelToAllocate < 20 ) {
 		return;
-	}
-
-	// If the last part has ellipses, expand it.
-	const lastPart = arr[ arr.length - 1 ];
-	const currWidth = lastPart.style.width;
-	if ( currWidth < finalPartOriginalLength ) {
-		lastPart.style.width += Math.min( currWidth + pixelToAllocate, finalPartOriginalLength );
 	}
 
 	/**

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -47,7 +47,7 @@ const allHidden = ( arr ) => arr.every( ( crumb ) => crumb.classList.contains( '
  *
  * @return {void}
  */
-const collapseCrumbs = ( arr, container, breakpoint ) => {
+const collapseCrumbs = ( breadcrumbs, container, breakpoint ) => {
 	const middleCrumbs = arr.slice( 1, arr.length - 1 );
 
 	// First, try to truncate the text

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -1,0 +1,133 @@
+/**
+ * Calculates the available space in the parent container between the breadcrumb container and the menu container.
+ *
+ * @param {HTMLElement} parent The parent container.
+ *
+ * @return {number} The available space in pixels
+ */
+const getAvailableSpace = ( parent ) => {
+	const parentWidth = parent.getBoundingClientRect().width;
+	let occupiedSpace = 0;
+
+	for ( const child of parent.children ) {
+		occupiedSpace += child.getBoundingClientRect().width;
+	}
+
+	return parentWidth - occupiedSpace;
+};
+
+/**
+ * This function collapses the breadcrumbs until the available space is greater than the breakpoint.
+ *
+ * @param {Array<HTMLElement>} arr        List of breadcrumb elements.
+ * @param {HTMLElement}        container  Breadcrumb parent container
+ * @param {number}             breakpoint The breakpoint in pixels.
+ *
+ * @return {void}
+ */
+const collapseCrumbs = ( arr, container, breakpoint ) => {
+	/**
+	 * Loop through left to right, truncate until space exceeds breakpoint.
+	 */
+	for ( let i = 0; i < arr.length; i++ ) {
+		if ( getAvailableSpace( container ) > breakpoint ) {
+			return;
+		}
+
+		const allTruncated =
+			arr.filter( ( crumb ) => crumb.firstChild.classList.contains( 'truncated' ) ).length === arr.length;
+
+		if ( allTruncated ) {
+			arr[ i ].classList.add( 'hidden' );
+		} else {
+			arr[ i ].firstChild.classList.add( 'truncated' );
+		}
+	}
+};
+
+/**
+ * This function expands the breadcrumbs until the available space is less than the breakpoint.
+ *
+ * @param {Array<HTMLElement>} arr        List of breadcrumb elements.
+ * @param {HTMLElement}        container  Breadcrumb parent container
+ * @param {number}             breakpoint The breakpoint in pixels.
+ *
+ * @return {void}
+ */
+const expandCrumbs = ( arr, container, breakpoint ) => {
+	const currentSpaceValue = getAvailableSpace( container );
+	let pixelToAllocate = Math.ceil( currentSpaceValue - breakpoint );
+
+	if ( pixelToAllocate < 0 ) {
+		return;
+	}
+
+	/**
+	 * Loop through right to left, expand
+	 */
+	for ( let i = arr.length - 1; i >= 0; i-- ) {
+		/**
+		 * If there are hidden elements, show them first.
+		 */
+		const hiddenEls = arr.filter( ( crumb ) => crumb.classList.contains( 'hidden' ) );
+
+		if ( hiddenEls.length ) {
+			hiddenEls[ 0 ].classList.remove( 'hidden' );
+			return;
+		}
+
+		const anchorElement = arr[ i ].firstChild;
+
+		// We don't need to do anything if the element is already expanded.
+		if ( ! anchorElement.classList.contains( 'truncated' ) ) {
+			continue;
+		}
+
+		const spanWidth = anchorElement.firstChild.getBoundingClientRect().width;
+
+		// If the this item can't fit, wait until it can.
+		if ( spanWidth >= pixelToAllocate ) {
+			return;
+		}
+
+		anchorElement.classList.remove( 'truncated' );
+
+		pixelToAllocate -= spanWidth;
+	}
+};
+
+const init = () => {
+	const crumbContainer = document.querySelector( '.wp-block-wporg-site-breadcrumbs' );
+
+	if ( ! crumbContainer ) {
+		return;
+	}
+
+	const crumbs = Array.from( crumbContainer.children );
+
+	// We don't need to do anything for this many crumbs.
+	if ( crumbs.length <= 3 ) {
+		return;
+	}
+
+	const breakpoint = 50; // The menu and the breadcrumbs should never come closer than this.
+	const middleCrumbs = crumbs.slice( 1, crumbs.length - 1 );
+	let prevWindowWidth = window.innerWidth; // Track window expansion
+
+	const truncate = () => {
+		// Window is shrinking
+		if ( prevWindowWidth >= window.innerWidth ) {
+			collapseCrumbs( middleCrumbs, crumbContainer.parentElement, breakpoint );
+		} else {
+			expandCrumbs( middleCrumbs, crumbContainer.parentElement, breakpoint );
+		}
+
+		prevWindowWidth = window.innerWidth;
+	};
+
+	truncate();
+
+	window.addEventListener( 'resize', truncate );
+};
+
+document.addEventListener( 'DOMContentLoaded', init );

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -41,9 +41,9 @@ const allHidden = ( arr ) => arr.every( ( crumb ) => crumb.classList.contains( '
 /**
  * This function collapses the breadcrumbs until the available space is greater than the breakpoint.
  *
- * @param {Array<HTMLElement>} arr        List of breadcrumb elements.
- * @param {HTMLElement}        container  Breadcrumb parent container
- * @param {number}             breakpoint The breakpoint in pixels.
+ * @param {Array<HTMLElement>} breadcrumbs List of breadcrumb elements.
+ * @param {HTMLElement}        container   Breadcrumb parent container
+ * @param {number}             breakpoint  The breakpoint in pixels.
  *
  * @return {void}
  */

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -103,8 +103,9 @@ const expandCrumbs = ( arr, container, breakpoint, finalPartOriginalLength ) => 
 
 	// If the last part has ellipses, expand it.
 	const lastPart = arr[ arr.length - 1 ];
-	if ( lastPart.style.width < finalPartOriginalLength ) {
-		lastPart.style.width += pixelToAllocate;
+	const currWidth = lastPart.style.width;
+	if ( currWidth < finalPartOriginalLength ) {
+		lastPart.style.width += Math.min( currWidth + pixelToAllocate, finalPartOriginalLength );
 	}
 
 	lastPart.style.width = 'auto';

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -180,6 +180,9 @@ const init = () => {
 	// Run on init
 	truncate();
 
+	// Help reduce visible jank on load
+	crumbContainer.classList.add( 'has-rendered' );
+
 	let timeout = null;
 	window.addEventListener( 'resize', () => {
 		clearTimeout( timeout );

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -38,11 +38,11 @@ const collapseCrumbs = ( arr, container, breakpoint ) => {
 	}
 
 	// Second, hide the items if everything is truncated
-	const allHidden = () => arr.every( ( crumb ) => crumb.classList.contains( 'hidden' ) );
+	const allHidden = () => arr.every( ( crumb ) => crumb.classList.contains( 'is-hidden' ) );
 
 	let index2 = 0;
 	while ( getAvailableSpace( container ) < breakpoint && ! allHidden() ) {
-		arr[ index2 ].classList.add( 'hidden' );
+		arr[ index2 ].classList.add( 'is-hidden' );
 		index2++;
 	}
 };
@@ -67,17 +67,18 @@ const expandCrumbs = ( arr, container, breakpoint ) => {
 	const currentSpaceValue = getAvailableSpace( container );
 	let pixelToAllocate = Math.ceil( currentSpaceValue - breakpoint );
 
-	if ( pixelToAllocate < 0 ) {
+	// 20 is roughly the width of the ellipsis.
+	if ( pixelToAllocate < 20 ) {
 		return;
 	}
 
 	/**
 	 * If there are hidden elements, show them first.
 	 */
-	const hiddenEls = arr.filter( ( crumb ) => crumb.classList.contains( 'hidden' ) );
+	const hiddenEls = arr.filter( ( crumb ) => crumb.classList.contains( 'is-hidden' ) );
 
 	if ( hiddenEls.length ) {
-		hiddenEls[ 0 ].classList.remove( 'hidden' );
+		hiddenEls[ 0 ].classList.remove( 'is-hidden' );
 		return;
 	}
 

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -108,8 +108,6 @@ const expandCrumbs = ( arr, container, breakpoint, finalPartOriginalLength ) => 
 		lastPart.style.width += Math.min( currWidth + pixelToAllocate, finalPartOriginalLength );
 	}
 
-	lastPart.style.width = 'auto';
-
 	/**
 	 * If there are hidden elements, show them first.
 	 */

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -35,12 +35,12 @@ const collapseCrumbs = ( arr, container, breakpoint ) => {
 		}
 
 		const allTruncated =
-			arr.filter( ( crumb ) => crumb.firstChild.classList.contains( 'truncated' ) ).length === arr.length;
+			arr.filter( ( crumb ) => crumb.firstChild.classList.contains( 'is-truncated' ) ).length === arr.length;
 
 		if ( allTruncated ) {
 			arr[ i ].classList.add( 'hidden' );
 		} else {
-			arr[ i ].firstChild.classList.add( 'truncated' );
+			arr[ i ].firstChild.classList.add( 'is-truncated' );
 		}
 	}
 };
@@ -79,7 +79,7 @@ const expandCrumbs = ( arr, container, breakpoint ) => {
 		const anchorElement = arr[ i ].firstChild;
 
 		// We don't need to do anything if the element is already expanded.
-		if ( ! anchorElement.classList.contains( 'truncated' ) ) {
+		if ( ! anchorElement.classList.contains( 'is-truncated' ) ) {
 			continue;
 		}
 
@@ -90,7 +90,7 @@ const expandCrumbs = ( arr, container, breakpoint ) => {
 			return;
 		}
 
-		anchorElement.classList.remove( 'truncated' );
+		anchorElement.classList.remove( 'is-truncated' );
 
 		pixelToAllocate -= spanWidth;
 	}

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -41,12 +41,20 @@ const collapseCrumbs = ( arr, container, breakpoint ) => {
 			arr[ i ].classList.add( 'hidden' );
 		} else {
 			arr[ i ].firstChild.classList.add( 'is-truncated' );
+			arr[ i ].firstChild.firstChild.classList.add( 'screen-reader-text' );
 		}
 	}
 };
 
 /**
  * This function expands the breadcrumbs until the available space is less than the breakpoint.
+ *
+ * The expected html for this to work is:
+ * <span>
+ *     <a href="#" data-title="Breadcrumb Title">
+ *         <span>Text</span>
+ *     </a>
+ * </span>
  *
  * @param {Array<HTMLElement>} arr        List of breadcrumb elements.
  * @param {HTMLElement}        container  Breadcrumb parent container
@@ -85,12 +93,13 @@ const expandCrumbs = ( arr, container, breakpoint ) => {
 
 		const spanWidth = anchorElement.firstChild.getBoundingClientRect().width;
 
-		// If the this item can't fit, wait until it can.
+		// If this item can't fit, wait until it can.
 		if ( spanWidth >= pixelToAllocate ) {
 			return;
 		}
 
 		anchorElement.classList.remove( 'is-truncated' );
+		anchorElement.firstChild.classList.remove( 'screen-reader-text' );
 
 		pixelToAllocate -= spanWidth;
 	}
@@ -125,6 +134,7 @@ const init = () => {
 		prevWindowWidth = window.innerWidth;
 	};
 
+	// Run on init
 	truncate();
 
 	window.addEventListener( 'resize', truncate );

--- a/mu-plugins/blocks/site-breadcrumbs/src/view.js
+++ b/mu-plugins/blocks/site-breadcrumbs/src/view.js
@@ -184,7 +184,7 @@ const init = () => {
 	window.addEventListener( 'resize', () => {
 		clearTimeout( timeout );
 
-		timeout = setTimeout( truncate, 200 );
+		timeout = setTimeout( truncate, 50 );
 	} );
 };
 


### PR DESCRIPTION
Fixes #325 

Building on conversations in https://github.com/WordPress/wporg-showcase-2022/pull/96, this PR attempts to do the following:
- Make the breadcrumb work on mobile
- Apply truncation to reduce the length of the breadcrumb on desktop
- Try to do as much as possible with CSS

I also think there's some work to be done to reduce the length of the crumbs in the data. This hopes to be a fallback in case we keep these surprisingly long crumbs.

# Mobile

The idea here is to keep everything visible but allow it to wrap naturally. In doing so, we do get a broken menu dropdown, we'll need to follow up with a PR to fix that if we agree on this approach.

## Updates crumbs `display` so it stacks on mobile

| Before | After |
| --- | --- |
| ![developer wordpress org_redesign-test_block-editor_how-to-guides_data-basics_4-building-a-create-page-form_ (1)](https://user-images.githubusercontent.com/1657336/222619141-3d620dc9-be4c-4ec5-b272-70df553b371f.png) | <img  src="https://user-images.githubusercontent.com/1657336/222618707-83ee9966-2733-4a2b-a3a1-5a847215b072.png" > |

## Move divider to `::after`

If the separator was an arrow, it would make sense to have them on the left. However, to me at least, the slash as the first character on a line reads weird.

| Before | AFter |
| --- | --- |
|  ![localhost_8888_block-editor_getting-started_devenv_docker-ubuntu_ (1)](https://user-images.githubusercontent.com/1657336/222618703-b337fd3f-f19e-41e7-8983-22abde7e4538.png) | ![localhost_8888_block-editor_getting-started_devenv_docker-ubuntu_](https://user-images.githubusercontent.com/1657336/222618707-83ee9966-2733-4a2b-a3a1-5a847215b072.png) |


# Desktop

The follow rules are applied:
 -  Excluding the last item, truncate the total length of the crumb at `125px` by default and show an ellipsis.
 - Display a maximum of `4` crumbs
   - Truncate crumbs from left to right, starting at `i = 1` and `last - 3`

### Example `5 crumbs`
<img src="https://user-images.githubusercontent.com/1657336/222614110-03087a83-db2a-48e4-a4ce-d4d00153e95a.png" width="500">

### Example `4 crumbs`
<img src="https://user-images.githubusercontent.com/1657336/222614107-f6395dbd-fc83-465f-8616-dd883a1cbedf.png" width="500">


## _Unhiding_ the content on interaction

We want to maintain the ability to see the truncated text. As such, this PR currently displays the full text on hover & focus. 

### Hover (GIF)
![Screen Capture on 2566-03-03 at 11-08-12](https://user-images.githubusercontent.com/1657336/222613807-57172ace-9875-4b38-a1ad-630389b18748.gif)

### Focus (GIF)
![Screen Capture on 2566-03-03 at 11-08-32](https://user-images.githubusercontent.com/1657336/222613801-faf63f82-f574-41cd-b581-b95c1c34232e.gif)

### Problem

There is one problem with the current implementation; since it displays and displaces the content to the right, it sometimes forces the menu to drop down onto a new line. That is not a good experience.

### Example (GIF)
![Screen Capture on 2566-03-03 at 11-19-56](https://user-images.githubusercontent.com/1657336/222615091-4e008814-8e92-4459-afee-755952176e53.gif)

**Options to fix:**
- When we display it, overlay it on top as a tooltip so the underlying menu doesn't move.
- Hide all the items to the right when interacting with a specific crumb
- Use JS to pull the container itself out of the flow temporarily so that when it grows it doesn't affect the menu on the right
- Use JS to truncate other texts to maintain a similar total width

I'm thinking the first option is probably the best one. Does anyone have any thoughts here? 

@ryelle @renintw @adamwoodnz @WordPress/meta-design 



