### PR TITLE
Navigation: Update focus style, Get WordPress button mobile style

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
@@ -25,8 +25,9 @@
 		&:focus,
 		&:focus-visible,
 		&:focus-within {
-			outline: 1px dashed currentcolor;
-			outline-offset: -2px;
+			outline: none;
+			border-radius: 2px;
+			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
@@ -3,14 +3,14 @@
  */
 
 .wp-block-group.global-header {
-
-	/* This is the `a` on desktop, and the containing `li` on mobile. */
-	& .global-header__get-wordpress {
+	& .global-header__desktop-get-wordpress,
+	& .global-header__mobile-get-wordpress a {
 		background-color: var(--wp--preset--color--blueberry-1) !important; /* Override Gutenberg's !important */
 		color: var(--wp--preset--color--white) !important; /* Override the header color scheme */
 		padding: 10px 19px;
 		border-radius: 2px;
 		font-weight: 700;
+		font-size: var(--wp--preset--font-size--small);
 
 		&:hover {
 			cursor: pointer;
@@ -54,27 +54,15 @@
 
 	/* Mobile - `li` containing `a` */
 	& .wp-block-navigation__container .wp-block-navigation-item.global-header__mobile-get-wordpress {
-		padding: var(--wp--style--block-gap) 65px;
-		margin: 57px var(--wp--style--block-gap) 0 var(--wp--style--block-gap);
-		width: calc(100% - var(--wp--style--block-gap) - var(--wp--style--block-gap));
-		text-align: center;
+		margin-top: calc(var(--wp--style--block-gap) / 2);
+		margin-left: calc(var(--wp--style--block-gap) / 2);
+
+		& a {
+			padding: 10px 19px;
+		}
 
 		@media (--tablet) {
 			display: none;
-		}
-
-		& a {
-			margin: 0 auto;
-			padding: 0;
-			color: inherit;
-
-			&:hover,
-			&:focus,
-			&:focus-visible {
-				background-color: unset;
-				text-decoration: none;
-				outline: none;
-			}
 		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -41,8 +41,9 @@
 		}
 
 		&:focus-visible {
-			outline: 1px dashed currentcolor;
-			outline-offset: -2px;
+			outline: none;
+			border-radius: 2px;
+			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -43,7 +43,7 @@
 		&:focus-visible {
 			outline: none;
 			border-radius: 2px;
-			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
+			box-shadow: inset 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -31,7 +31,7 @@
 		&:focus-visible {
 			outline: none;
 			border-radius: 2px;
-			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
+			box-shadow: inset 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 
@@ -39,7 +39,7 @@
 		&:focus-visible {
 			outline: none;
 			border-radius: 2px;
-			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
+			box-shadow: inset 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 
@@ -149,7 +149,7 @@
 			&:focus-visible {
 				outline: none;
 				border-radius: 2px;
-				box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
+				box-shadow: inset 0 0 0 1.5px var(--wp-global-header--link-color--active);
 			}
 
 			@media (--tablet) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -29,15 +29,17 @@
 		}
 
 		&:focus-visible {
-			outline: 1px dashed currentcolor;
-			outline-offset: -2px;
+			outline: none;
+			border-radius: 2px;
+			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 
 	& .wp-block-navigation__responsive-container-close {
 		&:focus-visible {
-			outline: 1px dashed currentcolor;
-			outline-offset: -2px;
+			outline: none;
+			border-radius: 2px;
+			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 
@@ -69,6 +71,8 @@
 
 			& .wp-block-navigation__responsive-container-content {
 				padding-top: 2em;
+				padding-left: calc(var(--wp--style--block-gap) / 2);
+				padding-right: calc(var(--wp--style--block-gap) / 2);
 			}
 		}
 	}
@@ -95,8 +99,12 @@
 
 			&.current-menu-item:not(.global-header__get-wordpress) {
 				border-left: var(--active-menu-item-border-height) solid var(--wp-global-header--link-color--active);
+				margin-left: calc((var(--wp--style--block-gap) / 2) * -1);
+				padding-left: calc(var(--wp--style--block-gap) / 2 - var(--active-menu-item-border-height));
 
 				@media (--tablet) {
+					margin-left: 0;
+					padding-left: 0;
 					border-bottom: var(--active-menu-item-border-height) solid var(--wp-global-header--link-color--active);
 					border-left: none;
 				}
@@ -127,19 +135,21 @@
 
 		& .wp-block-navigation-item a,
 		& .wp-block-navigation-submenu__toggle {
-			padding-left: var(--wp--style--block-gap);
-			padding-top: calc(var(--wp--style--block-gap) / 2);
-			padding-bottom: calc(var(--wp--style--block-gap) / 2);
-			padding-right: var(--wp--style--block-gap);
+			padding: calc(var(--wp--style--block-gap) / 2);
 
 			&:hover,
 			&:focus {
 				background-color: var(--wp-global-header--background-color--hover);
 			}
 
+			&:focus:not(:hover) {
+				text-decoration: none;
+			}
+
 			&:focus-visible {
-				outline: 1px dashed currentcolor;
-				outline-offset: -2px;
+				outline: none;
+				border-radius: 2px;
+				box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
 			}
 
 			@media (--tablet) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -26,8 +26,9 @@
 		}
 
 		&:focus-visible {
-			outline: 1px dashed currentcolor;
-			outline-offset: -2px;
+			outline: none;
+			border-radius: 2px;
+			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -28,7 +28,7 @@
 		&:focus-visible {
 			outline: none;
 			border-radius: 2px;
-			box-shadow: 0 0 0 1.5px var(--wp-global-header--link-color--active);
+			box-shadow: inset 0 0 0 1.5px var(--wp-global-header--link-color--active);
 		}
 	}
 


### PR DESCRIPTION
Fixes #372, fixes #363. This updates the focus style across the header, and removes the special styling on the mobile "Get WordPress" button.

I'm using the "current item" color for the focus state, which is `--wp--preset--color--blueberry-2` on the black background, `--wp--preset--color--deep-blueberry` on the white background, and `--wp--preset--color--white` on the blue background.

| | Default | Blue bg | White bg |
|---|---|---|---|
| Top level item focus | ![branch-default-1-large-menu-focus](https://user-images.githubusercontent.com/541093/228328732-73be22d4-48f2-424d-a138-e2f1432e3faf.png) | ![branch-blue-1-large-menu-focus](https://user-images.githubusercontent.com/541093/228328710-dee38bd6-1faf-4947-9fef-97ee00c0b386.png) | ![branch-white-1-large-menu-focus](https://user-images.githubusercontent.com/541093/228328748-3802f0fb-3add-4969-9870-751a3b606a38.png) |
| Menu open, submenu item focus | ![branch-default-2-large-menu-open](https://user-images.githubusercontent.com/541093/228328734-71805791-3440-4989-859f-429fc007c60a.png) | ![branch-blue-2-large-menu-open](https://user-images.githubusercontent.com/541093/228328713-a02ff21b-650a-46f9-a33c-82153bbdfe34.png) | ![branch-white-2-large-menu-open](https://user-images.githubusercontent.com/541093/228328753-f8fb333f-1027-4884-8f96-01688695adb3.png) |
| Get WordPress focus | ![branch-default-3-large-button-focus](https://user-images.githubusercontent.com/541093/228328736-f1de8ec6-0a77-46e7-92dc-a92fe1ff1339.png) | ![branch-blue-3-large-button-focus](https://user-images.githubusercontent.com/541093/228328715-c156e87b-5d18-4b94-a8df-ba0914733b1b.png) | ![branch-white-3-large-button-focus](https://user-images.githubusercontent.com/541093/228328756-e0a7248d-07b8-4801-96cd-26abb7e2569b.png) |
| Small screen, logo focus | ![branch-default-4-small-logo-focus](https://user-images.githubusercontent.com/541093/228328738-98644e9b-7a28-4d70-9bed-6cf043472ebd.png) | ![branch-blue-4-small-logo-focus](https://user-images.githubusercontent.com/541093/228328717-87b392ac-3935-4a01-9ee6-ca2add1b1d4e.png) | ![branch-white-4-small-logo-focus](https://user-images.githubusercontent.com/541093/228328760-7101af5a-bcc8-44cc-a0d5-d9284118f319.png) |
| Small screen, menu open, top level item focus | ![branch-default-5-small-menu-top-level](https://user-images.githubusercontent.com/541093/228328740-89d7f10e-177e-4463-b1e8-38528d6e1ba4.png) | ![branch-blue-5-small-menu-top-level](https://user-images.githubusercontent.com/541093/228328721-8f31203c-d3ed-4bab-bf79-130ae6e90a82.png) | ![branch-white-5-small-menu-top-level](https://user-images.githubusercontent.com/541093/228328761-a6c027ef-b550-4e3f-a3f3-ee17c3d61949.png) |
| Small screen, menu open, submenu item focus | ![branch-default-6-small-menu-2nd-level](https://user-images.githubusercontent.com/541093/228328743-6d06f421-3a54-47c1-9dcb-771f7f3e443e.png) | ![branch-blue-6-small-menu-2nd-level](https://user-images.githubusercontent.com/541093/228328728-8899f1f6-e1c8-455b-a986-449acb80f7b9.png) | ![branch-white-6-small-menu-2nd-level](https://user-images.githubusercontent.com/541093/228328762-1d7c47f3-24b0-4442-acd9-998cc2655e2e.png) |

The spacing around the small screen menu items have also been tweaked, but I've kept the highlight at the edge of the screen

<img width="200" src="https://user-images.githubusercontent.com/541093/228360030-dd831f28-423d-43bd-ae7e-2f4a8446abda.png" />
