### PR TITLE
Header: Make search icon consistent between desktop and mobile

### DIFF
--- a/mu-plugins/blocks/global-header-footer/images/search-for-light-bg.svg
+++ b/mu-plugins/blocks/global-header-footer/images/search-for-light-bg.svg
@@ -1,4 +1,6 @@
-<svg width="20" height="19" viewBox="0 0 20 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.5 17.5001L7.16667 12.5417" stroke="#1e1e1e" stroke-width="2"/>
-<path d="M18.9168 8.29167C18.9168 12.0426 15.8761 15.0833 12.1252 15.0833C8.37423 15.0833 5.3335 12.0426 5.3335 8.29167C5.3335 4.54073 8.37423 1.5 12.1252 1.5C15.8761 1.5 18.9168 4.54073 18.9168 8.29167Z" stroke="#1e1e1e" stroke-width="2"/>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="enable-background:new 0 0 24 24" viewBox="0 0 24 24">
+	<path
+		d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z"
+		style="fill-rule:evenodd;clip-rule:evenodd;fill:#1e1e1e"
+	/>
 </svg>

--- a/mu-plugins/blocks/global-header-footer/images/search.svg
+++ b/mu-plugins/blocks/global-header-footer/images/search.svg
@@ -1,4 +1,6 @@
-<svg width="20" height="19" viewBox="0 0 20 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.5 17.5001L7.16667 12.5417" stroke="white" stroke-width="2"/>
-<path d="M18.9168 8.29167C18.9168 12.0426 15.8761 15.0833 12.1252 15.0833C8.37423 15.0833 5.3335 12.0426 5.3335 8.29167C5.3335 4.54073 8.37423 1.5 12.1252 1.5C15.8761 1.5 18.9168 4.54073 18.9168 8.29167Z" stroke="white" stroke-width="2"/>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="enable-background:new 0 0 24 24" viewBox="0 0 24 24">
+	<path
+		d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z"
+		style="fill-rule:evenodd;clip-rule:evenodd;fill:white"
+	/>
 </svg>

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -38,7 +38,7 @@
 		height: 24px;
 		background-image: url(../images/search.svg);
 		background-repeat: no-repeat;
-		background-size: 17px 17px;
+		background-size: 24px 24px;
 		background-position: center;
 
 		&:hover,

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -38,12 +38,8 @@
 		height: 24px;
 		background-image: url(../images/search.svg);
 		background-repeat: no-repeat;
-		background-position: top 20px left var(--wp--style--block-gap);
-
-		@media (--tablet) {
-			background-size: 17px 17px;
-			background-position: center;
-		}
+		background-size: 17px 17px;
+		background-position: center;
 
 		&:hover,
 		&:focus {


### PR DESCRIPTION
Fixes #369

This keeps the desktop styles, and makes the mobile icon smaller and center-positioned. I think the size is correct, but I'm not sure what the precise alignment should be. Let me know if you'd like changes.

<img width="648" alt="Screenshot 2023-03-28 at 4 22 10 PM" src="https://user-images.githubusercontent.com/484068/228388515-8ebbe7d9-a7e1-4647-9ad2-c93e820cb5c8.png">
