### PR TITLE
Header/Footer: Don't enqueue `wp4.css` on WordCamp sites

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -181,6 +181,10 @@ function enqueue_compat_wp4_styles() {
 		return;
 	}
 
+	if ( defined( 'IS_WORDCAMP_NETWORK' ) ) {
+		return;
+	}
+
 	if (
 		( ! wp_is_block_theme() && ! current_theme_supports( 'wp4-styles' ) ) ||
 		( defined( 'REST_REQUEST' ) && REST_REQUEST )


### PR DESCRIPTION
The Parent theme was added to `events.wordpress.org` in https://github.com/WordPress/wordcamp.org/pull/1013. That site/network is hosted on the wordcamp.org server, which doesn't have (or need) `wp4.css`. Trying to enqueue it results in a `filemtime()` warning because the file doesn't exist.