### PR TITLE
Add Encryption methods.

### DIFF
--- a/mu-plugins/encryption/class-hiddenstring.php
+++ b/mu-plugins/encryption/class-hiddenstring.php
@@ -1,0 +1,164 @@
+<?php
+namespace WordPressdotorg\MU_Plugins\Encryption;
+/**
+ * Class HiddenString. This is a copy of https://github.com/paragonie/hidden-string without the additional dependencies.
+ *
+ * The purpose of this class is to encapsulate strings and hide their contents
+ * from stack traces should an unhandled exception occur.
+ *
+ * The only things that should be protected:
+ * - Passwords
+ * - Plaintext (before encryption)
+ * - Plaintext (after decryption)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+final class HiddenString
+{
+	/**
+	 * @var string
+	 */
+	protected $internalStringValue = '';
+
+	/**
+	 * Disallow the contents from being accessed via __toString()?
+	 *
+	 * @var bool
+	 */
+	protected $disallowInline = false;
+
+	/**
+	 * Disallow the contents from being accessed via __sleep()?
+	 *
+	 * @var bool
+	 */
+	protected $disallowSerialization = false;
+
+	/**
+	 * HiddenString constructor.
+	 * @param string $value
+	 * @param bool $disallowInline
+	 * @param bool $disallowSerialization
+	 *
+	 * @throws \TypeError
+	 */
+	public function __construct(
+		string $value,
+		bool $disallowInline = true,
+		bool $disallowSerialization = true
+	) {
+		$this->internalStringValue = self::safeStrcpy($value);
+		$this->disallowInline = $disallowInline;
+		$this->disallowSerialization = $disallowSerialization;
+	}
+
+	/**
+	 * @param HiddenString $other
+	 * @return bool
+	 * @throws \TypeError
+	 */
+	public function equals(HiddenString $other)
+	{
+		return \hash_equals(
+			$this->getString(),
+			$other->getString()
+		);
+	}
+
+	/**
+	 * Hide its internal state from var_dump()
+	 *
+	 * @return array
+	 */
+	public function __debugInfo()
+	{
+		return [
+			'internalStringValue' =>
+				'*',
+			'attention' =>
+				'If you need the value of a HiddenString, ' .
+				'invoke getString() instead of dumping it.'
+		];
+	}
+
+	/**
+	 * Wipe it from memory after it's been used.
+	 * @return void
+	 */
+	public function __destruct()
+	{
+		if (\is_callable('\sodium_memzero')) {
+			try {
+				\sodium_memzero($this->internalStringValue);
+				return;
+			} catch (\Throwable $ex) {
+			}
+		}
+	}
+
+	/**
+	 * Explicit invocation -- get the raw string value
+	 *
+	 * @return string
+	 * @throws \TypeError
+	 */
+	public function getString(): string
+	{
+		return self::safeStrcpy($this->internalStringValue);
+	}
+
+	/**
+	 * Returns a copy of the string's internal value, which should be zeroed.
+	 * Optionally, it can return an empty string.
+	 *
+	 * @return string
+	 * @throws \TypeError
+	 */
+	public function __toString(): string
+	{
+		if (!$this->disallowInline) {
+			return self::safeStrcpy($this->internalStringValue);
+		}
+		return '';
+	}
+
+	/**
+	 * @return array
+	 */
+	public function __sleep(): array
+	{
+		if (!$this->disallowSerialization) {
+			return [
+				'internalStringValue',
+				'disallowInline',
+				'disallowSerialization'
+			];
+		}
+		return [];
+	}
+
+	/**
+	 * PHP 7 uses interned strings. We don't want altering this one to alter
+	 * the original string.
+	 *
+	 * @param string $string
+	 * @return string
+	 * @throws \TypeError
+	 */
+	public static function safeStrcpy(string $string): string
+	{
+		$length = mb_strlen($string, '8bit');
+		$return = '';
+		/** @var int $chunk */
+		$chunk = $length >> 1;
+		if ($chunk < 1) {
+			$chunk = 1;
+		}
+		for ($i = 0; $i < $length; $i += $chunk) {
+			$return .= mb_substr($string, $i, $chunk, '8bit');
+		}
+		return $return;
+	}
+}

