### PR TITLE
Plugin Tweaks: Support the Code Syntax Block

### DIFF
--- a/mu-plugins/helpers/helpers.php
+++ b/mu-plugins/helpers/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WordPressdotorg\MU_Plugins\Helpers;
+
 defined( 'WPINC' ) || die();
 
 /**
@@ -21,4 +22,31 @@ function natural_language_join( array $list, $conjunction = 'and' ) : string {
 	}
 
 	return $last;
+}
+
+/**
+ * Check if a plugin is active on the current site.
+ *
+ * Clone of core's `is_plugin_active` and `is_plugin_active_for_network`, so
+ * they can be used on the frontend.
+ *
+ * @param string $plugin Path to the plugin file relative to the plugins directory.
+ * @return bool True, if in the active plugins list. False, not in the list.
+ */
+function is_plugin_active( $plugin ) {
+	// Single-site active.
+	if ( in_array( $plugin, (array) get_option( 'active_plugins', array() ), true ) ) {
+		return true;
+	}
+
+	if ( ! is_multisite() ) {
+		return false;
+	}
+
+	$plugins = get_site_option( 'active_sitewide_plugins' );
+	if ( isset( $plugins[ $plugin ] ) ) {
+		return true;
+	}
+
+	return false;
 }

--- a/mu-plugins/plugin-tweaks/code-syntax-block/index.php
+++ b/mu-plugins/plugin-tweaks/code-syntax-block/index.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Code Syntax Block Tweaks
+ *
+ * Adds support for the shortcodes provided by SyntaxHighlighter Evolved.
+ * This allows the current content (with shortcodes) to use the new design's
+ * syntax highlighting style & behavior.
+ *
+ * Also injects the stylesheet with our custom styles.
+ */
+
+namespace WordPressdotorg\MU_Plugins\Plugin_Tweaks\CodeSyntaxBlock;
+
+use function WordPressdotorg\MU_Plugins\Helpers\is_plugin_active;
+
+add_action( 'init', __NAMESPACE__ . '\maybe_init' );
+add_filter( 'mkaz_code_syntax_force_loading', '__return_true' );
+add_filter( 'mkaz_prism_css_url', __NAMESPACE__ . '\update_prism_css_url' );
+
+/**
+ * Initialize the shortcode replacements only if the Code Syntax Block is active.
+ */
+function maybe_init() {
+	if ( ! is_plugin_active( 'code-syntax-block/index.php' ) ) {
+		return;
+	}
+
+	add_shortcode( 'php', __NAMESPACE__ . '\do_shortcode_php' );
+	add_shortcode( 'js', __NAMESPACE__ . '\do_shortcode_js' );
+	add_shortcode( 'css', __NAMESPACE__ . '\do_shortcode_css' );
+	add_shortcode( 'code', __NAMESPACE__ . '\do_shortcode_code' );
+
+	add_filter(
+		'no_texturize_shortcodes',
+		function ( $shortcodes ) {
+			$shortcodes[] = 'php';
+			$shortcodes[] = 'js';
+			$shortcodes[] = 'css';
+			$shortcodes[] = 'code';
+			return $shortcodes;
+		}
+	);
+}
+
+/**
+ * Customize the syntax highlighter style.
+ * See https://github.com/PrismJS/prism-themes.
+ *
+ * @param string $url Absolute URL of the default CSS file you want to enqueue.
+ * @return string
+ */
+function update_prism_css_url( $url ) {
+	return plugins_url( 'prism.css', __FILE__ );
+}
+
+/**
+ * Render the php shortcode using the Code Syntax Block syntax.
+ *
+ * @param array|string $attr    Shortcode attributes array or empty string.
+ * @param string       $content Shortcode content.
+ * @param string       $tag     Shortcode name.
+ * @return string
+ */
+function do_shortcode_php( $attr, $content, $tag ) {
+	$attr = is_array( $attr ) ? $attr : array();
+	$attr['lang'] = 'php';
+
+	return do_shortcode_code( $attr, $content, $tag );
+}
+
+/**
+ * Render the js shortcode using the Code Syntax Block syntax.
+ *
+ * @param array|string $attr    Shortcode attributes array or empty string.
+ * @param string       $content Shortcode content.
+ * @param string       $tag     Shortcode name.
+ * @return string
+ */
+function do_shortcode_js( $attr, $content, $tag ) {
+	$attr = is_array( $attr ) ? $attr : array();
+	$attr['lang'] = 'js';
+
+	return do_shortcode_code( $attr, $content, $tag );
+}
+
+/**
+ * Render the css shortcode using the Code Syntax Block syntax.
+ *
+ * @param array|string $attr    Shortcode attributes array or empty string.
+ * @param string       $content Shortcode content.
+ * @param string       $tag     Shortcode name.
+ * @return string
+ */
+function do_shortcode_css( $attr, $content, $tag ) {
+	$attr = is_array( $attr ) ? $attr : array();
+	$attr['lang'] = 'css';
+
+	return do_shortcode_code( $attr, $content, $tag );
+}
+
+/**
+ * Render the code shortcode using the Code Syntax Block syntax.
+ *
+ * @param array|string $attr    Shortcode attributes array or empty string.
+ * @param string       $content Shortcode content.
+ * @param string       $tag     Shortcode name.
+ * @return string
+ */
+function do_shortcode_code( $attr, $content, $tag ) {
+	// Use an allowedlist of languages, falling back to PHP.
+	// This should account for all languages used in the handbooks.
+	$lang_list = [ 'js', 'json', 'sh', 'bash', 'html', 'css', 'scss', 'php', 'markdown', 'yaml' ];
+	$lang = in_array( $attr['lang'] ?? '', $lang_list ) ? $attr['lang'] ?? '' : 'php';
+
+	$content = _trim_code( $content );
+	// Hides numbers if <= 4 lines of code (last line has no linebreak).
+	$show_line_numbers = substr_count( $content, "\n" ) > 3;
+
+	// Shell is flagged with `sh` or `bash` in the handbooks, but Prism uses `shell`.
+	if ( 'sh' === $lang || 'bash' === $lang ) {
+		$lang = 'shell';
+	}
+
+	return do_blocks(
+		sprintf(
+			'<!-- wp:code {"lineNumbers":%3$s} --><pre class="wp-block-code"><code lang="%1$s" class="language-%1$s %4$s">%2$s</code></pre><!-- /wp:code -->',
+			$lang,
+			$content,
+			$show_line_numbers ? 'true' : 'false',
+			$show_line_numbers ? 'line-numbers' : ''
+		)
+	);
+}
+
+/**
+ * Trim off any extra space, including initial new lines.
+ * Strip out <br /> and <p> added by WordPress.
+ *
+ * @param string $content Shortcode content.
+ * @return string
+ */
+function _trim_code( $content ) {
+	$content = preg_replace( '/<br \/>/', '', $content );
+	$content = preg_replace( '/<\/p>\s*<p>/', "\n\n", $content );
+	// Trim everything except leading spaces.
+	$content = trim( $content, "\n\r\t\v\x00" );
+	return $content;
+}

