### PR TITLE
Always send POST/PUT/PATCH requests as JSON for compatibility

### DIFF
--- a/mu-plugins/utilities/class-helpscout.php
+++ b/mu-plugins/utilities/class-helpscout.php
@@ -148,10 +148,16 @@ class HelpScout {
 			$url = add_query_arg( $args, $url );
 		}
 
+		$body    = null;
+		$headers = [
+			'Accept'        => 'application/json',
+			'Authorization' => $this->get_auth_string(),
+		];
+
 		// Always send POST/PUT/PATCH requests as JSON.
 		if ( in_array( $method, [ 'POST', 'PUT', 'PATCH' ], true ) && $args ) {
 			$headers['Content-Type'] = 'application/json';
-			$args                    = wp_json_encode( $args );
+			$body                    = wp_json_encode( $args );
 		}
 
 		$request = wp_remote_request(
@@ -160,7 +166,7 @@ class HelpScout {
 				'method'  => $method,
 				'headers' => $headers,
 				'timeout' => $this->timeout,
-				'body'    => ( 'POST' === $method && $args ) ? $args : null,
+				'body'    => $body,
 			)
 		);
 

--- a/mu-plugins/utilities/class-helpscout.php
+++ b/mu-plugins/utilities/class-helpscout.php
@@ -148,14 +148,17 @@ class HelpScout {
 			$url = add_query_arg( $args, $url );
 		}
 
+		// Always send POST/PUT/PATCH requests as JSON.
+		if ( in_array( $method, [ 'POST', 'PUT', 'PATCH' ], true ) && $args ) {
+			$headers['Content-Type'] = 'application/json';
+			$args                    = wp_json_encode( $args );
+		}
+
 		$request = wp_remote_request(
 			$url,
 			array(
 				'method'  => $method,
-				'headers' => [
-					'Accept'        => 'application/json',
-					'Authorization' => $this->get_auth_string(),
-				],
+				'headers' => $headers,
 				'timeout' => $this->timeout,
 				'body'    => ( 'POST' === $method && $args ) ? $args : null,
 			)


### PR DESCRIPTION
While some endpoints accept form-encoded (Default WP_HTTP) some only accept JSON.

_Pending some extra testing_