--- a/mu-plugins/encryption/class-hiddenstring.php
+++ b/mu-plugins/encryption/class-hiddenstring.php
@@ -45,6 +45,7 @@ final class HiddenString
 	 * @throws \TypeError
 	 */
 	public function __construct(
+		#[\SensitiveParameter]
 		string $value,
 		bool $disallowInline = true,
 		bool $disallowSerialization = true

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -37,7 +37,7 @@ function wporg_encrypt( $value, string $context, string $key_name = '' ) {
  * @param string $value    The encrypted value.
  * @param string $context  Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
  * @param string $key_name The name of the key to use for decryption. Optional.
- * @return string|false The decrypted value, or false on error.
+ * @return HiddenString|false The decrypted value stored within a HiddenString instance, or false on error.
  */
 function wporg_decrypt( string $value, string $context, string $key_name = '' ) {
 	try {
@@ -52,7 +52,7 @@ function wporg_decrypt( string $value, string $context, string $key_name = '' ) 
 /**
  * Determine if a value is encrypted.
  *
- * @param string $value The value to check.
+ * @param HiddenString|string $value The value to check.
  * @return bool True if the value is encrypted, false otherwise.
  */
 function wporg_is_encrypted( string $value ) : bool {

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -8,23 +8,6 @@ use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
  */
 
 /**
- * Encrypt a value.
- *
- * Unlike the Encryption plugin, this function simply returns false for any errors.
- *
- * @param string $value The plaintext value.
- * @param string $key   The key to use for encryption. Optional.
- * @return string|false The encrypted value, or false on error.
- */
-function wporg_encrypt( string $value, string $key = '' ) {
-	try {
-		return \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, '', $key );
-	} catch ( Exception $e ) {
-		return false;
-	}
-}
-
-/**
  * Encrypt a value, with authentication.
  *
  * Unlike the Encryption plugin, this function simply returns false for any errors.
@@ -34,29 +17,9 @@ function wporg_encrypt( string $value, string $key = '' ) {
  * @param string $key   The key to use for encryption. Optional.
  * @return string|false The encrypted value, or false on error.
  */
-function wporg_authenticated_encrypt( string $value, string $additional_data = '', string $key = '' ) {
+function wporg_encrypt( $value, string $additional_data, string $key = '' ) {
 	try {
 		return \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $additional_data, $key );
-	} catch ( Exception $e ) {
-		return false;
-	}
-}
-
-/**
- * Decrypt a value.
- *
- * Unlike the Encryption plugin, this function simply returns false for any errors, and
- * HiddenStrings that can be cast to string as needed.
- *
- * @param string $value The encrypted value.
- * @param string $key   The key to use for decryption. Optional.
- * @return string|false The decrypted value, or false on error.
- */
-function wporg_decrypt( string $value, string $key = '' ) {
-	try {
-		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, '', $key );
-
-		return new HiddenString( $value->getString(), false );
 	} catch ( Exception $e ) {
 		return false;
 	}
@@ -73,7 +36,7 @@ function wporg_decrypt( string $value, string $key = '' ) {
  * @param string $key   The key to use for decryption. Optional.
  * @return string|false The decrypted value, or false on error.
  */
-function wporg_authenticated_decrypt( string $value, string $additional_data = '', string $key = '' ) {
+function wporg_decrypt( string $value, string $additional_data, string $key = '' ) {
 	try {
 		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, $additional_data, $key );
 

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -5,6 +5,9 @@ use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
  *
  * It provides a wrapper around the libsodium's Authenticated Encryption with
  * Additional Data ciphers (AEAD with XChaCha20-Poly1305)
+ *
+ * NOTE: $context should always be passed, and should either be set to the stringy User ID, or a unique-per-item string.
+ *       The context is not stored within the Encrypted data, but is used to validate that the value is being decrypted in the same context.
  */
 
 /**
@@ -12,14 +15,14 @@ use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
  *
  * Unlike the Encryption plugin, this function simply returns false for any errors.
  *
- * @param string $value The plaintext value.
- * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
- * @param string $key   The key to use for encryption. Optional.
+ * @param string $value   The plaintext value.
+ * @param string $context Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+ * @param string $key     The key to use for encryption. Optional.
  * @return string|false The encrypted value, or false on error.
  */
-function wporg_encrypt( $value, string $additional_data, string $key = '' ) {
+function wporg_encrypt( $value, string $context, string $key = '' ) {
 	try {
-		return \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $additional_data, $key );
+		return \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $context, $key );
 	} catch ( Exception $e ) {
 		return false;
 	}
@@ -31,14 +34,14 @@ function wporg_encrypt( $value, string $additional_data, string $key = '' ) {
  * Unlike the Encryption plugin, this function simply returns false for any errors, and
  * HiddenStrings that can be cast to string as needed.
  *
- * @param string $value The encrypted value.
- * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
- * @param string $key   The key to use for decryption. Optional.
+ * @param string $value   The encrypted value.
+ * @param string $context Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+ * @param string $key     The key to use for decryption. Optional.
  * @return string|false The decrypted value, or false on error.
  */
-function wporg_decrypt( string $value, string $additional_data, string $key = '' ) {
+function wporg_decrypt( string $value, string $context, string $key = '' ) {
 	try {
-		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, $additional_data, $key );
+		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, $context, $key );
 
 		return new HiddenString( $value->getString(), false );
 	} catch ( Exception $e ) {

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -15,14 +15,14 @@ use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
  *
  * Unlike the Encryption plugin, this function simply returns false for any errors.
  *
- * @param string $value   The plaintext value.
- * @param string $context Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
- * @param string $key     The key to use for encryption. Optional.
+ * @param string $value    The plaintext value.
+ * @param string $context  Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+ * @param string $key_name The name of the key to use for encryption. Optional.
  * @return string|false The encrypted value, or false on error.
  */
-function wporg_encrypt( $value, string $context, string $key = '' ) {
+function wporg_encrypt( $value, string $context, string $key_name = '' ) {
 	try {
-		return \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $context, $key );
+		return \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $context, $key_name );
 	} catch ( Exception $e ) {
 		return false;
 	}
@@ -34,14 +34,14 @@ function wporg_encrypt( $value, string $context, string $key = '' ) {
  * Unlike the Encryption plugin, this function simply returns false for any errors, and
  * HiddenStrings that can be cast to string as needed.
  *
- * @param string $value   The encrypted value.
- * @param string $context Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
- * @param string $key     The key to use for decryption. Optional.
+ * @param string $value    The encrypted value.
+ * @param string $context  Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+ * @param string $key_name The name of the key to use for decryption. Optional.
  * @return string|false The decrypted value, or false on error.
  */
-function wporg_decrypt( string $value, string $context, string $key = '' ) {
+function wporg_decrypt( string $value, string $context, string $key_name = '' ) {
 	try {
-		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, $context, $key );
+		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, $context, $key_name );
 
 		return new HiddenString( $value->getString(), false );
 	} catch ( Exception $e ) {

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -93,9 +93,8 @@ function wporg_authenticated_decrypt( string $value, string $additional_data = '
  * Determine if a value is encrypted.
  *
  * @param string $value The value to check.
- * @param string $key   Check if it uses this key. Optional. If not specified, it only validates that it's encrypted.
  * @return bool True if the value is encrypted, false otherwise.
  */
-function wporg_is_encrypted( string $value, string $key = '' ) : bool {
-	return \WordPressdotorg\MU_Plugins\Encryption\is_encrypted( $value, $key );
+function wporg_is_encrypted( string $value ) : bool {
+	return \WordPressdotorg\MU_Plugins\Encryption\is_encrypted( $value );
 }

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -2,6 +2,9 @@
 use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
 /**
  * This file contains globally-exported function names for the Encryption plugin.
+ *
+ * It provides a wrapper around the libsodium's Authenticated Encryption with
+ * Additional Data ciphers (AEAD with XChaCha20-Poly1305)
  */
 
 /**
@@ -25,6 +28,27 @@ function wporg_encrypt( string $value, string $key = '' ) {
 }
 
 /**
+ * Encrypt a value, with authentication.
+ *
+ * Unlike the Encryption plugin, this function simply returns false for any errors, and
+ * HiddenStrings that can be cast to string as needed.
+ *
+ * @param string $value The plaintext value.
+ * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
+ * @param string $key   The key to use for encryption. Optional.
+ * @return string|false The encrypted value, or false on error.
+ */
+function wporg_authenticated_encrypt( string $value, string $additional_data = '',string $key = '' ) {
+	try {
+		$value = \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $additional_data, $key );
+
+		return new HiddenString( $value->getString(), false );
+	} catch ( Exception $e ) {
+		return false;
+	}
+}
+
+/**
  * Decrypt a value.
  *
  * Unlike the Encryption plugin, this function simply returns false for any errors, and
@@ -37,6 +61,27 @@ function wporg_encrypt( string $value, string $key = '' ) {
 function wporg_decrypt( string $value, string $key = '' ) {
 	try {
 		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, '', $key );
+
+		return new HiddenString( $value->getString(), false );
+	} catch ( Exception $e ) {
+		return false;
+	}
+}
+
+/**
+ * Decrypt a value, with authentication.
+ *
+ * Unlike the Encryption plugin, this function simply returns false for any errors, and
+ * HiddenStrings that can be cast to string as needed.
+ *
+ * @param string $value The encrypted value.
+ * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
+ * @param string $key   The key to use for decryption. Optional.
+ * @return string|false The decrypted value, or false on error.
+ */
+function wporg_authenticated_decrypt( string $value, string $additional_data = '', string $key = '' ) {
+	try {
+		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, $additional_data, $key );
 
 		return new HiddenString( $value->getString(), false );
 	} catch ( Exception $e ) {

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -10,8 +10,7 @@ use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
 /**
  * Encrypt a value.
  *
- * Unlike the Encryption plugin, this function simply returns false for any errors, and
- * HiddenStrings that can be cast to string as needed.
+ * Unlike the Encryption plugin, this function simply returns false for any errors.
  *
  * @param string $value The plaintext value.
  * @param string $key   The key to use for encryption. Optional.
@@ -19,9 +18,7 @@ use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
  */
 function wporg_encrypt( string $value, string $key = '' ) {
 	try {
-		$value = \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, '', $key );
-
-		return new HiddenString( $value->getString(), false );
+		return \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, '', $key );
 	} catch ( Exception $e ) {
 		return false;
 	}
@@ -30,8 +27,7 @@ function wporg_encrypt( string $value, string $key = '' ) {
 /**
  * Encrypt a value, with authentication.
  *
- * Unlike the Encryption plugin, this function simply returns false for any errors, and
- * HiddenStrings that can be cast to string as needed.
+ * Unlike the Encryption plugin, this function simply returns false for any errors.
  *
  * @param string $value The plaintext value.
  * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
@@ -40,9 +36,7 @@ function wporg_encrypt( string $value, string $key = '' ) {
  */
 function wporg_authenticated_encrypt( string $value, string $additional_data = '', string $key = '' ) {
 	try {
-		$value = \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $additional_data, $key );
-
-		return new HiddenString( $value->getString(), false );
+		return \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $additional_data, $key );
 	} catch ( Exception $e ) {
 		return false;
 	}

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -1,0 +1,56 @@
+<?php
+use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
+/**
+ * This file contains globally-exported function names for the Encryption plugin.
+ */
+
+/**
+ * Encrypt a value.
+ *
+ * Unlike the Encryption plugin, this function simply returns false for any errors, and
+ * HiddenStrings that can be cast to string as needed.
+ *
+ * @param string $value The plaintext value.
+ * @param string $key   The key to use for encryption. Optional.
+ * @return string|false The encrypted value, or false on error.
+ */
+function wporg_encrypt( string $value, string $key = '' ) {
+	try {
+		$value = \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, '', $key );
+
+		return new HiddenString( $value->getString(), false );
+	} catch ( Exception $e ) {
+		return false;
+	}
+}
+
+/**
+ * Decrypt a value.
+ *
+ * Unlike the Encryption plugin, this function simply returns false for any errors, and
+ * HiddenStrings that can be cast to string as needed.
+ *
+ * @param string $value The encrypted value.
+ * @param string $key   The key to use for decryption. Optional.
+ * @return string|false The decrypted value, or false on error.
+ */
+function wporg_decrypt( string $value, string $key = '' ) {
+	try {
+		$value = \WordPressdotorg\MU_Plugins\Encryption\decrypt( $value, '', $key );
+
+		return new HiddenString( $value->getString(), false );
+	} catch ( Exception $e ) {
+		return false;
+	}
+}
+
+/**
+ * Determine if a value is encrypted.
+ *
+ * @param string $value The value to check.
+ * @param string $key   Check if it uses this key. Optional. If not specified, it only validates that it's encrypted.
+ * @return bool True if the value is encrypted, false otherwise.
+ */
+function wporg_is_encrypted( string $value, string $key = '' ) : bool {
+	return \WordPressdotorg\MU_Plugins\Encryption\is_encrypted( $value, $key );
+}

--- a/mu-plugins/encryption/exports.php
+++ b/mu-plugins/encryption/exports.php
@@ -38,7 +38,7 @@ function wporg_encrypt( string $value, string $key = '' ) {
  * @param string $key   The key to use for encryption. Optional.
  * @return string|false The encrypted value, or false on error.
  */
-function wporg_authenticated_encrypt( string $value, string $additional_data = '',string $key = '' ) {
+function wporg_authenticated_encrypt( string $value, string $additional_data = '', string $key = '' ) {
 	try {
 		$value = \WordPressdotorg\MU_Plugins\Encryption\encrypt( $value, $additional_data, $key );
 

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -34,19 +34,19 @@ const NONCE_LENGTH = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES;
 /**
  * Encrypt a value.
  *
- * @param string $value           Value to encrypt.
- * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
- * @param string $key             Key to use for encryption. Optional.
+ * @param string $value   Value to encrypt.
+ * @param string $context Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+ * @param string $key     Key to use for encryption. Optional.
  * @return string Encrypted value, exceptions thrown on error.
  */
-function encrypt( $value, string $additional_data, string $key = '' ) {
+function encrypt( $value, string $context, string $key = '' ) {
 	$nonce = random_bytes( NONCE_LENGTH );
 	if ( ! $nonce ) {
 		throw new Exception( 'Unable to create a nonce.' );
 	}
 
-	if ( empty( $additional_data ) ) {
-		throw new Exception( '$additional_data cannot be empty.' );
+	if ( empty( $context ) ) {
+		throw new Exception( '$context cannot be empty.' );
 	}
 
 	if ( $value instanceOf HiddenString ) {
@@ -54,7 +54,7 @@ function encrypt( $value, string $additional_data, string $key = '' ) {
 	}
 
 	$key       = get_encryption_key( $key );
-	$encrypted = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt( $value, $additional_data, $nonce, $key->getString() );
+	$encrypted = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt( $value, $context, $nonce, $key->getString() );
 
 	sodium_memzero( $value );
 
@@ -64,12 +64,12 @@ function encrypt( $value, string $additional_data, string $key = '' ) {
 /**
  * Decrypt a value.
  *
- * @param string $value           Value to decrypt.
- * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
- * @param string $key             Key to use for decryption. Optional.
+ * @param string $value   Value to decrypt.
+ * @param string $context Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext.
+ * @param string $key     Key to use for decryption. Optional.
  * @return HiddenString Decrypted value.
  */
-function decrypt( $value, string $additional_data, string $key = '' ) : HiddenString {
+function decrypt( $value, string $context, string $key = '' ) : HiddenString {
 	if ( $value instanceOf HiddenString ) {
 		$value = $value->getString();
 	}
@@ -89,7 +89,7 @@ function decrypt( $value, string $additional_data, string $key = '' ) : HiddenSt
 	$key       = get_encryption_key( $key );
 	$nonce     = mb_substr( $value, 0, NONCE_LENGTH, '8bit' );
 	$value     = mb_substr( $value, NONCE_LENGTH, null, '8bit' );
-	$plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt( $value, $additional_data, $nonce, $key->getString() );
+	$plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt( $value, $context, $nonce, $key->getString() );
 
 	sodium_memzero( $nonce );
 	sodium_memzero( $value );

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -40,9 +40,8 @@ const NONCE_LENGTH = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES;
  * @return string Encrypted value, exceptions thrown on error.
  */
 function encrypt( $value, string $additional_data = '', string $key = '' ) {
-	$key   = get_encryption_key( $key );
 	$nonce = random_bytes( NONCE_LENGTH );
-	if ( ! $key || ! $nonce ) {
+	if ( ! $nonce ) {
 		throw new Exception( 'Unable to create a nonce.' );
 	}
 
@@ -50,6 +49,7 @@ function encrypt( $value, string $additional_data = '', string $key = '' ) {
 		$value = $value->getString();
 	}
 
+	$key       = get_encryption_key( $key );
 	$encrypted = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt( $value, $additional_data, $nonce, $key->getString() );
 
 	sodium_memzero( $value );
@@ -66,12 +66,6 @@ function encrypt( $value, string $additional_data = '', string $key = '' ) {
  * @return string Decrypted value.
  */
 function decrypt( $value, string $additional_data = '', string $key = '' ) : HiddenString {
-	// Fetch the encryption key.
-	$key = get_encryption_key( $key );
-	if ( ! $key ) {
-		throw new Exception( 'Unable to get the encryption key.' );
-	}
-
 	if ( $value instanceOf HiddenString ) {
 		$value = $value->getString();
 	}
@@ -88,6 +82,7 @@ function decrypt( $value, string $additional_data = '', string $key = '' ) : Hid
 		throw new Exception( 'Invalid cipher text.' );
 	}
 
+	$key       = get_encryption_key( $key );
 	$nonce     = mb_substr( $value, 0, NONCE_LENGTH, '8bit' );
 	$value     = mb_substr( $value, NONCE_LENGTH, null, '8bit' );
 	$plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt( $value, $additional_data, $nonce, $key->getString() );

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -22,7 +22,7 @@ const PREFIX = '$t1$';
  *
  * @var int
  */
-const KEY_LENGTH   = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES;
+const KEY_LENGTH = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES;
 
 /**
  * The length of the per-encrypted-item nonce.
@@ -40,8 +40,8 @@ const NONCE_LENGTH = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES;
  * @return string Encrypted value, exceptions thrown on error.
  */
 function encrypt( $value, string $additional_data = '', string $key = '' ) {
-	$key       = get_encryption_key( $key );
-	$nonce     = random_bytes( NONCE_LENGTH );
+	$key   = get_encryption_key( $key );
+	$nonce = random_bytes( NONCE_LENGTH );
 	if ( ! $key || ! $nonce ) {
 		throw new Exception( 'Unable to create a nonce.' );
 	}
@@ -120,6 +120,8 @@ function is_encrypted( $value ) {
 	if ( mb_strlen( $value, '8bit' ) < NONCE_LENGTH + mb_strlen( PREFIX, '8bit' ) ) {
 		return false;
 	}
+
+	sodium_memzero( $value );
 
 	return true;
 }

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -117,7 +117,7 @@ function is_encrypted( $value ) {
 		return false;
 	}
 
-	if ( mb_strlen( $value, '8bit' ) < NONCE_LENGTH + strlen( PREFIX ) ) {
+	if ( mb_strlen( $value, '8bit' ) < NONCE_LENGTH + mb_strlen( PREFIX, '8bit' ) ) {
 		return false;
 	}
 

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -23,13 +23,19 @@ const PREFIX = '$t1$';
  * @var int
  */
 const KEY_LENGTH   = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES;
+
+/**
+ * The length of the per-encrypted-item nonce.
+ *
+ * @var int
+ */
 const NONCE_LENGTH = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES;
 
 /**
  * Encrypt a value.
  *
  * @param string $value           Value to encrypt.
- * @param string $additional_data Additional data to include in the encryption. Optional.
+ * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
  * @param string $key             Key to use for encryption. Optional.
  * @return string Encrypted value, exceptions thrown on error.
  */
@@ -55,7 +61,7 @@ function encrypt( $value, string $additional_data = '', string $key = '' ) {
  * Decrypt a value.
  *
  * @param string $value           Value to decrypt.
- * @param string $additional_data Additional data to include in the encryption. Optional.
+ * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
  * @param string $key             Key to use for decryption. Optional.
  * @return string Decrypted value.
  */
@@ -136,7 +142,7 @@ function is_encrypted( $value, string $key = '' ) {
  * @param string $key The key to use for decryption.
  * @return string The encryption key.
  */
-function get_encryption_key( $key = '' ) {
+function get_encryption_key( string $key = '' ) {
 	$constant = 'WPORG_ENCRYPTION_KEY';
 
 	if ( $key ) {

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -85,7 +85,7 @@ function decrypt( $value, string $additional_data = '', string $key = '' ) : Hid
 	$value = sodium_hex2bin( $value );
 
 	if ( mb_strlen( $value, '8bit' ) < NONCE_LENGTH ) {
-		throw new Exception( 'Invalid cipher text' );
+		throw new Exception( 'Invalid cipher text.' );
 	}
 
 	$nonce     = mb_substr( $value, 0, NONCE_LENGTH, '8bit' );
@@ -96,7 +96,7 @@ function decrypt( $value, string $additional_data = '', string $key = '' ) : Hid
 	sodium_memzero( $value );
 
 	if ( false === $plaintext ) {
-		throw new Exception( 'Invalid cipher text' );
+		throw new Exception( 'Invalid cipher text.' );
 	}
 
 	return new HiddenString( $plaintext );

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -69,11 +69,7 @@ function encrypt( $value, string $context, string $key_name = '' ) {
  * @param string $key_name The name of the key to use for decryption. Optional.
  * @return HiddenString Decrypted value.
  */
-function decrypt( $value, string $context, string $key_name = '' ) : HiddenString {
-	if ( $value instanceOf HiddenString ) {
-		$value = $value->getString();
-	}
-
+function decrypt( string $value, string $context, string $key_name = '' ) : HiddenString {
 	if ( ! is_encrypted( $value ) ) {
 		throw new Exception( 'Value is not encrypted.' );
 	}

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -106,10 +106,9 @@ function decrypt( $value, string $additional_data = '', string $key = '' ) : Hid
  * Check if a value is encrypted.
  *
  * @param string $value Value to check.
- * @param string $key   Key to use for decryption. Optional.
  * @return bool True if the value is encrypted, false otherwise.
  */
-function is_encrypted( $value, string $key = '' ) {
+function is_encrypted( $value ) {
 	if ( $value instanceOf HiddenString ) {
 		$value = $value->getString();
 	}
@@ -120,17 +119,6 @@ function is_encrypted( $value, string $key = '' ) {
 
 	if ( mb_strlen( $value, '8bit' ) < NONCE_LENGTH + strlen( PREFIX ) ) {
 		return false;
-	}
-
-	// Check if that's the key.
-	if ( $key ) {
-		try {
-			if ( ! decrypt( $value, $key ) ) {
-				return false;
-			}
-		} catch ( Exception $e ) {
-			return false;
-		}
 	}
 
 	return true;

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -100,7 +100,7 @@ function decrypt( string $value, string $context, string $key_name = '' ) : Hidd
 /**
  * Check if a value is encrypted.
  *
- * @param string $value Value to check.
+ * @param HiddenString|string $value Value to check.
  * @return bool True if the value is encrypted, false otherwise.
  */
 function is_encrypted( $value ) {

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -1,0 +1,160 @@
+<?php
+namespace WordPressdotorg\MU_Plugins\Encryption;
+use Exception;
+/**
+ * Plugin Name: WordPress.org Encryption
+ * Description: Encryption functions for use on WordPress.org.
+ */
+require __DIR__ . '/exports.php';
+
+/**
+ * Prefix for encrypted secrets. Contains a version identifier.
+ *
+ * $t1$ -> v1 (RFC 6238, encrypted with XChaCha20-Poly1305, with a key derived from HMAC-SHA256
+ *      of the defined key.
+ *
+ * @var string
+ */
+const PREFIX = '$t1$';
+
+/**
+ * The length of the keys.
+ *
+ * @var int
+ */
+const KEY_LENGTH   = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES;
+const NONCE_LENGTH = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES;
+
+/**
+ * Encrypt a value.
+ *
+ * @param string $value           Value to encrypt.
+ * @param string $additional_data Additional data to include in the encryption. Optional.
+ * @param string $key             Key to use for encryption. Optional.
+ * @return string Encrypted value, exceptions thrown on error.
+ */
+function encrypt( $value, string $additional_data = '', string $key = '' ) {
+	$key       = get_encryption_key( $key );
+	$nonce     = random_bytes( NONCE_LENGTH );
+	if ( ! $key || ! $nonce ) {
+		throw new Exception( 'Unable to create a nonce.' );
+	}
+
+	if ( $value instanceOf HiddenString ) {
+		$value = $value->getString();
+	}
+
+	$encrypted = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt( $value, $additional_data, $nonce, $key->getString() );
+
+	sodium_memzero( $value );
+
+	return new HiddenString( PREFIX . sodium_bin2hex( $nonce . $encrypted ) );
+}
+
+/**
+ * Decrypt a value.
+ *
+ * @param string $value           Value to decrypt.
+ * @param string $additional_data Additional data to include in the encryption. Optional.
+ * @param string $key             Key to use for decryption. Optional.
+ * @return string Decrypted value.
+ */
+function decrypt( $value, string $additional_data = '', string $key = '' ) : HiddenString {
+	// Fetch the encryption key.
+	$key = get_encryption_key( $key );
+	if ( ! $key ) {
+		throw new Exception( 'Unable to get the encryption key.' );
+	}
+
+	if ( $value instanceOf HiddenString ) {
+		$value = $value->getString();
+	}
+
+	if ( ! is_encrypted( $value ) ) {
+		throw new Exception( 'Value is not encrypted.' );
+	}
+
+	// Remove the prefix, and convert back to binary.
+	$value = mb_substr( $value, mb_strlen( PREFIX, '8bit' ), null, '8bit' );
+	$value = sodium_hex2bin( $value );
+
+	if ( mb_strlen( $value, '8bit' ) < NONCE_LENGTH ) {
+		throw new Exception( 'Invalid cipher text' );
+	}
+
+	$nonce     = mb_substr( $value, 0, NONCE_LENGTH, '8bit' );
+	$value     = mb_substr( $value, NONCE_LENGTH, null, '8bit' );
+	$plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt( $value, $additional_data, $nonce, $key->getString() );
+
+	sodium_memzero( $nonce );
+	sodium_memzero( $value );
+
+	if ( false === $plaintext ) {
+		throw new Exception( 'Invalid cipher text' );
+	}
+
+	return new HiddenString( $plaintext );
+}
+
+/**
+ * Check if a value is encrypted.
+ *
+ * @param string $value Value to check.
+ * @param string $key   Key to use for decryption. Optional.
+ * @return bool True if the value is encrypted, false otherwise.
+ */
+function is_encrypted( $value, string $key = '' ) {
+	if ( $value instanceOf HiddenString ) {
+		$value = $value->getString();
+	}
+
+	if ( ! str_starts_with( $value, PREFIX ) ) {
+		return false;
+	}
+
+	if ( mb_strlen( $value, '8bit' ) < NONCE_LENGTH + strlen( PREFIX ) ) {
+		return false;
+	}
+
+	// Check if that's the key.
+	if ( $key ) {
+		try {
+			if ( ! decrypt( $value, $key ) ) {
+				return false;
+			}
+		} catch ( Exception $e ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Get the encryption key.
+ *
+ * @param string $key The key to use for decryption.
+ * @return string The encryption key.
+ */
+function get_encryption_key( $key = '' ) {
+	$constant = 'WPORG_ENCRYPTION_KEY';
+
+	if ( $key ) {
+		$constant = 'WPORG_' . str_replace( '-', '_', strtoupper( $key ) ) . '_ENCRYPTION_KEY';
+	}
+
+	if ( ! defined( $constant ) ) {
+		throw new Exception( sprintf( 'Encryption key "%s" not defined.', $constant ) );
+	}
+
+	return new HiddenString( sodium_hex2bin( constant( $constant ) ) );
+}
+
+/**
+ * Generate a random encryption key.
+ *
+ * @return string The encryption key.
+ */
+function generate_encryption_key() {
+	return sodium_bin2hex( random_bytes( KEY_LENGTH ) );
+}

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -125,7 +125,7 @@ function is_encrypted( $value ) {
  * Get the encryption key.
  *
  * @param string $key_name The name of the key to use for decryption.
- * @return string The encryption key.
+ * @return HiddenString The encryption key.
  */
 function get_encryption_key( string $key_name = '' ) {
 
@@ -148,7 +148,7 @@ function get_encryption_key( string $key_name = '' ) {
 /**
  * Generate a random encryption key.
  *
- * @return string The encryption key.
+ * @return HiddenString The encryption key.
  */
 function generate_encryption_key() {
 	return new HiddenString( random_bytes( KEY_LENGTH ) );

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -54,7 +54,7 @@ function encrypt( $value, string $additional_data = '', string $key = '' ) {
 
 	sodium_memzero( $value );
 
-	return new HiddenString( PREFIX . sodium_bin2hex( $nonce . $encrypted ) );
+	return PREFIX . sodium_bin2hex( $nonce . $encrypted );
 }
 
 /**

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -128,17 +128,21 @@ function is_encrypted( $value ) {
  * @return string The encryption key.
  */
 function get_encryption_key( string $key = '' ) {
-	$constant = 'WPORG_ENCRYPTION_KEY';
 
-	if ( $key ) {
-		$constant = 'WPORG_' . str_replace( '-', '_', strtoupper( $key ) ) . '_ENCRYPTION_KEY';
+	$keys = [];
+	if ( function_exists( 'wporg_encryption_keys' ) ) {
+		$keys = wporg_encryption_keys();
 	}
 
-	if ( ! defined( $constant ) ) {
-		throw new Exception( sprintf( 'Encryption key "%s" not defined.', $constant ) );
+	if ( ! $key ) {
+		$key = 'default';
 	}
 
-	return new HiddenString( sodium_hex2bin( constant( $constant ) ) );
+	if ( ! isset( $keys[ $key ] ) ) {
+		throw new Exception( sprintf( 'Encryption key "%s" not defined.', $key ) );
+	}
+
+	return $keys[ $key ];
 }
 
 /**
@@ -147,5 +151,5 @@ function get_encryption_key( string $key = '' ) {
  * @return string The encryption key.
  */
 function generate_encryption_key() {
-	return sodium_bin2hex( random_bytes( KEY_LENGTH ) );
+	return new HiddenString( random_bytes( KEY_LENGTH ) );
 }

--- a/mu-plugins/encryption/index.php
+++ b/mu-plugins/encryption/index.php
@@ -39,10 +39,14 @@ const NONCE_LENGTH = SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES;
  * @param string $key             Key to use for encryption. Optional.
  * @return string Encrypted value, exceptions thrown on error.
  */
-function encrypt( $value, string $additional_data = '', string $key = '' ) {
+function encrypt( $value, string $additional_data, string $key = '' ) {
 	$nonce = random_bytes( NONCE_LENGTH );
 	if ( ! $nonce ) {
 		throw new Exception( 'Unable to create a nonce.' );
+	}
+
+	if ( empty( $additional_data ) ) {
+		throw new Exception( '$additional_data cannot be empty.' );
 	}
 
 	if ( $value instanceOf HiddenString ) {
@@ -63,9 +67,9 @@ function encrypt( $value, string $additional_data = '', string $key = '' ) {
  * @param string $value           Value to decrypt.
  * @param string $additional_data Additional, authenticated data. This is used in the verification of the authentication tag appended to the ciphertext, but it is not encrypted or stored in the ciphertext. Optional.
  * @param string $key             Key to use for decryption. Optional.
- * @return string Decrypted value.
+ * @return HiddenString Decrypted value.
  */
-function decrypt( $value, string $additional_data = '', string $key = '' ) : HiddenString {
+function decrypt( $value, string $additional_data, string $key = '' ) : HiddenString {
 	if ( $value instanceOf HiddenString ) {
 		$value = $value->getString();
 	}

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -29,3 +29,4 @@ require_once __DIR__ . '/plugin-tweaks/index.php';
 require_once __DIR__ . '/rest-api/index.php';
 require_once __DIR__ . '/skip-to/skip-to.php';
 require_once __DIR__ . '/db-user-sessions/index.php';
+require_once __DIR__ . '/encryption/index.php';

--- a/phpunit/test-encryption.php
+++ b/phpunit/test-encryption.php
@@ -1,0 +1,163 @@
+<?php
+use WordPressdotorg\MU_Plugins\Encryption\HiddenString;
+use const WordPressdotorg\MU_Plugins\Encryption\{ PREFIX, NONCE_LENGTH, KEY_LENGTH };
+use function WordPressdotorg\MU_Plugins\Encryption\{encrypt, decrypt, is_encrypted, get_encryption_key, generate_encryption_key };
+
+class Test_WPORG_Encryption extends WP_UnitTestCase {
+
+	public function wpSetUpBeforeClass() {
+		if ( ! defined( 'WPORG_ENCRYPTION_KEY' ) ) {
+			define( 'WPORG_ENCRYPTION_KEY', generate_encryption_key() );
+		}
+		if ( ! defined( 'WPORG_SECONDARY_ENCRYPTION_KEY' ) ) {
+			define( 'WPORG_SECONDARY_ENCRYPTION_KEY', generate_encryption_key() );
+		}
+	}
+
+	public function test_encrypt_decrypt() {
+		$input = 'This is a plaintext string. It contains no sensitive data.';
+
+		$encrypted = encrypt( $input );
+
+		$this->assertNotEquals( $input, $encrypted );
+
+		$decrypted = decrypt( $encrypted );
+
+		$this->assertTrue( $decrypted instanceOf HiddenString );
+
+		$this->assertNotEquals( $input, $decrypted );
+		$this->assertEquals( $input, $decrypted->getString() );
+		$this->assertNotEquals( $input, (string) $decrypted );
+	}
+
+	public function test_authenticated_encrypt_decrypt() {
+		$input = 'This is a plaintext string. It contains no sensitive data.';
+		$additional_data = 'USER1';
+
+		$encrypted = encrypt( $input, $additional_data );
+
+		$this->assertNotEquals( $input, $encrypted );
+		$this->assertStringNotContainsString( $additional_data, $encrypted );
+
+		$this->expectException( Exception::class );
+		$decrypt_without_data = decrypt( $encrypted );
+
+		$this->expectException( Exception::class );
+		$decrypt_with_wrong_data = decrypt( $encrypted, 'USER2' );
+
+		$this->expectException( Exception::class );
+		$decrypt_with_wrong_key = decrypt( $encrypted, $additional_data, 'secondary' );
+
+		$decrypted = decrypt( $encrypted, $additional_data );
+
+		$this->assertTrue( $decrypted instanceOf HiddenString );
+
+		$this->assertNotEquals( $input, $decrypted );
+		$this->assertEquals( $input, $decrypted->getString() );
+	}
+
+	public function test_is_encrypted() {
+		$this->assertFalse( is_encrypted( 'TEST STRING' ) );
+		$this->assertFalse( is_encrypted( PREFIX ) );
+		$this->assertFalse( is_encrypted( PREFIX . 'TEST STRING' ) );
+
+		$string_prefix_length = str_repeat( '.', mb_strlen( PREFIX, '8bit' ) );
+		$string_nonce_length  = str_repeat( '.', NONCE_LENGTH );
+
+		$this->assertFalse( is_encrypted( $string_prefix_length . $string_nonce_length ) );
+		$this->assertFalse( is_encrypted( $string_prefix_length . $string_nonce_length . 'TEST STRING' ) );
+
+		$this->assertTrue( is_encrypted( PREFIX . $string_nonce_length ) );
+		$this->assertTrue( is_encrypted( PREFIX . $string_nonce_length . 'TEST STRING' ) );
+
+		$test_string = 'This is a plaintext string. It contains no sensitive data.';
+		$this->assertTrue( is_encrypted( encrypt( $test_string ) ) );
+	}
+
+	public function test_generate_key_different() {
+		$one_key = generate_encryption_key();
+
+		$length = mb_strlen( sodium_hex2bin( $one_key ), '8bit' );
+		$this->assertEquals( KEY_LENGTH, $length );
+
+		$two_key = generate_encryption_key();
+		$this->assertNotEquals( $one_key, $two_key );
+	}
+
+	public function test_get_encryption_key() {
+		$this->assertSame( sodium_hex2bin( WPORG_ENCRYPTION_KEY ), get_encryption_key()->getString() );
+		$this->assertSame( sodium_hex2bin( WPORG_ENCRYPTION_KEY ), get_encryption_key( '' )->getString() );
+		$this->assertSame( sodium_hex2bin( WPORG_ENCRYPTION_KEY ), get_encryption_key( false )->getString() );
+
+		$this->assertSame( sodium_hex2bin( WPORG_SECONDARY_ENCRYPTION_KEY ), get_encryption_key( 'secondary' )->getString() );
+
+		$this->expectException( Exception::class );
+		get_encryption_key( '404-key' );
+	}
+
+	public function test_can_encrypt_hiddenstring() {
+		$hidden_string = new HiddenString( "TEST STRING" );
+
+		$encrypted = encrypt( $hidden_string );
+
+		$this->assertTrue( is_encrypted( $encrypted ) );
+
+		$this->assertSame( $hidden_string->getString(), decrypt( $encrypted )->getString() );
+	}
+
+	public function test_encrypt_decrypt_invalid_inputs() {
+		$this->expectException( Exception::class );
+		encrypt( "TEST STRING", '', '404-key' );
+
+		$this->expectException( Exception::class );
+		decrypt( "TEST STRING", '', '404-key' );
+
+		$this->expectException( Exception::class );
+		decrypt( "TEST STRING" );
+	}
+
+	public function test_exported_functions() {
+		// This only tests the behavioural functions, not the encryption/decryption.
+
+		$input = 'This is a plaintext string. It contains no sensitive data.';
+
+		$encrypted = wporg_encrypt( $input );
+
+		$this->assertNotEquals( $input, $encrypted );
+
+		$decrypted = wporg_decrypt( $encrypted );
+
+		$this->assertTrue( $decrypted instanceOf HiddenString );
+
+		$this->assertNotSame( $input, $decrypted );
+		$this->assertEquals( $input, $decrypted->getString() );
+		$this->assertEquals( $input, (string) $decrypted );
+
+		$this->assertFalse( wporg_encrypt( '', '404-key' ) );
+		$this->assertFalse( wporg_decrypt( '', '404-key' ) );
+		$this->assertFalse( wporg_decrypt( 'TEST STRING' ) );
+	}
+
+	public function test_exported_authenticated_functions() {
+		// This only tests the behavioural functions, not the encryption/decryption.
+
+		$input           = 'This is a plaintext string. It contains no sensitive data.';
+		$additional_data = 'USER1';
+
+		$encrypted = wporg_authenticated_encrypt( $input, $additional_data );
+
+		$this->assertNotEquals( $input, $encrypted );
+
+		$decrypted = wporg_authenticated_decrypt( $encrypted, $additional_data );
+
+		$this->assertTrue( $decrypted instanceOf HiddenString );
+
+		$this->assertNotSame( $input, $decrypted );
+		$this->assertEquals( $input, $decrypted->getString() );
+		$this->assertEquals( $input, (string) $decrypted );
+
+		$this->assertFalse( wporg_authenticated_encrypt( '', '', '404-key' ) );
+		$this->assertFalse( wporg_authenticated_decrypt( '', '', '404-key' ) );
+		$this->assertFalse( wporg_authenticated_decrypt( 'TEST STRING' ) );
+	}
+}


### PR DESCRIPTION
This adds a new set of Encryption methods based off of other implementations of it.

There are two methods to use it, the namespaced methods which throw specific exceptions, or the globally-defined functions that operate as "standard PHP" (which are detailed below)

It uses Additional Data ciphers (AEAD with XChaCha20-Poly1305) via the Sodium library and supports multiple keys

Using `$context` (Additional Data) is required, and should be either set to a per-user/site/post value or to a per-feature unique token.

For example, two keys could be defined
 - WPORG_ENCRYPTION_KEY: .... = accessed via `wporg_encrypt( $string, (string) $user_id )` & `wporg_decrypt( $encrypted_value, (string) $user_id )`
 - WPORG_PLUGINS_ENCRYPTION_KEY: ... = accessed via `wporg_encrypt( $string, (string) $user_id, 'plugins' )` & `wporg_decrypt( $encrypted_value, (string) $user_id, 'plugins' )`

This is based off a combination of https://github.com/WordPress/two-factor/pull/389 and an Automattic implementations of it.
~This has not been unit tested, and does not include any yet.~
This has not been written with the intention of running on older versions of WordPress or PHP.
~This has not been peer-reviewed.~ This may contain egregious errors on my part.
This is being submitted so as to provide the basis of https://github.com/WordPress/wporg-two-factor/pull/103