### PR TITLE
Menu: Remove section-level menu highlight

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -117,18 +117,14 @@
 				& > button svg {
 					stroke: var(--wp-global-header--link-color--active);
 				}
-
-				& .current-menu-item {
-					border: none;
-				}
 			}
 
 			&.has-child {
 				padding-bottom: 0;
 			}
 
-			& ul .current-menu-item {
-				border-left: none;
+			& ul.wp-block-navigation-submenu .current-menu-item {
+				border-left-color: transparent;
 				border-bottom: none;
 			}
 		}


### PR DESCRIPTION
Fixes #370 — This removes the previous "section" highlights (where a page matching anything in one of the submenu's selections would highlight every level to the top). Now the menu items only highlight when they are an exact match for the current page.

**Screenshots**

| | Large screen | Small screen |
|---|---|---|
| Top level match | ![large-top-level-item](https://user-images.githubusercontent.com/541093/230187344-8599b8bc-5e86-429d-be81-70d3fe8acd15.png) | ![small-top-level](https://user-images.githubusercontent.com/541093/230187349-13c0bff4-5760-4e6c-863e-cc6d44b523d5.png) |
| 2nd level match | ![large-sub-item](https://user-images.githubusercontent.com/541093/230187343-be8ff340-d016-423f-8d79-9555a9bfbd36.png) | ![small-sub-item](https://user-images.githubusercontent.com/541093/230187347-91654d93-e896-404a-b192-86b324313cae.png) |
| 3rd level, no match in menu | ![large-sub-inner](https://user-images.githubusercontent.com/541093/230187341-9cb11aab-aa0e-4aa9-b184-d962f82017e4.png)<br />Single plugin | ![small-sub-inner](https://user-images.githubusercontent.com/541093/230187345-6e9c612e-90d9-4884-88ad-8895447bfe8b.png)<br />About - Accessibility page |

Subpages in News also no longer highlight the "News" item:

![large-news-inner](https://user-images.githubusercontent.com/541093/230187339-6dcf8251-a658-415a-8c40-a2153feb0662.png)

**To test**

Due to how the menu works, you need a sandbox to test this. Just make sure the menu items are correctly highlighted, while not highlighting the top-level items.