### PR TITLE
Header: Fix header & nav issues on small screens

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/view.js
+++ b/mu-plugins/blocks/global-header-footer/js/view.js
@@ -185,6 +185,22 @@
 			closeSearchButton.setAttribute( 'aria-label', labels.closeSearchLabel || 'Close Search' );
 		}
 
+		// Watch for the `has-modal-open` class to be removed, and remove the global class too.
+		// This works as a callback to be fired when the global header modals are closed, as
+		// they're attached when each modal opens.
+		const modalCloseObserver = new window.MutationObserver( ( mutationList, observer ) => {
+			for ( const mutation of mutationList ) {
+				const { attributeName, type, target } = mutation;
+				if ( type === 'attributes' && attributeName === 'class' ) {
+					if ( ! target.classList.contains( 'has-modal-open' ) ) {
+						target.classList.remove( 'has-global-modal-open' );
+					}
+				}
+			}
+			// Remove the observer to prevent recursion. This will be re-attached when the modal is opened.
+			observer.disconnect();
+		} );
+
 		const openButtons = document.querySelectorAll( '[data-micromodal-trigger]' );
 		openButtons.forEach( function ( button ) {
 			// When any open menu button is clicked, find any existing close buttons and click them.
@@ -198,6 +214,15 @@
 				);
 
 				closeButtons.forEach( ( _button ) => _button.click() );
+
+				// If this button opened the global search, add a class and trigger the close observer.
+				if (
+					button.parentNode.classList.contains( 'global-header__navigation' ) ||
+					button.parentNode.classList.contains( 'global-header__search' )
+				) {
+					document.documentElement.classList.add( 'has-global-modal-open' );
+					modalCloseObserver.observe( document.documentElement, { attributes: true } );
+				}
 			} );
 		} );
 	} );

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -95,3 +95,11 @@
 		}
 	}
 }
+
+/* When on the main (non-rosetta) sites, the logo should take over 100% space. */
+html[lang="en-US"] .wp-block-group.global-header .wp-block-image.global-header__wporg-logo-mark {
+
+	@media (--mobile-only) {
+		flex-basis: 100%;
+	}
+}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -334,7 +334,7 @@
  * See https://github.com/WordPress/wporg-mu-plugins/issues/371/.
  */
 @media (--mobile-only) {
-	html.has-modal-open .global-header {
+	html.has-global-modal-open .global-header {
 		position: fixed;
 		z-index: 9999; /* Arbitrary z-index to be above any possible element on a page. */
 		left: 0;


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-parent-2021/issues/85 — there are two parts to the issue there, and so two fixes here:

[Fix logo spacing on default English site](https://github.com/WordPress/wporg-mu-plugins/commit/b5c397aaa75517b4b6ecfbcdb34f26f109f2c81e)
Fixes issue introduced in https://github.com/WordPress/wporg-mu-plugins/commit/43a8a94a4de8cd16ac2b079c9eeb70eb71146a1d where the menu & search icons collapsed to the left on small screens. The logo flex size needs to be different when there is no locale name.

[Only apply page scroll fix to header modals](https://github.com/WordPress/wporg-mu-plugins/commit/25eae377d775bb7e23a4c4cb3c168aec8982f580)
This prevents other nav modals (like the page subnav) which toggle the `has-modal-open` class from affecting the position of the global header bar.

**Screenshots**

Small screen, menu open
<img alt="" width="500" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/aac3e09f-2999-420d-a013-1b7db365a2fc" />

Larger screen, no change
![Screen Shot 2023-05-30 at 13 58 07](https://github.com/WordPress/wporg-mu-plugins/assets/541093/e5587fa0-9f77-433e-85d6-95bfc2909cc6)

Rosetta sites, locale still correctly aligned on small screens
![Screen Shot 2023-05-30 at 13 59 08](https://github.com/WordPress/wporg-mu-plugins/assets/541093/6e7b3f11-846a-404c-b7a2-9185cf9f10c6)