--- a/mu-plugins/plugin-tweaks/code-syntax-block/prism.css
+++ b/mu-plugins/plugin-tweaks/code-syntax-block/prism.css
@@ -1,0 +1,246 @@
+/**
+ * Custom theme for developer.wordpress.org.
+ * Forked from a11y-dark theme by ericwbailey, which was based on the okaidia theme.
+ *
+ * https://github.com/PrismJS/prism-themes/blob/master/themes/prism-a11y-dark.css
+ * https://github.com/PrismJS/prism/blob/gh-pages/themes/prism-okaidia.css
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #101517;
+	background: none;
+	font-family: Hack, "Fira Code", Consolas, Menlo, Monaco, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+	transition: height 500ms;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	overflow: auto;
+	border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #f6f7f7;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: 0.1em;
+	border-radius: 0.3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: #007017;
+}
+
+.token.punctuation {
+	color: #50575e;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #043959;
+}
+
+.token.boolean,
+.token.number {
+	color: #101517;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #2271b1;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+	color: #a85f00;
+}
+
+.token.function {
+	color: #b8236d;
+}
+
+.token.keyword {
+	color: #135e96;
+	font-weight: 600;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function-definition {
+	color: #101517;
+}
+
+.token.important,
+.token.bold {
+	font-weight: 700;
+}
+
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+
+@media screen and (-ms-high-contrast: active) {
+	code[class*="language-"],
+	pre[class*="language-"] {
+		color: windowText;
+		background: window;
+	}
+
+	:not(pre) > code[class*="language-"],
+	pre[class*="language-"] {
+		background: window;
+	}
+
+	.token.important {
+		background: highlight;
+		color: window;
+		font-weight: 700;
+	}
+
+	.token.atrule,
+	.token.attr-value,
+	.token.function,
+	.token.keyword,
+	.token.operator,
+	.token.selector {
+		font-weight: 700;
+	}
+
+	.token.attr-value,
+	.token.comment,
+	.token.doctype,
+	.token.function,
+	.token.keyword,
+	.token.operator,
+	.token.property,
+	.token.string {
+		color: highlight;
+	}
+
+	.token.attr-value,
+	.token.url {
+		font-weight: 700;
+	}
+}
+
+/* Line Numbers */
+pre.line-numbers {
+	position: relative;
+	padding-left: 3.8em;
+	counter-reset: linenumber;
+}
+
+pre.line-numbers > code {
+	position: relative;
+}
+
+.line-numbers .line-numbers-rows {
+	position: absolute;
+	pointer-events: none;
+	top: 0;
+	font-size: 100%;
+	left: -3.8em;
+	width: 4em; /* works for line-numbers below 10000 lines */
+	letter-spacing: -1px;
+	border-right: 0;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
+.line-numbers-rows > span {
+	pointer-events: none;
+	display: block;
+	counter-increment: linenumber;
+}
+
+.line-numbers-rows > span::before {
+	content: counter(linenumber);
+	color: #5c6370;
+	display: block;
+	padding-right: 0.8em;
+	text-align: right;
+}
+
+/* Copy button */
+.wp-code-block-button-container {
+	position: sticky;
+	top: calc(var(--wp-global-header-height) + var(--wp-admin--admin-bar--height));
+	z-index: 1;
+	display: flex;
+	justify-content: right;
+	padding: 1rem;
+	background: #fff;
+	border-width: 1px 1px 0;
+	border-style: solid;
+	border-color: #dcdcde;
+	border-top-left-radius: 0.3em;
+	border-top-right-radius: 0.3em;
+}
+
+@media screen and (max-width: 889px) {
+	.wp-code-block-button-container {
+		top: var(--wp-admin--admin-bar--height);
+	}
+}
+
+@media screen and (max-width: 600px) {
+	.wp-code-block-button-container {
+		top: 0;
+	}
+}
+
+.wp-code-block-button-container button {
+	font-size: 1.2rem !important;
+}
+
+.wp-code-block-button-container button + button {
+	margin-left: 0.5em;
+}
+
+.wp-code-block-button-container + pre {
+	margin-top: 0;
+	border-width: 0 1px 1px;
+	border-style: solid;
+	border-color: #dcdcde;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
+}

--- a/mu-plugins/plugin-tweaks/index.php
+++ b/mu-plugins/plugin-tweaks/index.php
@@ -9,5 +9,6 @@ namespace WordPressdotorg\MU_Plugins\Plugin_Tweaks;
 
 defined( 'WPINC' ) || die();
 
-require_once __DIR__ . '/wporg-internal-notes.php';
+require_once __DIR__ . '/code-syntax-block/index.php';
 require_once __DIR__ . '/stream.php';
+require_once __DIR__ . '/wporg-internal-notes.php';


### PR DESCRIPTION
Drafting this, as it isn't necessary anywhere just yet— just something I started on because of https://github.com/WordPress/wporg-documentation-2022/issues/56 (before realizing we hadn't set up Code Syntax Block there). When the redesigns start up again, we can revisit it.

When working on the Developer site, we switched from SyntaxHighlighter Evolved to the Code Syntax Block plugin, with a custom style for the syntax highlight. SyntaxHighlighter also provided some shortcodes, so when that is deactivated, those shortcodes break.

This PR pulls out the code from Developer to support those legacy shortcodes by injecting in the Code block, if Code Syntax Block is active. This allows us to deactivate SyntaxHighlighter Evolved without needing to update all the old content.

This also adds in the custom prism theme, so that we can have a central place for those styles to live.

| Before | After |
|---|---|
| <img width="729" alt="Screenshot 2023-04-07 at 12 32 14 PM" src="https://user-images.githubusercontent.com/541093/230644259-a8746d11-9b31-4718-ad1b-d2f16f696462.png"> | <img width="733" alt="Screenshot 2023-04-07 at 12 31 58 PM" src="https://user-images.githubusercontent.com/541093/230644261-01025f47-b467-4f66-b899-a7db7a4d048a.png"> |
