### PR TITLE
Header: Add background to logo on hover

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -40,10 +40,15 @@
 			padding-top: 16px;
 		}
 
+		&:hover {
+			background-color: var(--wp-global-header--background-color--hover);
+		}
+
 		&:focus-visible {
 			outline: none;
 			border-radius: 2px;
 			box-shadow: inset 0 0 0 1.5px var(--wp-global-header--link-color--active);
+			background-color: var(--wp-global-header--background-color--hover);
 		}
 	}
 


### PR DESCRIPTION
Fixes #366 — Add the hover color behind the logo.

| Default | Blue | White | Classic |
|---|---|---|---|
| ![branch-default-1](https://user-images.githubusercontent.com/541093/228882024-0766e529-97df-4f4a-907b-e48be3b3d9ff.png) | ![branch-blue-1](https://user-images.githubusercontent.com/541093/228882016-1de1e58f-9f21-4906-87ec-90c8b3a8e564.png) | ![branch-white-1](https://user-images.githubusercontent.com/541093/228882038-eeec866a-9e5b-4f6b-a2a6-423785c4e1e1.png) | ![branch-old-1](https://user-images.githubusercontent.com/541093/228882031-f7b9f284-edbd-460d-8506-60e1c47f2b1b.png) |
| ![branch-default-2](https://user-images.githubusercontent.com/541093/228882028-c5fc63c1-8ec6-4b2f-8b08-209b8b9eda1f.png) | ![branch-blue-2](https://user-images.githubusercontent.com/541093/228882023-e41c7548-3e05-4ae7-afcf-85428ce70151.png) | ![branch-white-2](https://user-images.githubusercontent.com/541093/228882041-1e4ee90f-4eec-4e4e-95e0-ca10a6014996.png) | ![branch-old-2](https://user-images.githubusercontent.com/541093/228882034-221693c6-ccf7-4006-8314-5b65788c4674.png) |