### PR TITLE
Admin Bar: Hide the admin bar for logged out users by default

### DIFF
--- a/mu-plugins/blocks/global-header-footer/admin-bar.php
+++ b/mu-plugins/blocks/global-header-footer/admin-bar.php
@@ -11,39 +11,16 @@ add_action( 'admin_bar_menu', __NAMESPACE__ . '\filter_admin_bar_links', 500 ); 
 add_filter( 'show_admin_bar', __NAMESPACE__ . '\should_show_admin_bar' );
 
 /**
- * Show the admin bar most of the time.
+ * Hide the admin bar for logged out users.
+ *
+ * The admin bar can be shown to logged out users by activating the Logged Out Admin Bar plugin.
  *
  * @param bool $show_admin_bar Whether the admin bar should be shown.
  * @return bool
  */
 function should_show_admin_bar( $show_admin_bar ) {
-	$can_access_admin = is_super_admin() || current_user_can( 'read' );
-
 	// Folks who can access wp-admin should always see the bar, for convenience.
-	if ( $can_access_admin ) {
-		return true;
-	}
-
-	// w.org/showcase visitors are unlikely to have/want an account.
-	// w.org/showcase/submit-a-wordpress-site/ has a login link for that edge case.
-	if ( 718 === get_current_blog_id() ) {
-		return false;
-	}
-
-	$is_download_page = get_permalink() === get_download_url();
-
-	/*
-	 * Visitors are confused by the admin bar on w.org/home and w.org/download, and it generates a large
-	 * number of support requests. Folks mistakenly assume they have to register for a w.org account in
-	 * order to download WP or set up a site.
-	 */
-	if ( 1 === get_current_blog_id() || is_rosetta_site() ) { // 1 is wordpress.org/.
-		if ( is_front_page() || $is_download_page ) {
-			return false;
-		}
-	}
-
-	return true;
+	return is_super_admin() || current_user_can( 'read' );
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/admin-bar.php
+++ b/mu-plugins/blocks/global-header-footer/admin-bar.php
@@ -19,7 +19,6 @@ add_filter( 'show_admin_bar', __NAMESPACE__ . '\should_show_admin_bar' );
  * @return bool
  */
 function should_show_admin_bar( $show_admin_bar ) {
-	// Folks who can access wp-admin should always see the bar, for convenience.
 	return is_super_admin() || current_user_can( 'read' );
 }
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/admin-bar.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/admin-bar.pcss
@@ -1,13 +1,13 @@
 #wpadminbar {
-	--wporg-admin-bar--background-color: var(--wp--preset--color--nero);
-	--wporg-admin-bar--background-color--hover: var(--wp--preset--color--charcoal-2);
+	--wporg-admin-bar--background-color: var(--wp--preset--color--charcoal-2);
+	--wporg-admin-bar--background-color--hover: var(--wp--preset--color--nero);
 
 	--wporg-admin-bar--link-color: var(--wp--preset--color--white);
 	--wporg-admin-bar--link-color--active: var(--wp--preset--color--blueberry-2);
 	--wporg-admin-bar--separator: var(--wp--preset--color--charcoal-3);
 
-	background-color: var(--wp--preset--color--nero);
-	color: var(--wp--preset--color--white);
+	background-color: var(--wporg-admin-bar--background-color);
+	color: var(--wporg-admin-bar--link-color);
 
 	& * {
 		font-family: var(--wp--preset--font-family--inter);


### PR DESCRIPTION
Fixes #355 — Hides the admin bar unless you're logged in and have permissions on the site. Individual sites can override this by activating the Logged Out Admin Bar plugin, which is already active on many sites (see https://github.com/WordPress/wporg-mu-plugins/issues/355#issuecomment-1496286517).

Additionally, this fixes the background color of the admin bar, so that it matches the black version of the header bar.

**Screenshots**

| Small | Large |
|---|---|
| ![Screen Shot 2023-04-04 at 12 53 48](https://user-images.githubusercontent.com/541093/229863214-583975bd-e724-4ab2-a39c-536f7fc1acfb.png) | ![Screen Shot 2023-04-04 at 12 54 00](https://user-images.githubusercontent.com/541093/229863219-fb3e3b74-8913-47fc-b344-d62488cabc79.png) |

**To test**

- Be logged out
- View the /about/ page or any child page
- There should be no admin bar
- Log in
- Reload that page
- Now there is an admin bar

If you test on a sandbox, you will still see the admin bar on the various directories, make.w.org/*, support forums, etc. even when logged out.