### PR TITLE
Sidebar Container: Run the fixed sidebar check after expanding the table of contents

### DIFF
--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -85,15 +85,6 @@ function isSidebarWithinViewport( container ) {
 
 function init() {
 	const container = document.querySelector( '.wp-block-wporg-sidebar-container' );
-
-	if ( container ) {
-		if ( isSidebarWithinViewport( container ) ) {
-			container.classList.add( 'is-fixed-sidebar' );
-			onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).
-			window.addEventListener( 'scroll', onScroll );
-		}
-	}
-
 	const toggleButton = container?.querySelector( '.wporg-table-of-contents__toggle' );
 	const list = container?.querySelector( '.wporg-table-of-contents__list' );
 
@@ -144,6 +135,14 @@ function init() {
 				} );
 			}
 		} );
+	}
+
+	if ( container ) {
+		if ( isSidebarWithinViewport( container ) ) {
+			container.classList.add( 'is-fixed-sidebar' );
+			onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).
+			window.addEventListener( 'scroll', onScroll );
+		}
 	}
 
 	// If there is no table of contents, hide the heading.


### PR DESCRIPTION
Fixes #409 — When the page was loaded initially, the `isSidebarWithinViewport` check was run on the collapsed sidebar, so the height check in `isSidebarWithinViewport` passed and the sidebar is set as fixed. Then, a few lines later, the collapse/expand toggle logic expanded the sidebar on large screens, and now it could be too tall for the fixed sidebar behavior.

This fix just swaps the initial `isSidebarWithinViewport` to after the toggle button logic, so that the menu is in it's correct state when the height is measured.

To test:

- Use the documentation test site
- View a few articles with different ToC lengths, for example http://localhost:8888/article/roles-and-capabilities/, http://localhost:8888/article/before-you-create-a-network/
- Try at different screen sizes