### PR TITLE
Header & Footer: Use core supports for text, background, and border controls

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -377,7 +377,15 @@ function render_global_header( $attributes = array() ) {
 		$markup = ob_get_clean() . $markup;
 	}
 
-	return $markup;
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array( 'class' => 'global-header wp-block-group' )
+	);
+	return sprintf(
+		'<header %1$s>%2$s</header>%3$s',
+		$wrapper_attributes,
+		$markup,
+		wp_kses_post( render_header_alert_banner() )
+	);
 }
 
 /**
@@ -822,7 +830,6 @@ function render_global_footer( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array( 'class' => 'global-footer wp-block-group' )
 	);
-	// var_dump( $wrapper_attributes );
 	return sprintf(
 		'<footer %1$s>%2$s</footer>',
 		$wrapper_attributes,
@@ -840,7 +847,7 @@ function render_global_footer( $attributes, $content, $block ) {
 function update_block_style_colors( $block ) {
 	if (
 		! empty( $block['blockName'] ) &&
-		'wporg/global-footer' === $block['blockName'] &&
+		in_array( $block['blockName'], [ 'wporg/global-footer', 'wporg/global-header' ], true ) &&
 		! empty( $block['attrs']['style'] )
 	) {
 		if ( 'black-on-white' === $block['attrs']['style'] ) {
@@ -1062,7 +1069,7 @@ function swap_header_search_action( $block_content, $block ) {
 	return $block_content;
 }
 
-/*
+/**
  * Translate the tagline with the necessary text domain.
  */
 function get_cip_text() {
@@ -1074,29 +1081,4 @@ function get_cip_text() {
 	}
 
 	return $translated;
-}
-
-/**
- * Generate the classes based on the selected color scheme.
- *
- * This applies the expected color class using the format of Gutenberg's text
- * and background styles, though the actual colors are applied via CSS custom
- * properties in `_common.scss`.
- */
-function get_container_classes( $color_scheme ) {
-	$classes = ' has-text-color has-background';
-	switch ( $color_scheme ) {
-		case 'white-on-blue':
-			$classes .= ' has-white-color has-blueberry-1-background-color';
-			break;
-		case 'black-on-white':
-			$classes .= ' has-charcoal-2-color has-white-background-color';
-			break;
-		case 'white-on-black':
-		default:
-			$classes .= ' has-white-color has-charcoal-2-background-color';
-			break;
-	}
-
-	return $classes;
 }

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -17,6 +17,7 @@ add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
 add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
 add_filter( 'render_block_core/navigation-link', __NAMESPACE__ . '\swap_submenu_arrow_svg' );
 add_filter( 'render_block_core/search', __NAMESPACE__ . '\swap_header_search_action', 10, 2 );
+add_filter( 'render_block_data', __NAMESPACE__ . '\update_block_style_colors' );
 
 /**
  * Register block types
@@ -828,6 +829,32 @@ function render_global_footer( $attributes, $content, $block ) {
 		$markup,
 	);
 }
+
+/**
+ * Convert the `style` attribute on the footer block to use color settings.
+ *
+ * @param array $block The parsed block data.
+ *
+ * @return array
+ */
+function update_block_style_colors( $block ) {
+	if (
+		! empty( $block['blockName'] ) &&
+		'wporg/global-footer' === $block['blockName'] &&
+		! empty( $block['attrs']['style'] )
+	) {
+		if ( 'black-on-white' === $block['attrs']['style'] ) {
+			$block['attrs']['textColor']       = 'charcoal-2';
+			$block['attrs']['backgroundColor'] = 'white';
+		} elseif ( 'white-on-blue' === $block['attrs']['style'] ) {
+			$block['attrs']['textColor']       = 'white';
+			$block['attrs']['backgroundColor'] = 'blueberry-1';
+		}
+	}
+
+	return $block;
+}
+
 
 /**
  * Localise a `core/navigation-link` block link to point to the Rosetta site resource.

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -784,11 +784,13 @@ function rest_render_global_footer( $request ) {
 /**
  * Render the global footer in a block context.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
- * @return string
+ * @return string Returns the block markup.
  */
