### PR TITLE
Footer: Align "wordpress.org" baseline with "code is poetry"

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -48,6 +48,8 @@
 
 		@media (--tablet) {
 			display: inline;
+			position: relative;
+			top: -2px; /* Align baseline of "wordpress.org" with baseline of "code is poetry". */
 			margin-bottom: 0;
 		}
 	}
@@ -96,14 +98,7 @@
 				width: 188px;
 				height: 13px;
 				left: calc(50% - (188px / 2)); /* Align horizontally. Width must match width of the image. */
-
-				/*
-				 * Align vertically with W logo and social links.
-				 * This is intentionally not the exact center, since that wouldn't appear perfectly aligned to
-				 * the human eye. It needs to be a little off-center to appear centered.
-				 * Must match the height of the image.
-				 */
-				top: calc(13px / 1.5);
+				top: 6px; /* Align baseline of "code is poetry" with "wordpress.org" logo. */
 			}
 		}
 	}

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/social-links.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/social-links.pcss
@@ -23,7 +23,7 @@
 	}
 
 	& .wp-social-link svg {
-		width: 29px;
-		height: 29px;
+		width: 28px;
+		height: 28px;
 	}
 }


### PR DESCRIPTION
Fixes #362

<img width="1323" alt="Screenshot 2023-03-28 at 3 49 53 PM" src="https://user-images.githubusercontent.com/484068/228384211-1d51ffe6-12c6-4420-a74f-4284e34d827a.png">
