### PR TITLE
Add class to html to detect js.

### DIFF
--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -1,6 +1,5 @@
 <?php
 namespace WordPressdotorg\MU_Plugins;
-
 use WordPressdotorg\Autoload;
 
 /**

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -1,5 +1,6 @@
 <?php
 namespace WordPressdotorg\MU_Plugins;
+
 use WordPressdotorg\Autoload;
 
 /**
@@ -25,6 +26,7 @@ require_once __DIR__ . '/blocks/screenshot-preview/block.php';
 require_once __DIR__ . '/blocks/site-breadcrumbs/index.php';
 require_once __DIR__ . '/blocks/table-of-contents/index.php';
 require_once __DIR__ . '/global-fonts/index.php';
+require_once __DIR__ . '/no-js/index.php';
 require_once __DIR__ . '/plugin-tweaks/index.php';
 require_once __DIR__ . '/rest-api/index.php';
 require_once __DIR__ . '/skip-to/skip-to.php';

--- a/mu-plugins/no-js/index.php
+++ b/mu-plugins/no-js/index.php
@@ -7,8 +7,8 @@
 namespace WordPressdotorg\MU_Plugins\NO_JS;
 
 // Actions & Filters
-add_filter( 'language_attributes', __NAMESPACE__ . '\add_no_js_class_to_html_tag', 10, 2 );
-add_action( 'wp_head', __NAMESPACE__ . '\add_custom_js' );
+add_filter( 'language_attributes', __NAMESPACE__ . '\add_no_js_tag', 10, 2 );
+add_action( 'wp_head', __NAMESPACE__ . '\remove_js_tag' );
 
 /**
  * Add a 'no-js' tag by default.

--- a/mu-plugins/no-js/index.php
+++ b/mu-plugins/no-js/index.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Plugin Name: No-JS
+ * Description: This adds a 'no-js' class and removes it with JS for styling.
+ */
+
+namespace WordPressdotorg\MU_Plugins\NO_JS;
+
+// Actions & Filters
+add_filter( 'language_attributes', __NAMESPACE__ . '\add_no_js_class_to_html_tag', 10, 2 );
+add_action( 'wp_head', __NAMESPACE__ . '\add_custom_js' );
+
+/**
+ * Add a 'no-js' tag by default.
+ *
+ * @param string $output
+ * @param string $doctype
+ * @return string
+ */
+function add_no_js_tag( $output, $doctype ) {
+	if ( 'html' !== $doctype ) {
+		return $output;
+	}
+
+	$output .= ' class="no-js"';
+
+	return $output;
+}
+
+/**
+ * Remove the 'no-js' class from html using JS.
+ */
+function remove_js_tag() {
+	?>
+	<script>
+		document.documentElement.classList.remove('no-js')
+	</script>
+	<?php
+}

--- a/mu-plugins/no-js/index.php
+++ b/mu-plugins/no-js/index.php
@@ -4,7 +4,7 @@
  * Description: This adds a 'no-js' class and removes it with JS for styling.
  */
 
-namespace WordPressdotorg\MU_Plugins\NO_JS;
+namespace WordPressdotorg\MU_Plugins\No_JS;
 
 // Actions & Filters
 add_filter( 'language_attributes', __NAMESPACE__ . '\add_no_js_tag', 10, 2 );


### PR DESCRIPTION
There are a couple of components (chapters, breadcrumb ) that have a flash due to javascript running post initial paint. This PR adds `no-js` to the HTML element and removes it using `js` so we can set up styling to stop the _jank_.

### Use case
The breadcrumbs flash before we are able to calculate how much we need to truncate them. In an only `js` world, we could add a class that obscures them and remove it once we are done calculating. However, if the browser isn't running js, that class would never be removed and the user would never see the breadcrumbs. With the `no-js` class, we can do something like the following:

```
.breadcrumbs {
     opacity: 0;
}

.no-js .breadcrumbs {
   opacity: 1;
}
```

Note: That's just a basic example and probably not the actual solution that would be used.