### PR TITLE
When querying Helpscout via get_paged(), merge the results even for arrays

### DIFF
--- a/mu-plugins/utilities/class-helpscout.php
+++ b/mu-plugins/utilities/class-helpscout.php
@@ -123,12 +123,8 @@ class HelpScout {
 		while ( ! empty( $api->_links->next->href ) ) {
 			$api = $this->get( $api->_links->next->href );
 
-			if ( is_array( $api->_embedded ) ) {
-				
-			} else {
-				foreach ( $api->_embedded as $field => $value ) {
-					$response->_embedded->$field = array_merge( $response->_embedded->$field, $value );
-				}
+			foreach ( $api->_embedded as $field => $value ) {
+				$response->_embedded->$field = array_merge( $response->_embedded->$field, $value );
 			}
 		}
 


### PR DESCRIPTION
This was a customization that I have locally.

I don't actually know why I have it made, but I recall thinking "What was I thinking when I wrote that?" when I made this change. I suspect it's probably needed to actually make the function work correctly.