### PR TITLE
Maps: Add list of markers below the map

### DIFF
--- a/mu-plugins/blocks/google-map/README.md
+++ b/mu-plugins/blocks/google-map/README.md
@@ -1,6 +1,6 @@
 # Google Map
 
-Displays a Google Map with markers for each event. Markers will be clustered for performance and UX.
+Displays a Google Map with markers for each event. Markers will be clustered for performance and UX. Optionally, show a list of the same events, and a search feature.
 
 Currently only supports programmatic usage in block theme templates etc. There's no UI available for adding markers.
 

--- a/mu-plugins/blocks/google-map/postcss/style.pcss
+++ b/mu-plugins/blocks/google-map/postcss/style.pcss
@@ -3,21 +3,30 @@
  */
 
 .wp-block-wporg-google-map {
-	position: relative;
-	width: 100%;
-	max-width: 100%;
-	background-color: #aadaff;
+	& .wporg-google-map__container {
+		position: relative;
+		width: 100%;
+		max-width: 100%;
+		background-color: #aadaff;
 
-	/*
-	 * This is a bit too opinionated, but it's required to prevent the map from collapsing. The theme can override it when needed.
-	 * @link https://developers.google.com/maps/documentation/javascript/overview#Map_DOM_Elements
-	 */
-	height: clamp(200px, 50vh, 90vh);
+		/*
+		* This is a bit too opinionated, but it's required to prevent the map from collapsing. The theme can override it when needed.
+		* @link https://developers.google.com/maps/documentation/javascript/overview#Map_DOM_Elements
+		*/
+		height: clamp(200px, 50vh, 90vh);
 
-	@media screen and ( max-width: 385px ) {
-		width: 100vw;
+		@media screen and ( max-width: 385px ) {
+			width: 100vw;
 
-		/* Make sure there's enough room to scroll past it using mobile gestures. */
-		max-height: 90vh;
+			/* Make sure there's enough room to scroll past it using mobile gestures. */
+			max-height: 90vh;
+		}
+	}
+
+	& .wporg-marker-list__container {
+		& h3,
+		& p {
+			margin: 0;
+		}
 	}
 }

--- a/mu-plugins/blocks/google-map/src/block.json
+++ b/mu-plugins/blocks/google-map/src/block.json
@@ -19,6 +19,15 @@
 		"markers": {
 			"type": "array",
 			"default": []
+		},
+		"showMap": {
+			"type": "boolean",
+			"default": true
+		},
+		"showList": {
+			"type": "boolean",
+			"default": true
+		},
 		}
 	},
 	"supports": {

--- a/mu-plugins/blocks/google-map/src/components/list.js
+++ b/mu-plugins/blocks/google-map/src/components/list.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getEventDateTime } from '../utilities/date-time';
+import { formatLocation } from '../utilities/content';
+
+/**
+ * Render a list of the map markers.
+ *
+ * @param {Object} props
+ * @param {Array}  props.markers
+ *
+ * @return {JSX.Element}
+ */
+export default function List( { markers } ) {
+	if ( markers.length === 0 ) {
+		return <p className="wporg-marker-list__container">{ __( 'No items available', 'wporg' ) }</p>;
+	}
+
+	return (
+		<ul className="wporg-marker-list__container">
+			{ markers.map( ( marker ) => (
+				<li
+					key={ marker.id }
+					id={ 'wporg-marker-list-item__id-' + marker.id }
+					className="wporg-marker-list-item"
+				>
+					<h3 className="wporg-marker-list-item__title">
+						<a href={ marker.url }>{ marker.title }</a>
+					</h3>
+
+					<p className="wporg-marker-list-item__location">{ formatLocation( marker.location ) }</p>
+					<p className="wporg-marker-list-item__date-time">{ getEventDateTime( marker.timestamp ) }</p>
+				</li>
+			) ) }
+		</ul>
+	);
+}

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -44,7 +44,7 @@ export default function Map( { apiKey, markers, icon } ) {
 
 	return (
 		// Container height must be set explicitly.
-		<>
+		<div className="wporg-google-map__container">
 			{ ! loaded && <Spinner /> }
 
 			<GoogleMapReact
@@ -58,6 +58,6 @@ export default function Map( { apiKey, markers, icon } ) {
 				onGoogleApiLoaded={ mapLoaded }
 				options={ options }
 			/>
-		</>
+		</div>
 	);
 }

--- a/mu-plugins/blocks/google-map/src/components/marker-content.js
+++ b/mu-plugins/blocks/google-map/src/components/marker-content.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getEventDateTime } from '../utilities/date-time';
+import { formatLocation } from '../utilities/content';
 
 /**
  * Render the content for a map marker.
@@ -80,19 +81,4 @@ function MeetupMarker( { id, title, url, meetup, timestamp, location } ) {
 			<p className="wporg-map-marker__date-time">{ getEventDateTime( timestamp ) }</p>
 		</div>
 	);
-}
-
-/**
- * Format the `online` location type for display.
- *
- * @param {string} location
- *
- * @return {string}
- */
-function formatLocation( location ) {
-	if ( 'online' === location ) {
-		location = 'Online';
-	}
-
-	return location;
 }

--- a/mu-plugins/blocks/google-map/src/front.js
+++ b/mu-plugins/blocks/google-map/src/front.js
@@ -1,6 +1,11 @@
 /* global wporgGoogleMap */
 
 /**
+ * External dependencies
+ */
+import { pick } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { createRoot } from '@wordpress/element';
@@ -9,6 +14,7 @@ import { createRoot } from '@wordpress/element';
  * Internal dependencies
  */
 import Map from './components/map';
+import List from './components/list';
 
 const init = () => {
 	const wrapper = document.getElementById( wporgGoogleMap.id );
@@ -18,8 +24,16 @@ const init = () => {
 	}
 
 	const root = createRoot( wrapper );
+	const mapArgs = pick( wporgGoogleMap, [ 'apiKey', 'markers', 'icon' ] );
+	const listArgs = pick( wporgGoogleMap, [ 'markers' ] );
 
-	root.render( <Map { ...wporgGoogleMap } /> );
+	root.render(
+		<>
+			{ wporgGoogleMap.showMap && <Map { ...mapArgs } /> }
+
+			{ wporgGoogleMap.showList && <List { ...listArgs } /> }
+		</>
+	);
 };
 
 document.addEventListener( 'DOMContentLoaded', init );

--- a/mu-plugins/blocks/google-map/src/utilities/content.js
+++ b/mu-plugins/blocks/google-map/src/utilities/content.js
@@ -1,0 +1,14 @@
+/**
+ * Format the `online` location type for display.
+ *
+ * @param {string} location
+ *
+ * @return {string}
+ */
+export function formatLocation( location ) {
+	if ( 'online' === location ) {
+		location = 'Online';
+	}
+
+	return location;
+}


### PR DESCRIPTION
This adds a list of markers below the map. It uses React so that the same timezone formatting that the map uses can be applied, and also so that the list can be filtered based on search queries (future PR)