### PR TITLE
New Block: Try a modal/popover block

### DIFF
--- a/mu-plugins/blocks/modal/icons/chevron.svg
+++ b/mu-plugins/blocks/modal/icons/chevron.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false">
+    <path d="M1.50002 4L6.00002 8L10.5 4" fill="none" stroke="currentColor" stroke-width="1.5"></path>
+</svg>

--- a/mu-plugins/blocks/modal/icons/chevron.svg
+++ b/mu-plugins/blocks/modal/icons/chevron.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false">
-    <path d="M1.50002 4L6.00002 8L10.5 4" fill="none" stroke="currentColor" stroke-width="1.5"></path>
-</svg>

--- a/mu-plugins/blocks/modal/icons/close.svg
+++ b/mu-plugins/blocks/modal/icons/close.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path>
+</svg>

--- a/mu-plugins/blocks/modal/index.php
+++ b/mu-plugins/blocks/modal/index.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Block Name: Modal
+ * Description: A container hidden behind a button, which pops up on click.
+ *
+ * This contains 3 variations on this concept:
+ * - Modal: The container that floats in the middle of the screen. Clicking
+ *   outside the container or hitting escape will close it.
+ * - Popover: The container stays attached to the toggle button but overlaps
+ *   the content, like a dropdown menu. Clicking outside the container or
+ *   hitting escape will close it.
+ * - Collapsed (inline): The container is hidden by default, but when expanded,
+ *   pushes the content below down to not overlap. Only closed by clicking the
+ *   toggle, to prevent content jumps.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\MU_Plugins\Modal_Block;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		__DIR__ . '/build/modal',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+	register_block_type(
+		__DIR__ . '/build/inner-content',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_inner_content',
+		)
+	);
+}
+
+/**
+ * Returns a local SVG icon.
+ *
+ * @param string $icon Name of the icon to render, corresponds to file name.
+ * @return string
+ */
+function render_icon( $icon ) {
+	$file_path = __DIR__ . '/icons/' . $icon . '.svg';
+	if ( file_exists( $file_path ) ) {
+		return file_get_contents( $file_path );
+	}
+}
+
+/**
+ * Render the block content for the modal/popover/inline container.
+ *
+ * The modal requires more HTML for micromodal support, but inline and popover
+ * use the same markup with slightly different CSS.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render_inner_content( $attributes, $content, $block ) {
+	// Fetch the type from the parent block.
+	$type = $block->context['wporg/modal/type'];
+	if ( ! $type ) {
+		return;
+	}
+
+	if ( 'inline' === $type || 'popover' === $type ) {
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wporg-modal__modal alignwide' ) );
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
+			$content
+		);
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$close_icon = render_icon( 'close' );
+
+	return <<<HTML
+<div class="wporg-modal__modal" aria-hidden="true">
+	<div tabindex="-1" class="wporg-modal__overlay" data-micromodal-close>
+		<div class="wporg-modal__container" role="dialog" aria-modal="true">
+			<div {$wrapper_attributes}>
+				<button class="wporg-modal__button" aria-label="Close" data-micromodal-close>{$close_icon}</button>
+				{$content}
+			</div>
+		</div>
+	</div>
+</div>
+HTML;
+}
+
+/**
+ * Render the block content for the parent Modal block (button). The modal
+ * container itself is rendered by the child block.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	$type = $attributes['type'];
+	$label = $attributes['label'];
+	$class = 'is-type-' . $type;
+
+	// Add the chevron if this is not a modal.
+	if ( 'inline' === $type || 'popover' === $type ) {
+		$icon = render_icon( 'chevron' );
+		$label .= ' ' . $icon;
+	}
+
+	$toggle_button = '<button class="wporg-modal__button wp-block-button__link" aria-expanded="false">' . $label . '</button>';
+
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class ) );
+	return sprintf(
+		'<div %1$s>%2$s%3$s</div>',
+		$wrapper_attributes,
+		$toggle_button,
+		$content
+	);
+}

--- a/mu-plugins/blocks/modal/index.php
+++ b/mu-plugins/blocks/modal/index.php
@@ -69,7 +69,7 @@ function render_icon( $icon ) {
  */
 function render_inner_content( $attributes, $content, $block ) {
 	// Fetch the type from the parent block.
-	$type = $block->context['wporg/modal/type'];
+	$type = $block->context['wporg/modal/type'] ?? '';
 	if ( ! $type ) {
 		return;
 	}
@@ -112,22 +112,26 @@ HTML;
  */
 function render( $attributes, $content, $block ) {
 	$type = $attributes['type'];
-	$label = $attributes['label'];
 	$class = 'is-type-' . $type;
 
-	// Add the chevron if this is not a modal.
-	if ( 'inline' === $type || 'popover' === $type ) {
-		$icon = render_icon( 'chevron' );
-		$label .= ' ' . $icon;
+	// Replace the button block's link with an HTML button, retain all block styles.
+	// This only replaces the first link, so the modal can still contain links/buttons.
+	if ( preg_match( '/(<a([^>]*)>)(.*?)(<\/a>)/i', $content, $matches ) ) {
+		$link = $matches[0]; // full match.
+		// Add in the modal button class, used by the view script.
+		$attributes = str_replace( 'class="', 'class="wporg-modal__button ', $matches[2] );
+		$button = sprintf(
+			'<button aria-expanded="false" %1$s>%2$s</button>',
+			$attributes,
+			$matches[3] // innerText.
+		);
+		$content = str_replace( $link, $button, $content );
 	}
-
-	$toggle_button = '<button class="wporg-modal__button wp-block-button__link" aria-expanded="false">' . $label . '</button>';
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class ) );
 	return sprintf(
-		'<div %1$s>%2$s%3$s</div>',
+		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,
-		$toggle_button,
 		$content
 	);
 }

