### PR TITLE
Specify a composer autoloader-suffix such that the Composer class names don't change each deploy.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
 		"allow-plugins": {
 			"composer/installers": true,
 			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
+		},
+		"autoloader-suffix": "_wporg_mu_plugins"
 	},
 	"scripts": {
 		"format": "phpcbf -p",


### PR DESCRIPTION
Due to how composer works, it generates a new autoloader classname on each build, this is generated from a hash of the built configuration - which includes the git hash of the latest git commit to this repo.

This results in changes such as this, without any meaningful changes to the actual composer autoloaders:
```diff
-class ComposerStaticInitd304aa995aee3f8f33a4ed8212934834
+class ComposerStaticInitafee523dbfd1bd7f873d099f361b18c0
```

As there should only ever be a singular instance of `wporg-mu-plugins` loaded, we can instead specify a static suffix:
```diff
-class ComposerStaticInitd304aa995aee3f8f33a4ed8212934834
+class ComposerStaticInit_wporg_mu_plugins
```

This shouldn't cause any compat issues, and will reduce the changes in build diffs, and avoid situations where the new Class is loaded but the old classname is called, which can happen in a race-condition during WordPress.org deploys.