-function render_global_footer( $attributes = array() ) {
+function render_global_footer( $attributes, $content, $block ) {
 	remove_inner_group_container();
 
 	if ( is_rosetta_site() ) {
@@ -816,7 +818,15 @@ function render_global_footer( $attributes = array() ) {
 
 	remove_filter( 'render_block_data', __NAMESPACE__ . '\localize_nav_links' );
 
-	return $markup;
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array( 'class' => 'global-footer wp-block-group' )
+	);
+	// var_dump( $wrapper_attributes );
+	return sprintf(
+		'<footer %1$s>%2$s</footer>',
+		$wrapper_attributes,
+		$markup,
+	);
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -371,17 +371,19 @@ function render_global_header( $attributes = array() ) {
 	 *
 	 * API requests also need `<head>` etc so they can get the styles.
 	 */
+	$head_markup = '';
 	if ( ! wp_is_block_theme() || $is_rest_request ) {
 		ob_start();
 		require_once __DIR__ . '/classic-header.php';
-		$markup = ob_get_clean() . $markup;
+		$head_markup = ob_get_clean();
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array( 'class' => 'global-header wp-block-group' )
 	);
 	return sprintf(
-		'<header %1$s>%2$s</header>%3$s',
+		'%1$s<header %2$s>%3$s</header>%4$s',
+		$head_markup,
 		$wrapper_attributes,
 		$markup,
 		wp_kses_post( render_header_alert_banner() )
@@ -819,10 +821,11 @@ function render_global_footer( $attributes, $content, $block ) {
 	$is_rest_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
 
 	// Render the classic markup second, so the `wp_footer()` call will execute callbacks that blocks added.
+	$footer_markup = '';
 	if ( ! wp_is_block_theme() || $is_rest_request ) {
 		ob_start();
 		require_once __DIR__ . '/classic-footer.php';
-		$markup .= ob_get_clean();
+		$footer_markup = ob_get_clean();
 	}
 
 	remove_filter( 'render_block_data', __NAMESPACE__ . '\localize_nav_links' );
@@ -831,9 +834,10 @@ function render_global_footer( $attributes, $content, $block ) {
 		array( 'class' => 'global-footer wp-block-group' )
 	);
 	return sprintf(
-		'<footer %1$s>%2$s</footer>',
+		'<footer %1$s>%2$s</footer>%3$s',
 		$wrapper_attributes,
 		$markup,
+		$footer_markup,
 	);
 }
 

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -13,8 +13,6 @@ defined( 'WPINC' ) || die();
  * @var string $locale_title
  */
 
-$color_scheme = apply_filters( 'wporg_footer_color_scheme', $attributes['style'] );
-
 $container_class = 'global-footer';
 
 $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attributes['textColor'], 'charcoal' ) ?

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -15,113 +15,109 @@ defined( 'WPINC' ) || die();
 
 $color_scheme = apply_filters( 'wporg_footer_color_scheme', $attributes['style'] );
 
-$container_class = 'global-footer ' . get_container_classes( $color_scheme );
+$container_class = 'global-footer';
 
-$code_is_poetry_src = str_contains( $container_class, 'has-charcoal-2-color' ) ?
+$code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attributes['textColor'], 'charcoal' ) ?
 	plugins_url( '/images/code-is-poetry-for-light-bg.svg', __FILE__ ) :
 	'https://s.w.org/style/images/code-is-poetry-for-dark-bg.svg';
 
 ?>
 
+<!-- wp:group {"className":"global-footer__navigation-container"} -->
+<div class="wp-block-group global-footer__navigation-container">
+	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-important","overlayMenu":"never"} -->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'About', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/about/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'News', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/news/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Hosting', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/hosting/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Donate', 'Menu item title', 'wporg' ); ?>","url":"https://wordpressfoundation.org/donate/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Swag', 'Menu item title', 'wporg' ); ?>","url":"https://mercantile.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
+	<!-- /wp:navigation -->
 
-<!-- wp:group {"tagName":"footer","align":"full","className":"<?php echo esc_attr( $container_class ); ?>"} -->
-<footer class="wp-block-group alignfull <?php echo esc_attr( $container_class ); ?>">
-	<!-- wp:group {"className":"global-footer__navigation-container"} -->
-	<div class="wp-block-group global-footer__navigation-container">
-		<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-important","overlayMenu":"never"} -->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'About', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/about/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'News', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/news/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Hosting', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/hosting/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Donate', 'Menu item title', 'wporg' ); ?>","url":"https://wordpressfoundation.org/donate/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Swag', 'Menu item title', 'wporg' ); ?>","url":"https://mercantile.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- /wp:navigation -->
+	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-information","overlayMenu":"never"} -->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Documentation', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/documentation/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Developers', 'Menu item title', 'wporg' ); ?>","url":"https://developer.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Get Involved', 'Menu item title', 'wporg' ); ?>","url":"https://make.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Learn', 'Menu item title', 'wporg' ); ?>","url":"https://learn.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
+	<!-- /wp:navigation -->
 
-		<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-information","overlayMenu":"never"} -->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Documentation', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/documentation/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Developers', 'Menu item title', 'wporg' ); ?>","url":"https://developer.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Get Involved', 'Menu item title', 'wporg' ); ?>","url":"https://make.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Learn', 'Menu item title', 'wporg' ); ?>","url":"https://learn.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- /wp:navigation -->
+	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-resources","overlayMenu":"never"} -->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Showcase', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/showcase/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Plugins', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/plugins/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Themes', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/themes/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Patterns', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/patterns/","kind":"custom","isTopLevelLink":true} /-->
+	<!-- /wp:navigation -->
 
-		<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-resources","overlayMenu":"never"} -->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Showcase', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/showcase/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Plugins', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/plugins/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Themes', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/themes/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Patterns', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/patterns/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- /wp:navigation -->
+	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-community","overlayMenu":"never"} -->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordCamp', 'Menu item title', 'wporg' ); ?>","url":"https://central.wordcamp.org/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordPress.TV', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.tv/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'BuddyPress', 'Menu item title', 'wporg' ); ?>","url":"https://buddypress.org/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'bbPress', 'Menu item title', 'wporg' ); ?>","url":"https://bbpress.org/","kind":"custom","isTopLevelLink":true} /-->
+	<!-- /wp:navigation -->
 
-		<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-community","overlayMenu":"never"} -->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordCamp', 'Menu item title', 'wporg' ); ?>","url":"https://central.wordcamp.org/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordPress.TV', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.tv/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'BuddyPress', 'Menu item title', 'wporg' ); ?>","url":"https://buddypress.org/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'bbPress', 'Menu item title', 'wporg' ); ?>","url":"https://bbpress.org/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- /wp:navigation -->
+	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-external","overlayMenu":"never"} -->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordPress.com', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.com/?ref=wporg-footer","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Matt', 'Menu item title', 'wporg' ); ?>","url":"https://ma.tt/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Privacy', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/about/privacy/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Public Code', 'Menu item title', 'wporg' ); ?>","url":"https://publiccode.eu/","kind":"custom","isTopLevelLink":true} /-->
+	<!-- /wp:navigation -->
+</div> <!-- /wp:group -->
 