--- a/mu-plugins/blocks/modal/postcss/editor-style.pcss
+++ b/mu-plugins/blocks/modal/postcss/editor-style.pcss
@@ -1,0 +1,4 @@
+.wporg-modal__modal {
+	border: 1px dashed black;
+	padding: 8px;
+}

--- a/mu-plugins/blocks/modal/postcss/editor-style.pcss
+++ b/mu-plugins/blocks/modal/postcss/editor-style.pcss
@@ -1,4 +1,9 @@
 .wporg-modal__modal {
-	border: 1px dashed black;
+	border: 1px dashed #000;
 	padding: 8px;
+}
+
+.wp-block-wporg-modal.is-selected .wporg-modal__modal,
+.wp-block-wporg-modal.has-child-selected .wporg-modal__modal {
+	display: block;
 }

--- a/mu-plugins/blocks/modal/postcss/style.pcss
+++ b/mu-plugins/blocks/modal/postcss/style.pcss
@@ -1,0 +1,93 @@
+.wporg-modal__modal {
+	display: none;
+}
+
+.wporg-modal__modal.is-open {
+	display: block;
+}
+
+.wporg-modal__overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 99999; /* Needs to be at leas this to overlay admin bar. */
+	background: rgba(0,0,0,0.6);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
+.wporg-modal__container {
+	background-color: var(--wp--preset--color--white);
+	width: 100%;
+	max-width: var(--wp--style--global--content-size);
+	max-height: 100vh;
+	overflow-y: auto;
+	box-sizing: border-box;
+
+	/* This extra div is needed to prevent clicks inside the container padding from closing the modal. */
+	& > div {
+		position: relative;
+		padding: var(--wp--preset--spacing--40);
+
+		& > button + * {
+			margin-top: 0;
+		}
+
+		& > *:last-child {
+			margin-bottom: 0;
+		}
+	}
+}
+
+.wporg-modal__button[data-micromodal-close] {
+	position: absolute;
+	top: var(--wp--preset--spacing--10);
+	right: var(--wp--preset--spacing--10);
+	width: calc(24px + var(--wp--preset--spacing--10));
+	height: calc(24px + var(--wp--preset--spacing--10));
+	line-height: 1;
+	padding: 0;
+	box-shadow: none;
+	text-decoration: none;
+	border: none;
+	color: currentColor;
+	background-color: transparent;
+	background-image: none;
+	cursor: pointer;
+	z-index: 10; /* Just enough to raise it above the other modal content. */
+
+	& svg {
+		vertical-align: middle;
+		fill: currentColor;
+	}
+}
+
+.wp-block-wporg-modal.is-type-popover {
+	position: relative;
+
+	& .wporg-modal__modal {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		z-index: 2;
+
+		opacity: 0;
+		overflow: hidden;
+		visibility: hidden;
+		height: 0;
+		width: 0;
+
+		&.is-open {
+			opacity: 1;
+			overflow: visible;
+			visibility: visible;
+	
+			height: auto;
+			min-width: 200px;
+			width: 100%;
+		}	
+	}
+}

