### PR TITLE
New Block: Link Wrapper to add a link to a group of blocks.

### DIFF
--- a/mu-plugins/blocks/link-wrapper/index.php
+++ b/mu-plugins/blocks/link-wrapper/index.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Block Name: Link Wrapper
+ * Description: Link a set of blocks to a given page.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\MU_Plugins\Link_Wrapper_Block;
+
+use function WordPressdotorg\MU_Plugins\Helpers\register_assets_from_metadata;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type( __DIR__ . '/build' );
+}

--- a/mu-plugins/blocks/link-wrapper/postcss/style.pcss
+++ b/mu-plugins/blocks/link-wrapper/postcss/style.pcss
@@ -1,0 +1,34 @@
+.wp-block-wporg-link-wrapper {
+	position: relative;
+	display: block;
+	text-decoration: none !important;
+	color: var(--wp--preset--color--charcoal-1);
+	overflow: hidden;
+
+	&:focus-visible {
+		outline: none;
+	}
+
+	&:hover {
+		text-decoration: underline !important;
+	}
+
+	/* Put the outline on `after` to ensure it's visible over a Cover block. */
+	&:focus-visible::after {
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		z-index: 10;
+		content: "";
+		outline: 1.5px solid var(--wp--preset--color--blueberry-1);
+		outline-offset: -1.5px;
+		box-shadow: inset 0 0 0 3px var(--wp--preset--color--white);
+		border-radius: inherit;
+	}
+
+	& .wporg-link-wrapper__notice {
+		margin: 1em 0 0;
+	}
+}

--- a/mu-plugins/blocks/link-wrapper/postcss/style.pcss
+++ b/mu-plugins/blocks/link-wrapper/postcss/style.pcss
@@ -28,7 +28,13 @@
 		border-radius: inherit;
 	}
 
+	/*
+	 * This needs to be in the frontend style.css so that it is loaded
+	 * inside the editor iframe.
+	 */
+
 	& .wporg-link-wrapper__notice {
 		margin: 1em 0 0;
+		color: #1e1e1e;
 	}
 }

--- a/mu-plugins/blocks/link-wrapper/src/block.json
+++ b/mu-plugins/blocks/link-wrapper/src/block.json
@@ -1,0 +1,53 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/link-wrapper",
+	"title": "Link Wrapper",
+	"icon": "admin-links",
+	"category": "layout",
+	"description": "Link a set of blocks to a given page.",
+	"textdomain": "wporg",
+	"attributes": {
+		"url": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "a",
+			"attribute": "href"
+		}
+	},
+	"supports": {
+		"align": true,
+		"color": {
+			"text": true,
+			"background": true,
+			"link": false
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": true,
+				"padding": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
+		"__experimentalLayout": true
+	},
+	"editorScript": "file:./index.js",
+	"style": "file:./style.css"
+}

--- a/mu-plugins/blocks/link-wrapper/src/index.js
+++ b/mu-plugins/blocks/link-wrapper/src/index.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { useRef } from '@wordpress/element';
+import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { Notice, PanelBody, TextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+function Edit( { attributes, setAttributes } ) {
+	const wrapperRef = useRef();
+
+	// Check for nested links or buttons. This doesn't catch every case, since
+	// some blocks have settings to output links on the frontend (images), but
+	// it provides some guardrails to validate the content.
+	const links = wrapperRef.current?.querySelectorAll( 'a,[data-type="core/button"]' ) || [];
+
+	return (
+		<>
+			<InspectorControls key="setting">
+				<PanelBody title={ __( 'Link destination', 'wporg' ) }>
+					<TextControl
+						label={ __( 'Link destination', 'wporg' ) }
+						hideLabelFromVision
+						value={ attributes.url }
+						onChange={ ( val ) => setAttributes( { url: val } ) }
+						type="url"
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...useBlockProps( { ref: wrapperRef } ) }>
+				<InnerBlocks />
+				{ !! links.length && (
+					<Notice
+						className="wporg-link-wrapper__notice"
+						spokenMessage={ null }
+						status="warning"
+						isDismissible={ false }
+					>
+						{ __(
+							'This block should not contain links or buttons. Remove the link, or use a different container.',
+							'wporg'
+						) }
+					</Notice>
+				) }
+			</div>
+		</>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: ( { attributes } ) => {
+		const blockProps = useBlockProps.save();
+		return (
+			<a { ...blockProps } href={ attributes.url }>
+				<InnerBlocks.Content />
+			</a>
+		);
+	},
+} );

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/blocks/global-header-footer/blocks.php';
 require_once __DIR__ . '/blocks/horizontal-slider/horizontal-slider.php';
 require_once __DIR__ . '/blocks/language-suggest/language-suggest.php';
 require_once __DIR__ . '/blocks/latest-news/latest-news.php';
