### PR TITLE
Add Blocks page navigation link under Download & Extend.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -443,6 +443,11 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
+					'title' => esc_html_x( 'Blocks', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/blocks/',
+					'type'  => 'custom',
+				),
+				array(
 					'title' => esc_html_x( 'Mobile', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/mobile/',
 					'type'  => 'custom',


### PR DESCRIPTION
Fixes #417 

Adds a "Blocks" link to the  Download & Extend menu in the header navigation across all .org sites. More information on the new Blocks page is available in https://github.com/WordPress/wporg-main-2022/issues/245. 

**This change should only be made once the Blocks page is live.**