--- a/mu-plugins/blocks/modal/postcss/style.pcss
+++ b/mu-plugins/blocks/modal/postcss/style.pcss
@@ -13,14 +13,13 @@
 	right: 0;
 	bottom: 0;
 	z-index: 99999; /* Needs to be at leas this to overlay admin bar. */
-	background: rgba(0,0,0,0.6);
+	background: rgba(0, 0, 0, 0.6);
 	display: flex;
 	justify-content: center;
 	align-items: center;
 }
 
 .wporg-modal__container {
-	background-color: var(--wp--preset--color--white);
 	width: 100%;
 	max-width: var(--wp--style--global--content-size);
 	max-height: 100vh;
@@ -31,6 +30,7 @@
 	& > div {
 		position: relative;
 		padding: var(--wp--preset--spacing--40);
+		background-color: var(--wp--preset--color--white);
 
 		& > button + * {
 			margin-top: 0;
@@ -84,10 +84,10 @@
 			opacity: 1;
 			overflow: visible;
 			visibility: visible;
-	
+
 			height: auto;
 			min-width: 200px;
 			width: 100%;
-		}	
+		}
 	}
 }

--- a/mu-plugins/blocks/modal/src/inner-content/block.json
+++ b/mu-plugins/blocks/modal/src/inner-content/block.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/modal-inner-content",
+	"title": "Modal Content",
+	"icon": "text-page",
+	"category": "layout",
+	"description": "Hidden content which appears when a button is clicked.",
+	"textdomain": "wporg",
+	"attributes": {},
+	"usesContext": [ "wporg/modal/type" ],
+	"parent": [ "wporg/modal" ],
+	"supports": {
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": true,
+				"padding": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		}
+	},
+	"editorScript": "file:./index.js"
+}

--- a/mu-plugins/blocks/modal/src/inner-content/index.js
+++ b/mu-plugins/blocks/modal/src/inner-content/index.js
@@ -13,7 +13,15 @@ function Edit() {
 	return (
 		<div className="wporg-modal__modal">
 			<div { ...useBlockProps() }>
-				<InnerBlocks templateLock={ false } />
+				<InnerBlocks
+					templateLock={ false }
+					template={ [
+						[
+							'core/navigation',
+							{ overlayMenu: 'never', layout: { type: 'flex', orientation: 'vertical' } },
+						],
+					] }
+				/>
 			</div>
 		</div>
 	);

--- a/mu-plugins/blocks/modal/src/inner-content/index.js
+++ b/mu-plugins/blocks/modal/src/inner-content/index.js
@@ -11,8 +11,10 @@ import metadata from './block.json';
 
 function Edit() {
 	return (
-		<div { ...useBlockProps() }>
-			<InnerBlocks templateLock={ false } />
+		<div className="wporg-modal__modal">
+			<div { ...useBlockProps() }>
+				<InnerBlocks templateLock={ false } />
+			</div>
 		</div>
 	);
 }

--- a/mu-plugins/blocks/modal/src/inner-content/index.js
+++ b/mu-plugins/blocks/modal/src/inner-content/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+function Edit() {
+	return (
+		<div { ...useBlockProps() }>
+			<InnerBlocks templateLock={ false } />
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => {
+		return <InnerBlocks.Content />;
+	},
+} );

--- a/mu-plugins/blocks/modal/src/modal/block.json
+++ b/mu-plugins/blocks/modal/src/modal/block.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/modal",
+	"title": "Modal",
+	"icon": "button",
+	"category": "layout",
+	"description": "A container hidden behind a button, which pops up on click.",
+	"textdomain": "wporg",
+	"attributes": {
+		"label": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string",
+			"default": "modal",
+			"enum": [ "inline", "modal", "popover" ]
+		}
+	},
+	"supports": {
+		"align": true,
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"providesContext": {
+		"wporg/modal/type": "type"
+	},
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:../editor-style.css",
+	"style": "file:../style.css",
+	"viewScript": "file:./view.js"
+}