+require_once __DIR__ . '/blocks/link-wrapper/index.php';
 require_once __DIR__ . '/blocks/notice/index.php';
 require_once __DIR__ . '/blocks/sidebar-container/index.php';
 require_once __DIR__ . '/blocks/screenshot-preview/block.php';


### PR DESCRIPTION
In https://github.com/WordPress/wporg-main-2022/issues/258, it was requested that the entire header banner be clickable. This new block mirrors the Group behavior, with an added attribute for "link destination" (`url`).

This is required before we can update the homepage swag banner, but you can test it with this code

```html
<!-- wp:wporg/link-wrapper {"align":"full","backgroundColor":"blueberry-1","textColor":"white","layout":{"type":"constrained"}} -->
<a class="wp-block-wporg-link-wrapper alignfull has-white-color has-blueberry-1-background-color has-text-color has-background" href="https://mercantile.wordpress.org/"><!-- wp:cover {"url":"https://wordpress.org/files/2023/03/confetti-eased-2-1.png","id":17922,"dimRatio":0,"overlayColor":"blueberry-1","focalPoint":{"x":0.5,"y":0.1},"minHeight":80,"contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"8px","right":"0","bottom":"8px","left":"0"}}},"textColor":"white"} -->
<div class="wp-block-cover alignfull is-light has-white-color has-text-color" style="padding-top:8px;padding-right:0;padding-bottom:8px;padding-left:0;min-height:80px"><span aria-hidden="true" class="wp-block-cover__background has-blueberry-1-background-color has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-17922" alt="" src="https://wordpress.org/files/2023/03/confetti-eased-2-1.png" style="object-position:50% 10%" data-object-fit="cover" data-object-position="50% 10%"/><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:image {"width":96,"height":80,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large is-resized"><img src="https://wordpress.org/files/2023/03/swag-bulk-org.png" alt="" width="96" height="80"/></figure>
<!-- /wp:image -->

<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.1"}}} -->
<p style="line-height:1.1">Celebrate the 20th anniversary on May 27th with new swag. #wp20</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div></div>
<!-- /wp:cover --></a>
<!-- /wp:wporg/link-wrapper -->
```

@WordPress/meta-design I've requested a review just to check that this focus & hover state works— I used the same double-border concept that was used on the search so that it could be seen against light & dark backgrounds. The swag banner itself can be reviewed when that PR is ready.

**Screenshots**

|    | Screenshot |
|---|---|
| Block in the editor | ![editor](https://github.com/WordPress/wporg-mu-plugins/assets/541093/ff1c7d8e-aab4-4615-bf77-58af93397748) |
| In editor, settings open | ![editor-settings](https://github.com/WordPress/wporg-mu-plugins/assets/541093/318b302d-3470-41bd-8dfb-0a10a3b57c6c) |
| In editor, warn if there's a nested link | ![editor-link-error](https://github.com/WordPress/wporg-mu-plugins/assets/541093/da654113-3777-4c99-abfc-bf34b9d1d3ac) |
| Front end | ![frontend](https://github.com/WordPress/wporg-mu-plugins/assets/541093/fe64da11-a392-4ab5-9613-6e34004894e8) |
| Front end, hover state | ![frontend-hover](https://github.com/WordPress/wporg-mu-plugins/assets/541093/a9dbe8b4-bfcd-4923-80d3-9f70d5d60477) |
| Front end, focus state (on a dark background) | ![frontend-focus-dark](https://github.com/WordPress/wporg-mu-plugins/assets/541093/64f9898a-94de-4e6b-a757-51923ef5c558) |
| Front end, focus state (on a light background) | ![frontend-focus-light](https://github.com/WordPress/wporg-mu-plugins/assets/541093/a35d5f42-60b6-43e5-88f6-dbda813569b3) |

**To test**

- Check out branch, build, spin up a child site
- Try adding the block to a page or template
- Set a destination
- Save & view on the frontend
- The block should look correct, and the entire area should be clickable
- Focus should also work as expected

Try a few different blocks — if you add a link or button, you should see the warning (it's not perfect, but it should catch easy issues).