### PR TITLE
Search: Unhide the label, update placeholder

### DIFF
--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -16,8 +16,8 @@ defined( 'WPINC' ) || die();
  */
 
 $search_args = array(
-	'label' => _x( 'Search in WordPress', 'button label', 'wporg' ),
-	'placeholder' => _x( 'Search WP.org...', 'input field placeholder', 'wporg' ),
+	'label' => _x( 'Search in WordPress.org', 'button label', 'wporg' ),
+	'placeholder' => _x( 'Type to search…', 'input field placeholder', 'wporg' ),
 	'buttonPosition' => 'button-inside',
 	'buttonUseIcon' => true,
 	'formAction' => 'https://wordpress.org/search/do-search.php',

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -83,21 +83,6 @@
 			margin-bottom: calc(var(--wp--custom--form--padding) / 2);
 			font-size: var(--wp--custom--form--typography--font-size);
 			color: var(--wp--custom--form--color--label);
-
-			@media (--tablet) {
-
-				/* See @mixin hide-accessibly in wporg-news-2021 */
-				border: 0;
-				clip: rect(1px, 1px, 1px, 1px);
-				clip-path: inset(50%);
-				height: 1px;
-				margin: -1px;
-				overflow: hidden;
-				padding: 0;
-				position: absolute;
-				width: 1px;
-				word-wrap: normal !important;
-			}
 		}
 
 		& .wp-block-search__inside-wrapper {


### PR DESCRIPTION
Fixes #367 — Update the label and placeholder text in the global search box.

<img width="326" alt="Screenshot 2023-04-10 at 10 58 43 AM" src="https://user-images.githubusercontent.com/541093/230927337-a15f5861-bd88-4de8-b210-ba3561d810a5.png">

More screenshots with slightly incorrect label text here: https://github.com/WordPress/wporg-mu-plugins/issues/367#issuecomment-1500370138

Feedback happening in #367.