--- a/mu-plugins/blocks/modal/src/modal/block.json
+++ b/mu-plugins/blocks/modal/src/modal/block.json
@@ -19,18 +19,9 @@
 	},
 	"supports": {
 		"align": true,
-		"color": {
-			"text": true,
-			"background": true,
-			"link": true
-		},
 		"spacing": {
 			"margin": true,
 			"padding": true
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true
 		}
 	},
 	"providesContext": {

--- a/mu-plugins/blocks/modal/src/modal/index.js
+++ b/mu-plugins/blocks/modal/src/modal/index.js
@@ -1,0 +1,79 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { InnerBlocks, RichText, useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+function Edit( { attributes, setAttributes, isSelected, clientId } ) {
+	const { label } = attributes;
+	const isInnerBlockSelected = useSelect(
+		( select ) => select( blockEditorStore ).hasSelectedInnerBlock( clientId, true ),
+		[ clientId ]
+	);
+
+	const onChangeContent = ( newValue ) => {
+		setAttributes( { label: newValue } );
+	};
+	const modalClass = isSelected || isInnerBlockSelected ? ' is-open' : '';
+
+	return (
+		<div { ...useBlockProps() }>
+			<RichText tagName="p" className="wp-block-button__link" onChange={ onChangeContent } value={ label } />
+			<div className={ `wporg-modal__modal ${ modalClass }` }>
+				<InnerBlocks
+					template={ [
+						[
+							'wporg/modal-inner-content',
+							{},
+							[
+								[
+									'core/navigation',
+									{ overlayMenu: 'never', layout: { type: 'flex', orientation: 'vertical' } },
+								],
+							],
+						],
+					] }
+					templateLock="all"
+				/>
+			</div>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => {
+		return <InnerBlocks.Content />;
+	},
+	variations: [
+		{
+			name: 'default',
+			title: metadata.title,
+			attributes: { type: 'modal' },
+			scope: [ 'inserter', 'transform' ],
+			isDefault: true,
+			isActive: [ 'type' ],
+		},
+		{
+			name: 'inline',
+			title: __( 'Collapsed', 'wporg' ),
+			attributes: { type: 'inline' },
+			scope: [ 'inserter', 'transform' ],
+			isActive: [ 'type' ],
+		},
+		{
+			name: 'popover',
+			title: __( 'Popover', 'wporg' ),
+			attributes: { type: 'popover' },
+			scope: [ 'inserter', 'transform' ],
+			isActive: [ 'type' ],
+		},
+	],
+} );

--- a/mu-plugins/blocks/modal/src/modal/index.js
+++ b/mu-plugins/blocks/modal/src/modal/index.js
@@ -13,22 +13,7 @@ import metadata from './block.json';
 function Edit() {
 	return (
 		<div { ...useBlockProps() }>
-			<InnerBlocks
-				template={ [
-					[ 'core/button' ],
-					[
-						'wporg/modal-inner-content',
-						{},
-						[
-							[
-								'core/navigation',
-								{ overlayMenu: 'never', layout: { type: 'flex', orientation: 'vertical' } },
-							],
-						],
-					],
-				] }
-				templateLock="all"
-			/>
+			<InnerBlocks template={ [ [ 'core/button' ], [ 'wporg/modal-inner-content' ] ] } templateLock="all" />
 		</div>
 	);
 }

--- a/mu-plugins/blocks/modal/src/modal/index.js
+++ b/mu-plugins/blocks/modal/src/modal/index.js
@@ -3,46 +3,32 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
-import { InnerBlocks, RichText, useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import metadata from './block.json';
 
-function Edit( { attributes, setAttributes, isSelected, clientId } ) {
-	const { label } = attributes;
-	const isInnerBlockSelected = useSelect(
-		( select ) => select( blockEditorStore ).hasSelectedInnerBlock( clientId, true ),
-		[ clientId ]
-	);
-
-	const onChangeContent = ( newValue ) => {
-		setAttributes( { label: newValue } );
-	};
-	const modalClass = isSelected || isInnerBlockSelected ? ' is-open' : '';
-
+function Edit() {
 	return (
 		<div { ...useBlockProps() }>
-			<RichText tagName="p" className="wp-block-button__link" onChange={ onChangeContent } value={ label } />
-			<div className={ `wporg-modal__modal ${ modalClass }` }>
-				<InnerBlocks
-					template={ [
+			<InnerBlocks
+				template={ [
+					[ 'core/button' ],
+					[
+						'wporg/modal-inner-content',
+						{},
 						[
-							'wporg/modal-inner-content',
-							{},
 							[
-								[
-									'core/navigation',
-									{ overlayMenu: 'never', layout: { type: 'flex', orientation: 'vertical' } },
-								],
+								'core/navigation',
+								{ overlayMenu: 'never', layout: { type: 'flex', orientation: 'vertical' } },
 							],
 						],
-					] }
-					templateLock="all"
-				/>
-			</div>
+					],
+				] }
+				templateLock="all"
+			/>
 		</div>
 	);
 }

--- a/mu-plugins/blocks/modal/src/modal/view.js
+++ b/mu-plugins/blocks/modal/src/modal/view.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import MicroModal from 'micromodal';
+
+let idCounter = 0;
+function getModalId( prefix = 'modal-' ) {
+	idCounter++;
+	return prefix + idCounter;
+}
+
+/**
+ * Set up the modal behavior for the modal type.
+ *
+ * @param {HTMLElement} container
+ */
+function intializeModal( container ) {
+	const modalId = getModalId( 'wporg-modal-' );
+	container.querySelector( 'button' ).setAttribute( 'data-micromodal-trigger', modalId );
+	container.querySelector( '.wporg-modal__modal' ).id = modalId;
+
+	MicroModal.init( {
+		onShow: ( modal ) => {
+			const button = container.querySelector( `button[data-micromodal-trigger=${ modal.id }]` );
+			button.setAttribute( 'aria-expanded', true );
+		},
+		onClose: ( modal ) => {
+			const button = container.querySelector( `button[data-micromodal-trigger=${ modal.id }]` );
+			button.setAttribute( 'aria-expanded', false );
+		},
+	} );
+}
+
+/**
+ * Set up the handlers for opening/closing the popover drawer.
+ * Uses the click handler from `intializeInline`, then adds handlers for
+ * closing when click or focus moves out of the popover.
+ * See the navigation block submenu behavior.
+ *
+ * @param {HTMLElement} container
+ */
+function intializePopover( container ) {
+	const button = container.querySelector( '* > .wporg-modal__button' );
+	const content = container.querySelector( '.wporg-modal__modal' );
+
+	if ( ! button || ! content ) {
+		return;
+	}
+
+	intializeInline( container );
+
+	// Close on click outside.
+	document.addEventListener( 'click', function ( event ) {
+		if ( ! container.contains( event.target ) ) {
+			button.setAttribute( 'aria-expanded', false );
+			content.classList.remove( 'is-open' );
+		}
+	} );
+
+	// Close on focus outside or escape key.
+	document.addEventListener( 'keyup', function ( event ) {
+		if ( event.key === 'Escape' || ! container.contains( event.target ) ) {
+			button.setAttribute( 'aria-expanded', false );
+			content.classList.remove( 'is-open' );
+		}
+	} );
+}
+
+/**
+ * Set up the click handler for opening/closing the inline drawer.
+ * This is also used by the "popover" style.
+ *
+ * @param {HTMLElement} container
+ */
+function intializeInline( container ) {
+	const button = container.querySelector( '* > .wporg-modal__button' );
+	const content = container.querySelector( '.wporg-modal__modal' );
+
+	if ( ! button || ! content ) {
+		return;
+	}
+
+	button.addEventListener( 'click', () => {
+		if ( button.getAttribute( 'aria-expanded' ) === 'true' ) {
+			button.setAttribute( 'aria-expanded', false );
+			content.classList.remove( 'is-open' );
+		} else {
+			button.setAttribute( 'aria-expanded', true );
+			content.classList.add( 'is-open' );
+		}
+	} );
+}
+
+function init() {
+	const containers = document.querySelectorAll( '.wp-block-wporg-modal' );
+
+	containers.forEach( ( container ) => {
+		if ( container.classList.contains( 'is-type-modal' ) ) {
+			intializeModal( container );
+		} else if ( container.classList.contains( 'is-type-popover' ) ) {
+			intializePopover( container );
+		} else {
+			intializeInline( container );
+		}
+	} );
+}
+
+window.addEventListener( 'load', init );

--- a/mu-plugins/blocks/modal/src/modal/view.js
+++ b/mu-plugins/blocks/modal/src/modal/view.js
@@ -16,16 +16,20 @@ function getModalId( prefix = 'modal-' ) {
  */
 function intializeModal( container ) {
 	const modalId = getModalId( 'wporg-modal-' );
-	container.querySelector( 'button' ).setAttribute( 'data-micromodal-trigger', modalId );
+	container.querySelector( '.wporg-modal__button' ).setAttribute( 'data-micromodal-trigger', modalId );
 	container.querySelector( '.wporg-modal__modal' ).id = modalId;
 
 	MicroModal.init( {
 		onShow: ( modal ) => {
-			const button = container.querySelector( `button[data-micromodal-trigger=${ modal.id }]` );
+			const button = container.querySelector(
+				`.wporg-modal__button[data-micromodal-trigger=${ modal.id }]`
+			);
 			button.setAttribute( 'aria-expanded', true );
 		},
 		onClose: ( modal ) => {
-			const button = container.querySelector( `button[data-micromodal-trigger=${ modal.id }]` );
+			const button = container.querySelector(
+				`.wporg-modal__button[data-micromodal-trigger=${ modal.id }]`
+			);
 			button.setAttribute( 'aria-expanded', false );
 		},
 	} );

--- a/mu-plugins/blocks/modal/src/modal/view.js
+++ b/mu-plugins/blocks/modal/src/modal/view.js
@@ -37,46 +37,25 @@ function intializeModal( container ) {
 
 /**
  * Set up the handlers for opening/closing the popover drawer.
- * Uses the click handler from `intializeInline`, then adds handlers for
- * closing when click or focus moves out of the popover.
- * See the navigation block submenu behavior.
  *
  * @param {HTMLElement} container
  */
 function intializePopover( container ) {
-	const button = container.querySelector( '* > .wporg-modal__button' );
-	const content = container.querySelector( '.wporg-modal__modal' );
-
-	if ( ! button || ! content ) {
-		return;
-	}
-
-	intializeInline( container );
-
-	// Close on click outside.
-	document.addEventListener( 'click', function ( event ) {
-		if ( ! container.contains( event.target ) ) {
-			button.setAttribute( 'aria-expanded', false );
-			content.classList.remove( 'is-open' );
-		}
-	} );
-
-	// Close on focus outside or escape key.
-	document.addEventListener( 'keyup', function ( event ) {
-		if ( event.key === 'Escape' || ! container.contains( event.target ) ) {
-			button.setAttribute( 'aria-expanded', false );
-			content.classList.remove( 'is-open' );
-		}
-	} );
+	intializeInline( container, true );
 }
 
 /**
  * Set up the click handler for opening/closing the inline drawer.
- * This is also used by the "popover" style.
+ *
+ * If `shouldAutoClose` is true (for the "popover" style), it adds handlers
+ * for closing when click or focus moves out of the popover.
+ *
+ * See the navigation block submenu behavior.
  *
  * @param {HTMLElement} container
+ * @param {boolean}     shouldAutoClose
  */
-function intializeInline( container ) {
+function intializeInline( container, shouldAutoClose = false ) {
 	const button = container.querySelector( '* > .wporg-modal__button' );
 	const content = container.querySelector( '.wporg-modal__modal' );
 
@@ -93,6 +72,24 @@ function intializeInline( container ) {
 			content.classList.add( 'is-open' );
 		}
 	} );
+
+	if ( shouldAutoClose ) {
+		// Close on click outside.
+		document.addEventListener( 'click', function ( event ) {
+			if ( ! container.contains( event.target ) ) {
+				button.setAttribute( 'aria-expanded', false );
+				content.classList.remove( 'is-open' );
+			}
+		} );
+
+		// Close on focus outside or escape key.
+		document.addEventListener( 'keyup', function ( event ) {
+			if ( event.key === 'Escape' || ! container.contains( event.target ) ) {
+				button.setAttribute( 'aria-expanded', false );
+				content.classList.remove( 'is-open' );
+			}
+		} );
+	}
 }
 
 function init() {

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/helpers/helpers.php';
 require_once __DIR__ . '/blocks/global-header-footer/blocks.php';
 require_once __DIR__ . '/blocks/horizontal-slider/horizontal-slider.php';
 require_once __DIR__ . '/blocks/language-suggest/language-suggest.php';
+require_once __DIR__ . '/blocks/modal/index.php';
 require_once __DIR__ . '/blocks/latest-news/latest-news.php';
 require_once __DIR__ . '/blocks/notice/index.php';
 require_once __DIR__ . '/blocks/screenshot-preview/block.php';

--- a/package.json
+++ b/package.json
@@ -64,5 +64,7 @@
 			"selector-class-pattern": null
 		}
 	},
-	"dependencies": {}
+	"dependencies": {
+		"micromodal": "0.4.10"
+	}
 }


### PR DESCRIPTION
On many of the redesigned sites, we've been circling around a filter bar design, which uses a modal-ish popover-ish component. For example on Themes, the list of filters is hidden behind the "filters" button. When it's clicked, the filters appear. There is no core block to do this, so we need to create one.

I started this block as a modal, using micromodal (which is also used by the Navigation block). I realized though, that a popover is a slightly different interaction, and ended up creating two variations on the Modal, Popover and Collapsed, ending with 3 new blocks.

- Modal: The container that floats in the middle of the screen. Clicking outside the container or hitting escape will close it.
- Popover: The container stays attached to the toggle button but overlaps the content, like a dropdown menu. Clicking outside the container or hitting escape will close it.
- Collapsed (inline): The container is hidden by default, but when expanded, pushes the content below down to not overlap. Only closed by clicking the toggle, to prevent content jumps.

It's meant to be more of a proof-of-concept. (More details and inspiration will be here before I un-draft this)

<!-- img alt="" src="https://user-images.githubusercontent.com/541093/235262355-5e2edaed-10ee-4382-a637-bc7cf45075a1.png" width="400" / -->

**Screenshots**

When closed, the block just renders the button:

![modal-closed](https://user-images.githubusercontent.com/541093/235262668-2d7043ae-820a-44b2-bfd6-b95395d6c4e9.png)

When the button is toggled on, the content appears. The styling needs help, of course, but a lot of that can be done in the editor, so that we can style differently for the different sites - themes can be dark while plugins is light, for example.

(I've added in form elements just to show how it would work, those would need to be custom blocks per-theme to support the different filtering methods)

<a id="examples"></a>

| Modal | Popover | Inline |
|---|---|---|
| ![modal-modal](https://user-images.githubusercontent.com/541093/235262677-30110db3-58c6-4ff3-a567-1187bdf5fccc.png) | ![modal-popover](https://user-images.githubusercontent.com/541093/235262678-ff4b3444-9b40-403c-a68c-4c75d24bafe1.png) | ![modal-inline](https://user-images.githubusercontent.com/541093/235262674-d99719bb-5da3-4942-b88e-8fadb35c5746.png) |

Editor— the block doesn't use a modal pattern in the editor, but the content does show/hide on selection.

| Default, other blocks selected | Modal block selected |
|---|---|
| ![modal-editor-closed](https://user-images.githubusercontent.com/541093/235262672-b4e1d3f5-79b3-456b-bd70-7cfd7019514d.png) | ![modal-editor-active](https://user-images.githubusercontent.com/541093/235262671-437b2701-41b4-4461-afbe-437b1852bc9f.png) |

**To test**

- Try it in the editor
- Or try using this page template: https://gist.github.com/ryelle/e4294389e82724782649c23eca4c4c78
