### PR TITLE
Prevent scrolling behind search modal - Alternate

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -10,6 +10,7 @@
  */
 
 /* Breakpoints should be synced with `wporg-parent-2021` (or `wporg-news-2021` until parent exists). */
+@custom-media --mobile-only (max-width: 879px);
 @custom-media --tablet (min-width: 890px);
 @custom-media --desktop (min-width: 1152px);
 @custom-media --desktop-wide (min-width: 1440px);
@@ -42,6 +43,7 @@ html {
 .global-header,
 .global-header__alert-banner,
 .global-footer,
+html.has-modal-open body:not(.admin-bar),
 #wpadminbar {
 	--wp--preset--font-family--eb-garamond: "EB Garamond", serif;
 	--wp--preset--font-family--inter: "Inter", sans-serif;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -10,22 +10,67 @@ html {
 	}
 }
 
+/*
+ * Fix iOS Safari scrolling bug. These styles have no other purpose.
+ * @link https://github.com/WordPress/wporg-mu-plugins/issues/371.
+ */
 html.has-modal-open {
-	position: fixed; /* hotfix for https://github.com/WordPress/gutenberg/pull/49369/ */
+	/* Override https://github.com/WordPress/gutenberg/pull/49369/ on other non-mobile breakpoints to avoid gap on right side of search modal. */
+	position: static;
 
+	@media (--mobile-only) {
+		/*position: fixed;*/ /* hotfix for https://github.com/WordPress/gutenberg/pull/49369/. remove when in stable release. */
+		/* if leave ^ enabled, then there's a gap at the bottom of the page where <main> shows through
+		if disable, then safari scroll a little, but it's not visible above the fold
+		 */
 
-	height: 100vh;
-	overflow: hidden;
+		height: 100lvh;
 
-	& body,
-	& .wp-site-blocks {
-		position: fixed;
-		height: 100vh;
 		overflow: hidden;
-	}
+		/* todo
+		     maybe set bg color grey to override
+		     try dvh height
+		     try setting height less than 100vh
 
-	& #wpadminbar {
-		position: fixed;
+		     add fixed to header in case that helps
+		    */
+
+		& body{
+			/*
+			none necessary
+			position: fixed;
+			height: 100vh;
+			overflow: hidden;*/
+
+			background: var(--wp--preset--color--charcoal-1);
+		}
+
+		& body:not(.admin-bar) {
+			background: var(--wp--preset--color--charcoal-5);
+		}
+
+
+		& .wp-site-blocks {
+			/* all of this necessary */
+			position: fixed;
+			height: 100vh;
+			overflow: hidden;
+		}
+
+		& .wp-block-navigation__responsive-container {
+			/* need to disable overflow vis from search.pcss? */
+
+			height: 100vh;
+
+			/*
+			these not necessary
+			position: fixed;
+			overflow: hidden;*/
+		}
+
+		& #wpadminbar {
+			position: fixed;
+		}
 	}
 }
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -10,6 +10,25 @@ html {
 	}
 }
 
+html.has-modal-open {
+	position: fixed; /* hotfix for https://github.com/WordPress/gutenberg/pull/49369/ */
+
+
+	height: 100vh;
+	overflow: hidden;
+
+	& body,
+	& .wp-site-blocks {
+		position: fixed;
+		height: 100vh;
+		overflow: hidden;
+	}
+
+	& #wpadminbar {
+		position: fixed;
+	}
+}
+
 .wp-block-group.global-header {
 	display: flex;
 	align-items: flex-start;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -15,57 +15,34 @@ html {
  * @link https://github.com/WordPress/wporg-mu-plugins/issues/371.
  */
 html.has-modal-open {
-	/* Override https://github.com/WordPress/gutenberg/pull/49369/ on other non-mobile breakpoints to avoid gap on right side of search modal. */
+	/*
+	 * Hotfix for https://github.com/WordPress/gutenberg/pull/49369/. Otherwise the styles below will break when
+	 * we update. Remove this after we install the update
+	 */
+	position: fixed;
+
+	/*
+	 * Override https://github.com/WordPress/gutenberg/pull/49369/. On desktop views it causes a gap to the right
+	 * of the search modal when it's open.
+	 */
 	position: static;
 
 	@media (--mobile-only) {
-		/*position: fixed;*/ /* hotfix for https://github.com/WordPress/gutenberg/pull/49369/. remove when in stable release. */
-		/* if leave ^ enabled, then there's a gap at the bottom of the page where <main> shows through
-		if disable, then safari scroll a little, but it's not visible above the fold
-		 */
-
 		height: 100lvh;
-
 		overflow: hidden;
-		/* todo
-		     maybe set bg color grey to override
-		     try dvh height
-		     try setting height less than 100vh
-
-		     add fixed to header in case that helps
-		    */
-
-		& body{
-			/*
-			none necessary
-			position: fixed;
-			height: 100vh;
-			overflow: hidden;*/
-
-			background: var(--wp--preset--color--charcoal-1);
-		}
 
 		& body:not(.admin-bar) {
 			background: var(--wp--preset--color--charcoal-5);
 		}
 
-
 		& .wp-site-blocks {
-			/* all of this necessary */
 			position: fixed;
 			height: 100vh;
 			overflow: hidden;
 		}
 
 		& .wp-block-navigation__responsive-container {
-			/* need to disable overflow vis from search.pcss? */
-
 			height: 100vh;
-
-			/*
-			these not necessary
-			position: fixed;
-			overflow: hidden;*/
 		}
 
 		& #wpadminbar {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -9,10 +9,6 @@
 
 	& .wp-block-navigation__responsive-container {
 		overflow: visible;
-
-		&.has-modal-open {
-			height: 100vh; /* this fixes the scrolling below the modal content. still need to fix the scrolling above it */
-		}
 	}
 
 	& .wp-block-navigation__responsive-container-open,

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -9,6 +9,10 @@
 
 	& .wp-block-navigation__responsive-container {
 		overflow: visible;
+
+		&.has-modal-open {
+			height: 100vh; /* this fixes the scrolling below the modal content. still need to fix the scrolling above it */
+		}
 	}
 
 	& .wp-block-navigation__responsive-container-open,


### PR DESCRIPTION
Fixes #371
Closes #381

This is an alternate approach, because applying the hotfix in #381 caused uninteded consequences. Fixing those caused [more problems, which in turn had to be fixed, causing more problems](https://github.com/WordPress/wporg-mu-plugins/pull/381/commits).