-		<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-external","overlayMenu":"never"} -->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordPress.com', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.com/?ref=wporg-footer","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Matt', 'Menu item title', 'wporg' ); ?>","url":"https://ma.tt/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Privacy', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/about/privacy/","kind":"custom","isTopLevelLink":true} /-->
-			<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Public Code', 'Menu item title', 'wporg' ); ?>","url":"https://publiccode.eu/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- /wp:navigation -->
-	</div> <!-- /wp:group -->
-
-	<!-- wp:group {"className":"global-footer__logos-container"} -->
-	<div class="wp-block-group global-footer__logos-container">
-		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false,"justifyContent":"left","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group">
-			<!-- wp:html -->
-			<!-- The design calls for two logos, a small "mark" on mobile/tablet, and the full logo for desktops. -->
-				<figure class="wp-block-image global-footer__wporg-logo-mark">
-					<a href="<?php echo esc_url( get_home_url() ); ?>">
-						<?php require __DIR__ . '/images/w-mark.svg'; ?>
-					</a>
-				</figure>
-
-				<figure class="wp-block-image global-footer__wporg-logo-full">
-					<a href="<?php echo esc_url( get_home_url() ); ?>">
-						<?php require __DIR__ . '/images/wporg-logo.svg'; ?>
-					</a>
-				</figure>
-			<!-- /wp:html -->
-
-			<?php if ( ! empty( $locale_title ) ) : ?>
-			<!-- wp:paragraph {"className":"global-footer__wporg-locale-title"} -->
-			<p class="global-footer__wporg-locale-title">
-				<a href="https://make.wordpress.org/polyglots/teams/">
-					<?php echo esc_html( $locale_title ); ?>
+<!-- wp:group {"className":"global-footer__logos-container"} -->
+<div class="wp-block-group global-footer__logos-container">
+	<!-- wp:group {"layout":{"type":"flex","allowOrientation":false,"justifyContent":"left","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:html -->
+		<!-- The design calls for two logos, a small "mark" on mobile/tablet, and the full logo for desktops. -->
+			<figure class="wp-block-image global-footer__wporg-logo-mark">
+				<a href="<?php echo esc_url( get_home_url() ); ?>">
+					<?php require __DIR__ . '/images/w-mark.svg'; ?>
 				</a>
-			</p>
-			<!-- /wp:paragraph -->
-			<?php endif; ?>
-		</div>
-		<!-- /wp:group -->
+			</figure>
 
-		<!-- wp:social-links {"className":"is-style-logos-only"} -->
-		<ul class="wp-block-social-links is-style-logos-only">
-			<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook","label":"<?php echo esc_html_x( 'Visit our Facebook page', 'Menu item title', 'wporg' ); ?>"} /-->
-			<!-- wp:social-link {"url":"https://twitter.com/WordPress","service":"twitter","label":"<?php echo esc_html_x( 'Visit our Twitter account', 'Menu item title', 'wporg' ); ?>"} /-->
-			<!-- wp:social-link {"url":"https://www.instagram.com/wordpress/","service":"instagram","label":"<?php echo esc_html_x( 'Visit our Instagram account', 'Menu item title', 'wporg' ); ?>"} /-->
-			<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin","label":"<?php echo esc_html_x( 'Visit our LinkedIn account', 'Menu item title', 'wporg' ); ?>"} /-->
-		</ul> <!-- /wp:social-links -->
+			<figure class="wp-block-image global-footer__wporg-logo-full">
+				<a href="<?php echo esc_url( get_home_url() ); ?>">
+					<?php require __DIR__ . '/images/wporg-logo.svg'; ?>
+				</a>
+			</figure>
+		<!-- /wp:html -->
 
-		<?php if ( str_starts_with( get_locale(), 'en_' ) ) : ?>
-			<!-- Use an image so it can have the MrsEaves font. -->
-			<!-- wp:image {"width":188,"height":13,"className":"global-footer__code_is_poetry"} -->
-			<figure class="wp-block-image is-resized global-footer__code_is_poetry">
-				<img
-					src=<?php echo esc_url( $code_is_poetry_src ); ?>
-					alt="<?php echo esc_html_x( 'Code is Poetry', 'Image alt text', 'wporg' ); ?>"
-					width="188"
-					height="13"
-				/>
-			</figure> <!-- /wp:image -->
-
-		<?php else : ?>
-			<!-- Use text so it can be translated. -->
-			<span class="global-footer__code_is_poetry">
-				<?php echo esc_html( get_cip_text() ); ?>
-			</span>
-
+		<?php if ( ! empty( $locale_title ) ) : ?>
+		<!-- wp:paragraph {"className":"global-footer__wporg-locale-title"} -->
+		<p class="global-footer__wporg-locale-title">
+			<a href="https://make.wordpress.org/polyglots/teams/">
+				<?php echo esc_html( $locale_title ); ?>
+			</a>
+		</p>
+		<!-- /wp:paragraph -->
 		<?php endif; ?>
-	</div> <!-- /wp:group -->
-</footer> <!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:social-links {"className":"is-style-logos-only"} -->
+	<ul class="wp-block-social-links is-style-logos-only">
+		<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook","label":"<?php echo esc_html_x( 'Visit our Facebook page', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://twitter.com/WordPress","service":"twitter","label":"<?php echo esc_html_x( 'Visit our Twitter account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://www.instagram.com/wordpress/","service":"instagram","label":"<?php echo esc_html_x( 'Visit our Instagram account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin","label":"<?php echo esc_html_x( 'Visit our LinkedIn account', 'Menu item title', 'wporg' ); ?>"} /-->
+	</ul> <!-- /wp:social-links -->
+
+	<?php if ( str_starts_with( get_locale(), 'en_' ) ) : ?>
+		<!-- Use an image so it can have the MrsEaves font. -->
+		<!-- wp:image {"width":188,"height":13,"className":"global-footer__code_is_poetry"} -->
+		<figure class="wp-block-image is-resized global-footer__code_is_poetry">
+			<img
+				src=<?php echo esc_url( $code_is_poetry_src ); ?>
+				alt="<?php echo esc_html_x( 'Code is Poetry', 'Image alt text', 'wporg' ); ?>"
+				width="188"
+				height="13"
+			/>
+		</figure> <!-- /wp:image -->
+
+	<?php else : ?>
+		<!-- Use text so it can be translated. -->
+		<span class="global-footer__code_is_poetry">
+			<?php echo esc_html( get_cip_text() ); ?>
+		</span>
+
+	<?php endif; ?>
+</div> <!-- /wp:group -->

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\MU_Plugins\Global_Header_Footer\Header;
 
-use function WordPressdotorg\MU_Plugins\Global_Header_Footer\{ get_home_url, get_download_url, get_container_classes, render_header_alert_banner };
+use function WordPressdotorg\MU_Plugins\Global_Header_Footer\{ get_home_url, get_download_url };
 
 defined( 'WPINC' ) || die();
 
@@ -14,15 +14,6 @@ defined( 'WPINC' ) || die();
  * @var string $locale_title
  * @var string $show_search
  */
-
-$container_class = 'global-header';
-if ( ! empty( $locale_title ) ) {
-	$container_class .= ' global-header__has-locale-title';
-}
-
-$color_scheme = apply_filters( 'wporg_header_color_scheme', $attributes['style'] );
-
-$container_class .= get_container_classes( $color_scheme );
 
 $search_args = array(
 	'label' => _x( 'Search', 'button label', 'wporg' ),
@@ -73,55 +64,50 @@ function recursive_menu( $menu_item, $top_level = true ) {
 
 ?>
 
-<!-- wp:group {"tagName":"header","align":"full","className":"<?php echo esc_attr( $container_class ); ?>"} -->
-<header class="wp-block-group alignfull <?php echo esc_attr( $container_class ); ?>">
-	<!-- wp:html -->
-	<figure class="wp-block-image global-header__wporg-logo-mark">
-		<a href="<?php echo esc_url( get_home_url() ); ?>">
-			<?php require __DIR__ . '/images/w-mark.svg'; ?>
-		</a>
-	</figure>
-	<!-- /wp:html -->
+<!-- wp:html -->
+<figure class="wp-block-image global-header__wporg-logo-mark">
+	<a href="<?php echo esc_url( get_home_url() ); ?>">
+		<?php require __DIR__ . '/images/w-mark.svg'; ?>
+	</a>
+</figure>
+<!-- /wp:html -->
 
-	<?php if ( ! empty( $locale_title ) ) : ?>
-	<!-- wp:paragraph {"className":"global-header__wporg-locale-title"} -->
-	<p class="global-header__wporg-locale-title">
-		<span><?php echo esc_html( $locale_title ); ?></span>
-	</p>
-	<!-- /wp:paragraph -->
-	<?php endif; ?>
+<?php if ( ! empty( $locale_title ) ) : ?>
+<!-- wp:paragraph {"className":"global-header__wporg-locale-title"} -->
+<p class="global-header__wporg-locale-title">
+	<span><?php echo esc_html( $locale_title ); ?></span>
+</p>
+<!-- /wp:paragraph -->
+<?php endif; ?>
 
-	<!-- wp:navigation {"className":"global-header__navigation","layout":{"type":"flex","orientation":"horizontal"}} -->
-		<?php
-		/*
-		 * Loop though menu items and create navigation item blocks. Recurses through any submenu items to output dropdowns.
-		 */
-		foreach ( $menu_items as $item ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo recursive_menu( $item );
-		}
-		?>
-	<!-- /wp:navigation -->
+<!-- wp:navigation {"className":"global-header__navigation","layout":{"type":"flex","orientation":"horizontal"}} -->
+	<?php
+	/*
+	* Loop though menu items and create navigation item blocks. Recurses through any submenu items to output dropdowns.
+	*/
+	foreach ( $menu_items as $item ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo recursive_menu( $item );
+	}
+	?>
+<!-- /wp:navigation -->
 
-	<?php if ( $show_search ) : ?>
-	<!--
-		The search block is inside a navigation menu because that provides the exact functionality the design
-		calls for. It also provides a consistent experience with the primary navigation menu, with respect to
-		keyboard navigation, ARIA states, etc. It also saves having to write custom code for all the interactions.
-	-->
-	<!-- wp:navigation {"className":"global-header__search","layout":{"type":"flex","orientation":"vertical"},"overlayMenu":"always"} -->
-		<!-- wp:search <?php echo wp_json_encode( $search_args ); ?> /-->
-	<!-- /wp:navigation -->
-	<?php endif; ?>
+<?php if ( $show_search ) : ?>
+<!--
+	The search block is inside a navigation menu because that provides the exact functionality the design
+	calls for. It also provides a consistent experience with the primary navigation menu, with respect to
+	keyboard navigation, ARIA states, etc. It also saves having to write custom code for all the interactions.
+-->
+<!-- wp:navigation {"className":"global-header__search","layout":{"type":"flex","orientation":"vertical"},"overlayMenu":"always"} -->
+	<!-- wp:search <?php echo wp_json_encode( $search_args ); ?> /-->
+<!-- /wp:navigation -->
+<?php endif; ?>
 
-	<!-- This is the first of two Get WordPress buttons; the other is in the navigation menu.
-		 Two are needed because they have different DOM hierarchies at different breakpoints. -->
-	<!-- wp:group {"className":"global-header__desktop-get-wordpress-container"} -->
-	<div class="global-header__desktop-get-wordpress-container">
-		<a href="<?php echo esc_url( get_download_url() ); ?>" class="global-header__desktop-get-wordpress global-header__get-wordpress">
-			<?php echo esc_html_x( 'Get WordPress', 'link anchor text', 'wporg' ); ?>
-		</a>
-	</div> <!-- /wp:group -->
-</header> <!-- /wp:group -->
-
-<?php echo wp_kses_post( render_header_alert_banner() ); ?>
+<!-- This is the first of two Get WordPress buttons; the other is in the navigation menu.
+	Two are needed because they have different DOM hierarchies at different breakpoints. -->
+<!-- wp:group {"className":"global-header__desktop-get-wordpress-container"} -->
+<div class="global-header__desktop-get-wordpress-container">
+	<a href="<?php echo esc_url( get_download_url() ); ?>" class="global-header__desktop-get-wordpress global-header__get-wordpress">
+		<?php echo esc_html_x( 'Get WordPress', 'link anchor text', 'wporg' ); ?>
+	</a>
+</div> <!-- /wp:group -->

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -87,6 +87,10 @@ html {
 	--wp-global-header--link-color: var(--wp--preset--color--charcoal-2);
 	--wp-global-header--link-color--active: var(--wp--preset--color--deep-blueberry);
 	--wp-global-header--text-color: var(--wp--preset--color--charcoal-2);
+
+	&.has-background[style*="background-color:"] {
+		--wp-global-header--background-color--hover: var(--wp--preset--color--light-grey-2);
+	}
 }
 
 .has-blueberry-1-background-color {

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -81,6 +81,8 @@ html {
 	--wp-global-header--text-color: var(--wp--preset--color--white);
 }
 
+.has-charcoal-0-color,
+.has-charcoal-1-color,
 .has-charcoal-2-color {
 	--wp-global-header--link-color: var(--wp--preset--color--charcoal-2);
 	--wp-global-header--link-color--active: var(--wp--preset--color--deep-blueberry);

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -16,6 +16,7 @@ html {
 	font-size: 21px;
 	height: var(--wp-global-header-height);
 	padding: 0;
+	box-sizing: content-box; /* Don't include border in header height. */
 
 	/*
 	 * Some themes set a `z-index` on content elements that follow the header, like `#masthead` in

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -304,13 +304,6 @@
 			background: var(--wp-global-header--background-color--hover);
 		}
 	}
-
-	& .wp-block-navigation__container {
-
-		@media (--tablet) {
-			background: var(--wp-global-header--background-color);
-		}
-	}
 }
 
 /* Gutenberg bug: Close button is not visible in Safari; override it locally */

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -146,10 +146,14 @@
 	}
 }
 
-.wp-block-group.global-header.has-white-background-color .global-header__search .wp-block-search__inside-wrapper {
-	border: 2px solid var(--wp-global-header--text-color);
-}
+.wp-block-group.global-header.has-charcoal-0-color,
+.wp-block-group.global-header.has-charcoal-1-color,
+.wp-block-group.global-header.has-charcoal-2-color {
+	& .global-header__search .wp-block-search__inside-wrapper {
+		border: 2px solid var(--wp-global-header--text-color);
+	}
 
-.wp-block-group.global-header.has-white-background-color .global-header__search .wp-block-navigation__responsive-container-open {
-	background-image: url(../images/search-for-light-bg.svg);
+	& .global-header__search .wp-block-navigation__responsive-container-open {
+		background-image: url(../images/search-for-light-bg.svg);
+	}
 }

--- a/mu-plugins/blocks/global-header-footer/src/footer/block.json
+++ b/mu-plugins/blocks/global-header-footer/src/footer/block.json
@@ -26,13 +26,7 @@
 			"width": true
 		}
 	},
-	"attributes": {
-		"style": {
-			"type": "string",
-			"default": "white-on-black",
-			"enum": [ "white-on-black", "black-on-white", "white-on-blue" ]
-		}
-	},
+	"attributes": {},
 	"textdomain": "wporg",
 	"style": "wporg-global-header-footer",
 	"editorStyle": "wporg-global-header-footer",

--- a/mu-plugins/blocks/global-header-footer/src/footer/block.json
+++ b/mu-plugins/blocks/global-header-footer/src/footer/block.json
@@ -5,6 +5,27 @@
 	"title": "Global Footer",
 	"category": "design",
 	"description": "Global footer for all of WordPress.org",
+	"supports": {
+		"color": {
+			"background": true,
+			"link": false,
+			"text": true
+		},
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"spacing": {
+			"margin": [ "top" ],
+			"padding": false,
+			"blockGap": false
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": false,
+			"style": true,
+			"width": true
+		}
+	},
 	"attributes": {
 		"style": {
 			"type": "string",

--- a/mu-plugins/blocks/global-header-footer/src/footer/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/footer/index.js
@@ -21,7 +21,7 @@ const variations = [
 const Edit = ( { attributes } ) => (
 	<div { ...useBlockProps() }>
 		<Disabled>
-			<ServerSideRender block={ metadata.name } attributes={ attributes } />
+			<ServerSideRender block={ metadata.name } attributes={ attributes } skipBlockSupportAttributes />
 		</Disabled>
 	</div>
 );

--- a/mu-plugins/blocks/global-header-footer/src/footer/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/footer/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import { Disabled } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
 import ServerSideRender from '@wordpress/server-side-render';
@@ -11,12 +10,6 @@ import { useBlockProps } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import metadata from './block.json';
-
-const variations = [
-	{ label: __( 'White on black (default)', 'wporg' ), value: 'white-on-black' },
-	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
-	{ label: __( 'White on blue', 'wporg' ), value: 'white-on-blue' },
-];
 
 const Edit = ( { attributes } ) => (
 	<div { ...useBlockProps() }>

--- a/mu-plugins/blocks/global-header-footer/src/footer/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/footer/index.js
@@ -28,13 +28,4 @@ const Edit = ( { attributes } ) => (
 
 registerBlockType( metadata.name, {
 	edit: Edit,
-
-	variations: variations.map( ( { value, label } ) => ( {
-		name: value,
-		/* translators: %s is the color scheme label. */
-		title: sprintf( __( 'Global Footer: %s', 'wporg' ), label ),
-		isActive: ( blockAttributes, variationAttributes ) => blockAttributes.style === variationAttributes.style,
-		scope: [ 'transform' ],
-		attributes: { style: value },
-	} ) ),
 } );

--- a/mu-plugins/blocks/global-header-footer/src/header/block.json
+++ b/mu-plugins/blocks/global-header-footer/src/header/block.json
@@ -5,13 +5,28 @@
 	"title": "Global Header",
 	"category": "design",
 	"description": "Global header for all of WordPress.org",
-	"attributes": {
-		"style": {
-			"type": "string",
-			"default": "white-on-black",
-			"enum": [ "white-on-black", "black-on-white", "white-on-blue" ]
+	"supports": {
+		"color": {
+			"background": true,
+			"link": false,
+			"text": true
+		},
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"spacing": {
+			"margin": [ "top" ],
+			"padding": false,
+			"blockGap": false
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": false,
+			"style": true,
+			"width": true
 		}
 	},
+	"attributes": {},
 	"textdomain": "wporg",
 	"style": "wporg-global-header-footer",
 	"editorStyle": "wporg-global-header-footer",

--- a/mu-plugins/blocks/global-header-footer/src/header/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/header/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import { Disabled } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
 import ServerSideRender from '@wordpress/server-side-render';
@@ -11,12 +10,6 @@ import { useBlockProps } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import metadata from './block.json';
-
-const variations = [
-	{ label: __( 'White on black (default)', 'wporg' ), value: 'white-on-black' },
-	{ label: __( 'Black on white', 'wporg' ), value: 'black-on-white' },
-	{ label: __( 'White on blue', 'wporg' ), value: 'white-on-blue' },
-];
 
 const Edit = ( { attributes } ) => (
 	<div { ...useBlockProps() }>
@@ -28,13 +21,4 @@ const Edit = ( { attributes } ) => (
 
 registerBlockType( metadata.name, {
 	edit: Edit,
-
-	variations: variations.map( ( { value, label } ) => ( {
-		name: value,
-		/* translators: %s is the color scheme label. */
-		title: sprintf( __( 'Global Header: %s', 'wporg' ), label ),
-		isActive: ( blockAttributes, variationAttributes ) => blockAttributes.style === variationAttributes.style,
-		scope: [ 'transform' ],
-		attributes: { style: value },
-	} ) ),
 } );

--- a/mu-plugins/blocks/global-header-footer/src/header/index.js
+++ b/mu-plugins/blocks/global-header-footer/src/header/index.js
@@ -14,7 +14,7 @@ import metadata from './block.json';
 const Edit = ( { attributes } ) => (
 	<div { ...useBlockProps() }>
 		<Disabled>
-			<ServerSideRender block={ metadata.name } attributes={ attributes } />
+			<ServerSideRender block={ metadata.name } attributes={ attributes } skipBlockSupportAttributes />
 		</Disabled>
 	</div>
 );


### PR DESCRIPTION
Fixes #338, fixes #341 — This enables the core supports for the text color, background color, and border controls on Global Header and Global Footer, replacing the existing "variations" approach for styling. Rather than continuing to add variations for "expressive" sites, we can allow configuration and tweak the CSS as needed.

**Screenshots**

The first three screenshots match the current behavior.

| Variation | Screenshot |
|-----|-----|
| White on black (default) | ![default](https://user-images.githubusercontent.com/541093/224840341-4a1cb860-dffe-4980-a63b-5a8df7462544.png) |
| Black on white | ![black-on-white](https://user-images.githubusercontent.com/541093/224840335-7a97dff9-17db-43ef-ae72-9c39a2dadbf2.png) |
| White on blue | ![white-on-blue](https://user-images.githubusercontent.com/541093/224840345-6e94421c-367d-43ce-a01d-bbe411089729.png) |
| With a border | ![with-borders](https://user-images.githubusercontent.com/541093/224840347-a66d18b8-ea66-4486-a655-2160db369e72.png) |
| Custom background | ![custom-color](https://user-images.githubusercontent.com/541093/224840340-6b8e6f7d-d921-4e7a-a03b-1baaba0406da.png) |

In the editor you can see the new UI

![in-editor](https://user-images.githubusercontent.com/541093/224840344-f35a3c35-a6b2-4853-b69c-ad1b1a0510a0.png)

Custom colors are supported on the header & footer. The footer handles this fine, since there are only two colors involved. Technically you can change the background color of the header to any color too, but the hover states & dropdowns are not smart enough to match arbitrary colors. Currently I've got this falling back to the grey dropdown when the text is a `charcoal`. But even the blue "current" state clashes. If/when we want new colors for the header, we'll need to add some extra CSS.

![custom-color-header](https://user-images.githubusercontent.com/541093/224840337-4222b956-d6be-49ff-85f2-abcf13a03bf7.png)

**To test**

You technically can try this in the site editor, but the blocks themselves are a little wonky. It's easier to test by editing the block in a template file, for example, try any of the following (swap out `header`/`footer`, different colors, etc):

Default
```html
<!-- wp:wporg/global-header /-->
```

Black on white
```html
<!-- wp:wporg/global-header {"backgroundColor":"white","textColor":"charcoal-2"} /-->
```

Black on a custom color
```html
<!-- wp:wporg/global-footer {"textColor":"charcoal-2","style":{"color":{"background":"#6ec9ae"}}} /-->
```

Black on white with a border
```html
<!-- wp:wporg/global-header {"textColor":"charcoal-2","backgroundColor":"white","style":{"border":{"bottom":{"color":"#0000001a","width":"1px","style":"solid"}}}} /-->
```

White on blue (using `style` syntax to ensure back-compat for the sites that are currently using it)
```html
<!-- wp:wporg/global-header {"style":"white-on-blue"} /-->
```

❗  Reviewing note: The changes in `header.php` and `footer.php` look massive, but it's mostly indentation changes because the wrapper element has been moved up to `blocks.php`.