### PR TITLE
Header: Add cachebuster to search icons.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -36,7 +36,7 @@
 		box-sizing: content-box;
 		width: 24px;
 		height: 24px;
-		background-image: url(../images/search.svg);
+		background-image: url(../images/search.svg?ver=96c7098);
 		background-repeat: no-repeat;
 		background-size: 24px 24px;
 		background-position: center;
@@ -151,6 +151,6 @@
 	}
 
 	& .global-header__search .wp-block-navigation__responsive-container-open {
-		background-image: url(../images/search-for-light-bg.svg);
+		background-image: url(../images/search-for-light-bg.svg?ver=96c7098);
 	}
 }


### PR DESCRIPTION
The old images appear to be permanently cached on production, even when not being pulled via the CDN. This is a temporary fix until I can track down and fix the root cause.

See #375
