### PR TITLE
Add a mechanism to only retry on redirect.

### DIFF
--- a/mu-plugins/blocks/screenshot-preview/src/screenshot.js
+++ b/mu-plugins/blocks/screenshot-preview/src/screenshot.js
@@ -123,9 +123,7 @@ function ScreenShotImg( { alt = '', queryString, src, isReady = false } ) {
 	}
 
 	if ( hasError || hasAborted ) {
-		return (
-			<div className="wporg-screenshot wporg-screenshot__has-error">{ __( 'error', 'wporg' ) }</div>
-		);
+		return <div className="wporg-screenshot wporg-screenshot__has-error">{ __( 'error', 'wporg' ) }</div>;
 	}
 
 	return <img src={ base64Img } alt={ alt } />;

--- a/mu-plugins/blocks/screenshot-preview/src/screenshot.js
+++ b/mu-plugins/blocks/screenshot-preview/src/screenshot.js
@@ -91,11 +91,13 @@ function ScreenShotImg( { alt = '', queryString, src, isReady = false } ) {
 				await convertResponseToBase64( res );
 
 				setHasLoaded( true );
+				setShouldRetry( false );
 			} else {
 				setAttempts( attempts + 1 );
 			}
 		} catch ( error ) {
 			setHasError( true );
+			setShouldRetry( false );
 		}
 	};
 

--- a/mu-plugins/blocks/screenshot-preview/src/screenshot.js
+++ b/mu-plugins/blocks/screenshot-preview/src/screenshot.js
@@ -50,9 +50,7 @@ function useInterval( callback, delay ) {
  * @return {Object} React component
  */
 function ScreenShotImg( { alt = '', queryString, src, isReady = false } ) {
-	const fullUrl = `https://s0.wp.com/mshots/v1/${ encodeURIComponent(
-		src
-	) }${ queryString }`;
+	const fullUrl = `https://s0.wp.com/mshots/v1/${ encodeURIComponent( src ) }${ queryString }`;
 
 	const [ attempts, setAttempts ] = useState( 0 );
 	const [ hasLoaded, setHasLoaded ] = useState( false );
@@ -126,9 +124,7 @@ function ScreenShotImg( { alt = '', queryString, src, isReady = false } ) {
 
 	if ( hasError || hasAborted ) {
 		return (
-			<div className="wporg-screenshot wporg-screenshot__has-error">
-				{ __( 'error', 'wporg' ) }
-			</div>
+			<div className="wporg-screenshot wporg-screenshot__has-error">{ __( 'error', 'wporg' ) }</div>
 		);
 	}
 


### PR DESCRIPTION
This PR updates the logic to make sure interval request are only done when the image service has returned a redirect.

### Background
When the image service doesn't have a cached image to serve, it sets `redirected = true` on the request response. In that case, we want to re-request the image. The current code wasn't looking at that signal and instead just re-requesting until loading was finally `false`. On slow connections, the new interval would continually request and sometimes spin up to 10 request for the same resource.

This change also updates the wait time to `2000`. This time makes a bit more sense, it slows down the spamming of the API. We could arguably even go higher but this seemed to _feel_ better for the users.


### How to test
_The screenshot component is compiled into `horizontal-slider`. In order to test, you'll need to replace both the `screenshot-preview` & `horizontal-slider` block on your sandbox._

1. Load these updates in your sandbox.
2. Open chrome dev tools, disable cache, open Network tab
3. Visit https://wordpress.org/themes/quadrat
4. Scroll down, expect to see some network requests, should be about 20
5. Expect the patterns to have loaded
6. Update connection speed to 3g
7. Expect the same amount of network requests (provided the api is still serving the cached version)