### PR TITLE
Add versioning for fonts

### DIFF
--- a/bin/font-subset.js
+++ b/bin/font-subset.js
@@ -10,9 +10,8 @@
  * 4. Change the fontFileName, fontWeight and fontFamily etc. accroding to the font you use in this script.
  * 5. npm run font-subset.
  * 6. Copy subsetting files and css styles to where they should be placed.
- * 7. Copy php versions from CLI output to global-fonts/index.php:get_font_url()
- * 8. remove output and fonts.
- * 9. Remove {"type": "module"} from package.json or the linter would prompt an error.
+ * 7. remove output and fonts.
+ * 8. Remove {"type": "module"} from package.json or the linter would prompt an error.
  */
 import { spawn } from 'child_process';
 import path from 'path';
@@ -95,8 +94,7 @@ for ( const alphabet of alphabets ) {
 	} );
 }
 
-let cssCode = '',
-	phpVersions = [];
+let cssCode = '';
 
 // Create our font face rules
 // This would need to be modified for other weights and styles
@@ -108,8 +106,6 @@ alphabets.forEach( ( alphabet ) => {
 	}
 
 	let hash = generateHash( filename );
-
-	phpVersions.push( `'${ alphabet.name }' => '${ hash }'` );
 
 	cssCode += `
 	/* ${ alphabet.name } */
@@ -137,6 +133,5 @@ ${ cssCode }
 	{},
 	() => {
 		console.log( 'CSS file written to:', cssPath );
-		console.log( 'Font versions for global-fonts/index.php: [ ', phpVersions.join(', '), ' ]' );
 	}
 );

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -41,9 +41,19 @@ function relative_to_absolute_urls( $editor_settings ) {
 	}
 
 	foreach ( $editor_settings['styles'] as $i => $style ) {
-		if ( str_contains( $style['css'], './Inter' ) || str_contains( $style['css'], './EB-Garamond' ) ) {
-			$url = plugins_url( '', __FILE__ );
-			$style['css'] = str_replace( 'url(./', "url($url/", $style['css'] );
+		if (
+			str_contains( $style['css'], './Inter' ) ||
+			str_contains( $style['css'], './EB-Garamond' ) ||
+			str_contains( $style['css'], './CourierPrime' ) ||
+			str_contains( $style['css'], './IBMPlexMono' )
+		) {
+			$style['css'] = preg_replace_callback(
+				'!url\(./(?P<path>[^)]+)\)!i',
+				function( $m ) {
+					return "url(" . plugins_url( $m['path'], __FILE__ ) . ")";
+				}
+			);
+
 			$editor_settings['styles'][ $i ] = $style;
 		}
 	}

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -152,50 +152,62 @@ function get_font_url( $font, $subset ) {
 
 	switch ( $lower_font ) {
 		case 'courier prime':
+			$font_versions  = [ 'cyrillic-ext' => '4ecb2879668a', 'cyrillic' => '4ecb2879668a', 'greek-ext' => '4ecb2879668a', 'greek' => 'eba1f8ff4da0', 'vietnamese' => 'da75b869896c', 'latin-ext' => '2aad680866fd', 'latin' => '7b9aa715ce49' ];
 			$font_folder    = 'CourierPrime/';
 			$font_file_name = 'CourierPrime-Regular-';
 			break;
 		case 'courier prime bold':
+			$font_versions  = [ 'cyrillic-ext' => 'c11c7999d78e', 'cyrillic' => 'c11c7999d78e', 'greek-ext' => 'c11c7999d78e', 'greek' => 'ba79634e2cd8', 'vietnamese' => '180aa42496b5', 'latin-ext' => '94527d576afd', 'latin' => '01c037d9e0a1' ];
 			$font_folder    = 'CourierPrime/';
 			$font_file_name = 'CourierPrime-Bold-';
 			break;
 		case 'inter':
+			$font_versions  = [ 'cyrillic-ext' => '870d267d091f', 'cyrillic' => '2e1f0e6a6eda', 'greek-ext' => 'f1fb719a6429', 'greek' => '8fb4801a481e', 'vietnamese' => 'ec198636627a', 'latin-ext' => '802f9ad48332', 'latin' => 'b07a289bdf69', 'arrows' => '63555c379a62' ];
 			$font_folder    = 'Inter/';
 			$font_file_name = 'Inter-';
 			break;
 		case 'eb garamond':
+			$font_versions  = [ 'cyrillic-ext' => '8176ef6e06a1', 'cyrillic' => '1af56bf0af64', 'greek-ext' => 'd3bd499d027a', 'greek' => 'ec834832b30b', 'vietnamese' => '30eaef521e8a', 'latin-ext' => 'a08861311328', 'latin' => '2c7bc866cb03', 'arrows' => '943d7defaf99' ];
 			$font_folder    = 'EB-Garamond/';
 			$font_file_name = 'EBGaramond-';
 			break;
 		case 'eb garamond italic':
+			$font_versions  = [ 'cyrillic-ext' => '7808b24a969c', 'cyrillic' => '766320cf480d', 'greek-ext' => '5c9c07959839', 'greek' => '9cdc7745aab9', 'vietnamese' => '47ae16ca8ebd', 'latin-ext' => 'cdaf0905fb1c', 'latin' => 'b6b388074e82' ];
 			$font_folder    = 'EB-Garamond/';
 			$font_file_name = 'EBGaramond-Italic-';
 			break;
 		case 'ibm plex mono extralight':
+			$font_versions  = [ 'cyrillic-ext' => '99488ab1f1b4', 'cyrillic' => '370513b21aa8', 'vietnamese' => '04a172643c2d', 'latin-ext' => '1214d6939808', 'latin' => '075de20a9833' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-ExtraLight-';
 			break;
 		case 'ibm plex mono extralight italic':
+			$font_versions  = [ 'cyrillic-ext' => 'f67b80c3648c', 'cyrillic' => '51c4ca00cdb0', 'vietnamese' => '632a48e3ba8e', 'latin-ext' => '454bc3623abc', 'latin' => '38cfc7b0cee7' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-ExtraLightItalic-';
 			break;
 		case 'ibm plex mono':
+			$font_versions  = [ 'cyrillic-ext' => 'd5b4785e465e', 'cyrillic' => 'dbae9f565349', 'vietnamese' => '0aa3dc1ec47b', 'latin-ext' => '139e6cd03358', 'latin' => '8ddc86b0ebf4' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-Regular-';
 			break;
 		case 'ibm plex mono italic':
+			$font_versions  = [ 'cyrillic-ext' => 'c415eab9d09e', 'cyrillic' => 'c586ce96eb42', 'vietnamese' => '0b8d65223f8f', 'latin-ext' => 'bb87d332affb', 'latin' => 'b8d4f3563cf8' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-Italic-';
 			break;
 		case 'ibm plex mono medium':
+			$font_versions  = [ 'cyrillic-ext' => '431d255a3afa', 'cyrillic' => 'beb561f0d2e7', 'greek-ext' => '49bf3255c571', 'greek' => '6152b28764d6', 'vietnamese' => 'c58ce4527d80', 'latin-ext' => '4ace19a3c116', 'latin' => '44150b50e9d4', 'arrows' => 'e9f571cc6a63' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-Medium-';
 			break;
 		case 'ibm plex mono bold':
+			$font_versions  = [ 'cyrillic-ext' => 'd20781be5b07', 'cyrillic' => 'c6178ab7258f', 'vietnamese' => '5e8388bb91ff', 'latin-ext' => 'ac5ae799cb8f', 'latin' => '59cad49c271e' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-Bold-';
 			break;
 		case 'ibm plex mono bold italic':
+			$font_versions  = [ 'cyrillic-ext' => 'acd7ea8d0d94', 'cyrillic' => '20d5b885400b', 'vietnamese' => 'a005afe26029', 'latin-ext' => '580700b45e3a', 'latin' => 'a96c20e7edc2' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-BoldItalic-';
 			break;
@@ -209,5 +221,7 @@ function get_font_url( $font, $subset ) {
 		return false;
 	}
 
-	return plugins_url( $filepath, __FILE__ );
+	$font_version = $font_versions[ $lower_subset ] ?? '';
+
+	return plugins_url( "{$filepath}?ver={$font_version}", __FILE__ );
 }

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -152,62 +152,50 @@ function get_font_url( $font, $subset ) {
 
 	switch ( $lower_font ) {
 		case 'courier prime':
-			$font_versions  = [ 'cyrillic-ext' => '4ecb2879668a', 'cyrillic' => '4ecb2879668a', 'greek-ext' => '4ecb2879668a', 'greek' => 'eba1f8ff4da0', 'vietnamese' => 'da75b869896c', 'latin-ext' => '2aad680866fd', 'latin' => '7b9aa715ce49' ];
 			$font_folder    = 'CourierPrime/';
 			$font_file_name = 'CourierPrime-Regular-';
 			break;
 		case 'courier prime bold':
-			$font_versions  = [ 'cyrillic-ext' => 'c11c7999d78e', 'cyrillic' => 'c11c7999d78e', 'greek-ext' => 'c11c7999d78e', 'greek' => 'ba79634e2cd8', 'vietnamese' => '180aa42496b5', 'latin-ext' => '94527d576afd', 'latin' => '01c037d9e0a1' ];
 			$font_folder    = 'CourierPrime/';
 			$font_file_name = 'CourierPrime-Bold-';
 			break;
 		case 'inter':
-			$font_versions  = [ 'cyrillic-ext' => '870d267d091f', 'cyrillic' => '2e1f0e6a6eda', 'greek-ext' => 'f1fb719a6429', 'greek' => '8fb4801a481e', 'vietnamese' => 'ec198636627a', 'latin-ext' => '802f9ad48332', 'latin' => 'b07a289bdf69', 'arrows' => '63555c379a62' ];
 			$font_folder    = 'Inter/';
 			$font_file_name = 'Inter-';
 			break;
 		case 'eb garamond':
-			$font_versions  = [ 'cyrillic-ext' => '8176ef6e06a1', 'cyrillic' => '1af56bf0af64', 'greek-ext' => 'd3bd499d027a', 'greek' => 'ec834832b30b', 'vietnamese' => '30eaef521e8a', 'latin-ext' => 'a08861311328', 'latin' => '2c7bc866cb03', 'arrows' => '943d7defaf99' ];
 			$font_folder    = 'EB-Garamond/';
 			$font_file_name = 'EBGaramond-';
 			break;
 		case 'eb garamond italic':
-			$font_versions  = [ 'cyrillic-ext' => '7808b24a969c', 'cyrillic' => '766320cf480d', 'greek-ext' => '5c9c07959839', 'greek' => '9cdc7745aab9', 'vietnamese' => '47ae16ca8ebd', 'latin-ext' => 'cdaf0905fb1c', 'latin' => 'b6b388074e82' ];
 			$font_folder    = 'EB-Garamond/';
 			$font_file_name = 'EBGaramond-Italic-';
 			break;
 		case 'ibm plex mono extralight':
-			$font_versions  = [ 'cyrillic-ext' => '99488ab1f1b4', 'cyrillic' => '370513b21aa8', 'vietnamese' => '04a172643c2d', 'latin-ext' => '1214d6939808', 'latin' => '075de20a9833' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-ExtraLight-';
 			break;
 		case 'ibm plex mono extralight italic':
-			$font_versions  = [ 'cyrillic-ext' => 'f67b80c3648c', 'cyrillic' => '51c4ca00cdb0', 'vietnamese' => '632a48e3ba8e', 'latin-ext' => '454bc3623abc', 'latin' => '38cfc7b0cee7' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-ExtraLightItalic-';
 			break;
 		case 'ibm plex mono':
-			$font_versions  = [ 'cyrillic-ext' => 'd5b4785e465e', 'cyrillic' => 'dbae9f565349', 'vietnamese' => '0aa3dc1ec47b', 'latin-ext' => '139e6cd03358', 'latin' => '8ddc86b0ebf4' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-Regular-';
 			break;
 		case 'ibm plex mono italic':
-			$font_versions  = [ 'cyrillic-ext' => 'c415eab9d09e', 'cyrillic' => 'c586ce96eb42', 'vietnamese' => '0b8d65223f8f', 'latin-ext' => 'bb87d332affb', 'latin' => 'b8d4f3563cf8' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-Italic-';
 			break;
 		case 'ibm plex mono medium':
-			$font_versions  = [ 'cyrillic-ext' => '431d255a3afa', 'cyrillic' => 'beb561f0d2e7', 'greek-ext' => '49bf3255c571', 'greek' => '6152b28764d6', 'vietnamese' => 'c58ce4527d80', 'latin-ext' => '4ace19a3c116', 'latin' => '44150b50e9d4', 'arrows' => 'e9f571cc6a63' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-Medium-';
 			break;
 		case 'ibm plex mono bold':
-			$font_versions  = [ 'cyrillic-ext' => 'd20781be5b07', 'cyrillic' => 'c6178ab7258f', 'vietnamese' => '5e8388bb91ff', 'latin-ext' => 'ac5ae799cb8f', 'latin' => '59cad49c271e' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-Bold-';
 			break;
 		case 'ibm plex mono bold italic':
-			$font_versions  = [ 'cyrillic-ext' => 'acd7ea8d0d94', 'cyrillic' => '20d5b885400b', 'vietnamese' => 'a005afe26029', 'latin-ext' => '580700b45e3a', 'latin' => 'a96c20e7edc2' ];
 			$font_folder    = 'IBMPlexMono/';
 			$font_file_name = 'IBMPlexMono-BoldItalic-';
 			break;
@@ -221,7 +209,7 @@ function get_font_url( $font, $subset ) {
 		return false;
 	}
 
-	$font_version = $font_versions[ $lower_subset ] ?? '';
+	$font_version = filemtime( __DIR__ . '/' . $filepath );
 
 	return plugins_url( "{$filepath}?ver={$font_version}", __FILE__ );
 }

--- a/mu-plugins/global-fonts/style.css
+++ b/mu-plugins/global-fonts/style.css
@@ -8,7 +8,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Regular-cyrillic-ext.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Regular-cyrillic-ext.woff2?ver=4ecb2879668a) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -18,7 +18,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Regular-cyrillic.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Regular-cyrillic.woff2?ver=4ecb2879668a) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -28,7 +28,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Regular-greek-ext.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Regular-greek-ext.woff2?ver=4ecb2879668a) format("woff2");
 	unicode-range: U+1F00-1FFF;
 }
 
@@ -38,7 +38,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Regular-greek.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Regular-greek.woff2?ver=eba1f8ff4da0) format("woff2");
 	unicode-range: U+0370-03FF;
 }
 
@@ -48,7 +48,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Regular-vietnamese.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Regular-vietnamese.woff2?ver=da75b869896c) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -58,7 +58,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Regular-latin-ext.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Regular-latin-ext.woff2?ver=2aad680866fd) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -68,7 +68,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Regular-latin.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Regular-latin.woff2?ver=7b9aa715ce49) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -82,7 +82,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Bold-cyrillic-ext.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Bold-cyrillic-ext.woff2?ver=c11c7999d78e) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -92,7 +92,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Bold-cyrillic.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Bold-cyrillic.woff2?ver=c11c7999d78e) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -102,7 +102,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Bold-greek-ext.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Bold-greek-ext.woff2?ver=c11c7999d78e) format("woff2");
 	unicode-range: U+1F00-1FFF;
 }
 
@@ -112,7 +112,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Bold-greek.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Bold-greek.woff2?ver=ba79634e2cd8) format("woff2");
 	unicode-range: U+0370-03FF;
 }
 
@@ -122,7 +122,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Bold-vietnamese.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Bold-vietnamese.woff2?ver=180aa42496b5) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -132,7 +132,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Bold-latin-ext.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Bold-latin-ext.woff2?ver=94527d576afd) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -142,7 +142,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./CourierPrime/CourierPrime-Bold-latin.woff2) format("woff2");
+	src: url(./CourierPrime/CourierPrime-Bold-latin.woff2?ver=01c037d9e0a1) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -156,7 +156,7 @@
 	font-weight: 100 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Inter/Inter-cyrillic-ext.woff2) format("woff2");
+	src: url(./Inter/Inter-cyrillic-ext.woff2?ver=870d267d091f) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -166,7 +166,7 @@
 	font-weight: 100 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Inter/Inter-cyrillic.woff2) format("woff2");
+	src: url(./Inter/Inter-cyrillic.woff2?ver=2e1f0e6a6eda) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -176,7 +176,7 @@
 	font-weight: 100 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Inter/Inter-greek-ext.woff2) format("woff2");
+	src: url(./Inter/Inter-greek-ext.woff2?ver=f1fb719a6429) format("woff2");
 	unicode-range: U+1F00-1FFF;
 }
 
@@ -186,7 +186,7 @@
 	font-weight: 100 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Inter/Inter-greek.woff2) format("woff2");
+	src: url(./Inter/Inter-greek.woff2?ver=8fb4801a481e) format("woff2");
 	unicode-range: U+0370-03FF;
 }
 
@@ -196,7 +196,7 @@
 	font-weight: 100 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Inter/Inter-vietnamese.woff2) format("woff2");
+	src: url(./Inter/Inter-vietnamese.woff2?ver=ec198636627a) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -206,7 +206,7 @@
 	font-weight: 100 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Inter/Inter-latin-ext.woff2) format("woff2");
+	src: url(./Inter/Inter-latin-ext.woff2?ver=802f9ad48332) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -216,7 +216,7 @@
 	font-weight: 100 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Inter/Inter-latin.woff2) format("woff2");
+	src: url(./Inter/Inter-latin.woff2?ver=b07a289bdf69) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -226,7 +226,7 @@
 	font-weight: 100 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Inter/Inter-arrows.woff2) format("woff2");
+	src: url(./Inter/Inter-arrows.woff2?ver=63555c379a62) format("woff2");
 	unicode-range: U+2190-2199;
 }
 
@@ -241,7 +241,7 @@
 	font-weight: 400 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-cyrillic-ext.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-cyrillic-ext.woff2?ver=8176ef6e06a1) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -251,7 +251,7 @@
 	font-weight: 400 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-cyrillic.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-cyrillic.woff2?ver=1af56bf0af64) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -261,7 +261,7 @@
 	font-weight: 400 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-greek-ext.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-greek-ext.woff2?ver=d3bd499d027a) format("woff2");
 	unicode-range: U+1F00-1FFF;
 }
 
@@ -271,7 +271,7 @@
 	font-weight: 400 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-greek.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-greek.woff2?ver=ec834832b30b) format("woff2");
 	unicode-range: U+0370-03FF;
 }
 
@@ -281,7 +281,7 @@
 	font-weight: 400 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-vietnamese.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-vietnamese.woff2?ver=30eaef521e8a) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -291,7 +291,7 @@
 	font-weight: 400 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-latin-ext.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-latin-ext.woff2?ver=a08861311328) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -301,7 +301,7 @@
 	font-weight: 400 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-latin.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-latin.woff2?ver=2c7bc866cb03) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -311,7 +311,7 @@
 	font-weight: 400 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-arrows.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-arrows.woff2?ver=943d7defaf99) format("woff2");
 	unicode-range: U+2190-2199;
 }
 
@@ -326,7 +326,7 @@
 	font-weight: 400 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-Italic-cyrillic-ext.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-Italic-cyrillic-ext.woff2?ver=7808b24a969c) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -336,7 +336,7 @@
 	font-weight: 400 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-Italic-cyrillic.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-Italic-cyrillic.woff2?ver=766320cf480d) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -346,7 +346,7 @@
 	font-weight: 400 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-Italic-greek-ext.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-Italic-greek-ext.woff2?ver=5c9c07959839) format("woff2");
 	unicode-range: U+1F00-1FFF;
 }
 
@@ -356,7 +356,7 @@
 	font-weight: 400 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-Italic-greek.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-Italic-greek.woff2?ver=9cdc7745aab9) format("woff2");
 	unicode-range: U+0370-03FF;
 }
 
@@ -366,7 +366,7 @@
 	font-weight: 400 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-Italic-vietnamese.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-Italic-vietnamese.woff2?ver=47ae16ca8ebd) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -376,7 +376,7 @@
 	font-weight: 400 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-Italic-latin-ext.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-Italic-latin-ext.woff2?ver=cdaf0905fb1c) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -386,7 +386,7 @@
 	font-weight: 400 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-Italic-latin.woff2) format("woff2");
+	src: url(./EB-Garamond/EBGaramond-Italic-latin.woff2?ver=b6b388074e82) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -411,7 +411,7 @@
 	font-weight: 200;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-cyrillic-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-cyrillic-ext.woff2?ver=99488ab1f1b4) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -421,7 +421,7 @@
 	font-weight: 200;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-cyrillic.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-cyrillic.woff2?ver=370513b21aa8) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -431,7 +431,7 @@
 	font-weight: 200;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-vietnamese.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-vietnamese.woff2?ver=04a172643c2d) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -441,7 +441,7 @@
 	font-weight: 200;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-latin-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-latin-ext.woff2?ver=1214d6939808) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -451,7 +451,7 @@
 	font-weight: 200;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-latin.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLight-latin.woff2?ver=075de20a9833) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -466,7 +466,7 @@
 	font-weight: 200;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-cyrillic-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-cyrillic-ext.woff2?ver=f67b80c3648c) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -476,7 +476,7 @@
 	font-weight: 200;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-cyrillic.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-cyrillic.woff2?ver=51c4ca00cdb0) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -486,7 +486,7 @@
 	font-weight: 200;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-vietnamese.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-vietnamese.woff2?ver=632a48e3ba8e) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -496,7 +496,7 @@
 	font-weight: 200;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-latin-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-latin-ext.woff2?ver=454bc3623abc) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -506,7 +506,7 @@
 	font-weight: 200;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-latin.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-ExtraLightItalic-latin.woff2?ver=38cfc7b0cee7) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -521,7 +521,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Regular-cyrillic-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Regular-cyrillic-ext.woff2?ver=d5b4785e465e) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -531,7 +531,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Regular-cyrillic.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Regular-cyrillic.woff2?ver=dbae9f565349) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -541,7 +541,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Regular-vietnamese.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Regular-vietnamese.woff2?ver=0aa3dc1ec47b) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -551,7 +551,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Regular-latin-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Regular-latin-ext.woff2?ver=139e6cd03358) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -561,7 +561,7 @@
 	font-weight: 400;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Regular-latin.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Regular-latin.woff2?ver=8ddc86b0ebf4) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -576,7 +576,7 @@
 	font-weight: 400;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Italic-cyrillic-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Italic-cyrillic-ext.woff2?ver=c415eab9d09e) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -586,7 +586,7 @@
 	font-weight: 400;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Italic-cyrillic.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Italic-cyrillic.woff2?ver=c586ce96eb42) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -596,7 +596,7 @@
 	font-weight: 400;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Italic-vietnamese.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Italic-vietnamese.woff2?ver=0b8d65223f8f) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -606,7 +606,7 @@
 	font-weight: 400;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Italic-latin-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Italic-latin-ext.woff2?ver=bb87d332affb) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -616,7 +616,7 @@
 	font-weight: 400;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Italic-latin.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Italic-latin.woff2?ver=b8d4f3563cf8) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -630,7 +630,7 @@
 	font-weight: 500;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Medium-cyrillic-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Medium-cyrillic-ext.woff2?ver=431d255a3afa) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -640,7 +640,7 @@
 	font-weight: 500;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Medium-cyrillic.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Medium-cyrillic.woff2?ver=beb561f0d2e7) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -650,7 +650,7 @@
 	font-weight: 500;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Medium-greek-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Medium-greek-ext.woff2?ver=49bf3255c571) format("woff2");
 	unicode-range: U+1F00-1FFF;
 }
 
@@ -660,7 +660,7 @@
 	font-weight: 500;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Medium-greek.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Medium-greek.woff2?ver=6152b28764d6) format("woff2");
 	unicode-range: U+0370-03FF;
 }
 
@@ -670,7 +670,7 @@
 	font-weight: 500;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Medium-vietnamese.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Medium-vietnamese.woff2?ver=c58ce4527d80) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -680,7 +680,7 @@
 	font-weight: 500;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Medium-latin-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Medium-latin-ext.woff2?ver=4ace19a3c116) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -690,7 +690,7 @@
 	font-weight: 500;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Medium-latin.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Medium-latin.woff2?ver=44150b50e9d4) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -700,7 +700,7 @@
 	font-weight: 500;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Medium-arrows.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Medium-arrows.woff2?ver=e9f571cc6a63) format("woff2");
 	unicode-range: U+2190-2199;
 }
 
@@ -714,7 +714,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Bold-cyrillic-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Bold-cyrillic-ext.woff2?ver=d20781be5b07) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -724,7 +724,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Bold-cyrillic.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Bold-cyrillic.woff2?ver=c6178ab7258f) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -734,7 +734,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Bold-vietnamese.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Bold-vietnamese.woff2?ver=5e8388bb91ff) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -744,7 +744,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Bold-latin-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Bold-latin-ext.woff2?ver=ac5ae799cb8f) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -754,7 +754,7 @@
 	font-weight: 700;
 	font-style: normal;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-Bold-latin.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-Bold-latin.woff2?ver=59cad49c271e) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -769,7 +769,7 @@
 	font-weight: 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-cyrillic-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-cyrillic-ext.woff2?ver=acd7ea8d0d94) format("woff2");
 	unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -779,7 +779,7 @@
 	font-weight: 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-cyrillic.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-cyrillic.woff2?ver=20d5b885400b) format("woff2");
 	unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -789,7 +789,7 @@
 	font-weight: 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-vietnamese.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-vietnamese.woff2?ver=a005afe26029) format("woff2");
 	unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 
@@ -799,7 +799,7 @@
 	font-weight: 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-latin-ext.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-latin-ext.woff2?ver=580700b45e3a) format("woff2");
 	unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -809,6 +809,6 @@
 	font-weight: 700;
 	font-style: italic;
 	font-display: swap;
-	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-latin.woff2) format("woff2");
+	src: url(./IBMPlexMono/IBMPlexMono-BoldItalic-latin.woff2?ver=a96c20e7edc2) format("woff2");
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/mu-plugins/global-fonts/style.css
+++ b/mu-plugins/global-fonts/style.css
@@ -390,16 +390,6 @@
 	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
-/* arrows */
-@font-face {
-	font-family: "EB Garamond";
-	font-weight: 400 700;
-	font-style: italic;
-	font-display: swap;
-	src: url(./EB-Garamond/EBGaramond-Italic-arrows.woff2) format("woff2");
-	unicode-range: U+2190-2199;
-}
-
 
 /*----------------------------*
  *  IBM Plex Mono ExtraLight  *


### PR DESCRIPTION
After #173 I realised that fonts weren't being handled correctly.

The `<head>` includes:
```
<link rel='preload' href='https://wordpress.org/wp-content/mu-plugins/pub-sync/global-fonts/Inter/Inter-latin.woff2' as='font' crossorigin='crossorigin' type='font/woff2' />
```

But that's no longer the URL, as the style.css is loaded from the cdn:
```
<link rel='stylesheet' id='wporg-global-fonts-css' href='https://s.w.org/wp-content/mu-plugins/pub-sync/global-fonts/style.css?ver=4c78359bcbb5' media='all' />
```

which would then load the following font, which does not match the preloaded URL.
```
https://s.w.org/wp-content/mu-plugins/pub-sync/global-fonts/Inter/Inter-latin.woff2
```

This PR...
 - Updates it to include a `?ver=` query var
   - The QV allows for the files to be updated in future, as they're now cached.
   - On Sandboxes: This is the file mod time **this will differ from style.css on sandboxes**
   - On Production: The CDN plugin will use a file hash, which should match those in style.css.
   - On Production: Allows the CSS and preload to have the same URL
 - Removes EB Garamond 'arrows' subset, which doesn't seem to exist

After starting to write this PR, I've realised I didn't need to add the font hashes into the PHP, so have removed that.