### PR TITLE
Search: Prevent visible page scroll when the search modal is open on iOS

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -10,6 +10,7 @@
  */
 
 /* Breakpoints should be synced with `wporg-parent-2021` (or `wporg-news-2021` until parent exists). */
+@custom-media --mobile-only (max-width: 889px);
 @custom-media --tablet (min-width: 890px);
 @custom-media --desktop (min-width: 1152px);
 @custom-media --desktop-wide (min-width: 1440px);

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -321,3 +321,22 @@
 		overflow: scroll;
 	}
 }
+
+/*
+ * On small screens, when the nav modal is open, position the header to overlay
+ * the page content.
+ *
+ * Technically, this should not scroll - GB sets `overflow: hidden` - but when
+ * the keyboard is open, iOS overrides the scroll behavior. This solution
+ * prevents visible page scroll without affecting layout of the page itself.
+ *
+ * See https://github.com/WordPress/wporg-mu-plugins/issues/371/.
+ */
+@media (--mobile-only) {
+	html.has-modal-open .global-header {
+		position: fixed;
+		z-index: 9999; /* Arbitrary z-index to be above any possible element on a page. */
+		left: 0;
+		right: 0;
+	}
+}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -24,7 +24,7 @@
 		}
 
 		&:hover,
-		&:focus {
+		&:focus-visible {
 			background-color: var(--wp-global-header--background-color--hover);
 		}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -42,7 +42,7 @@
 		background-position: center;
 
 		&:hover,
-		&:focus {
+		&:focus-visible {
 			background-color: var(--wp-global-header--background-color--hover);
 		}
 


### PR DESCRIPTION
On iOS, opening the search modal in the header triggers the keyboard to open, which re-enables page scrolling. When scrolling down & back up, the page contents are visible in the gap behind the modal. This PR fixes the header bar on scroll, so that it hides that scrolled content.

It is still strange that the page can be scrolled, but the other fixes cause larger layout issues (see https://github.com/WordPress/wporg-mu-plugins/issues/371#issuecomment-1505719345), and this only happens when the keyboard is open (and only on iOS) this seems like the best solution.

Fixes #371, see #381, see #382.

Note: this PR also includes a small fix to prevent the icon-buttons from appearing active when the tab is closed, I only noticed it on mobile, so fixed it here.

**Screenshots**

| | Production | PR |
|---|---|---|
| Home: block theme | ![](https://user-images.githubusercontent.com/541093/234339438-ae21cbab-4309-44a1-bac2-7334cc213c6b.PNG) | ![](https://user-images.githubusercontent.com/541093/234337862-0d232047-1b82-4d5f-b8d3-bcdfb113fca1.jpeg) |
| Patterns: classic theme, has admin bar | ![](https://user-images.githubusercontent.com/541093/234342635-efc19587-ca0f-4580-a1c5-b1fcec0b013a.jpeg) | ![](https://user-images.githubusercontent.com/541093/234337861-678dc2f7-2842-4e61-a875-b11a63a8d67b.jpeg) |
| Download: block theme, white header style | ![](https://user-images.githubusercontent.com/541093/234339443-91aacbfa-f619-48ab-bb57-5432cf53ea92.jpeg) | ![](https://user-images.githubusercontent.com/541093/234337859-bb556fa9-360e-4b2d-b50c-10c5ca9da992.jpeg) |
| Download, with keyboard closed, modal behaves correctly (no scroll) | no change | ![](https://user-images.githubusercontent.com/541093/234337855-c0c6a5ee-817a-458e-a36c-18c7df8f2b02.jpeg) |

**To test**

I used Charles.app's DNS spoofing to send *.wordpress.org traffic to my sandbox, then set my iPad to use my computer as a proxy. This let me load my sandboxed environment on my iPad. Then using the vertical orientation, I tested the header across different wporg pages.
