### PR TITLE
Add searching functionality to map

### DIFF
--- a/mu-plugins/blocks/google-map/README.md
+++ b/mu-plugins/blocks/google-map/README.md
@@ -30,6 +30,6 @@ $map_options = array(
 array(
 	0 => (object) array( ‘id’ => ‘72190236’, ‘type’ => ‘meetup’, ‘title’ => ‘WordPress For Beginners – WPSyd’, ‘url’ => ‘https://www.meetup.com/wordpress-sydney/events/294365830’, ‘meetup’ => ‘WordPress Sydney’, ‘location’ => ‘Sydney, Australia’, ‘latitude’ => ‘-33.865295’, ‘longitude’ => ‘151.2053’, ‘tz_offset’ => ‘36000’, ‘timestamp’ => 1693209600 ),
 	1 => (object) array( ‘id’ => ‘72190237’, ‘type’ => ‘meetup’, ‘title’ => ‘WordPress Help Desk’, ‘url’ => ‘https://www.meetup.com/wordpress-gwinnett/events/292032515’, ‘meetup’ => ‘WordPress Gwinnett’, ‘location’ => ‘online’, ‘latitude’ => ‘33.94’, ‘longitude’ => ‘-83.96’, ‘tz_offset’ => ‘-14400’, ‘timestamp’ => 1693260000 ),
-	2 => (object) array( ‘id’ => ‘72190235’, ‘type’ => ‘meetup’, ‘title’ => ‘WordPress Warwickshire Virtual Meetup ‘, ‘url’ => ‘https://www.meetup.com/wordpress-warwickshire-meetup/events/295325208’, ‘meetup’ => ‘WordPress Warwickshire Meetup’, ‘location’ => ‘online’, ‘latitude’ => ‘52.52’, ‘longitude’ => ‘-1.47’, ‘tz_offset’ => ‘3600’, ‘timestamp’ => 1693245600 ),
+	2 => (object) array ( 'id' => '72189909', 'type' => 'wordcamp', 'title' => 'WordCamp Jinja 2023', 'url' => 'https://jinja.wordcamp.org/2023/', 'meetup' => NULL, 'location' => 'Jinja City, Uganda', 'latitude' => '0.5862795', 'longitude' => '33.4589384', 'tz_offset' => '10800', 'timestamp' => 1693803600, ),
 )
 ```

--- a/mu-plugins/blocks/google-map/images/search.svg
+++ b/mu-plugins/blocks/google-map/images/search.svg
@@ -1,0 +1,2 @@
+<!-- Source: https://github.com/WordPress/wporg-mu-plugins/pull/375#issuecomment-1488504856 -->
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="enable-background:new 0 0 24 24" viewBox="0 0 24 24"><path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6S16.3 5 13 5zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#1e1e1e"/></svg>

--- a/mu-plugins/blocks/google-map/index.php
+++ b/mu-plugins/blocks/google-map/index.php
@@ -42,7 +42,9 @@ function render( $attributes, $content, $block ) {
 		}
 	}
 
-	$attributes['icon'] = array(
+	$attributes['searchIcon'] = plugins_url( 'images/search.svg', __FILE__ );
+
+	$attributes['markerIcon'] = array(
 		'markerUrl'           => plugins_url( 'images/map-marker.svg', __FILE__ ),
 		'markerAnchorXOffset' => 34,
 		'markerHeight'        => 68,

--- a/mu-plugins/blocks/google-map/postcss/style.pcss
+++ b/mu-plugins/blocks/google-map/postcss/style.pcss
@@ -3,6 +3,13 @@
  */
 
 .wp-block-wporg-google-map {
+	& .wporg-marker-search__container {
+		& .wporg-marker-search__icon {
+			width: 24px;
+			height: 24px;
+		}
+	}
+
 	& .wporg-google-map__container {
 		position: relative;
 		width: 100%;

--- a/mu-plugins/blocks/google-map/src/block.json
+++ b/mu-plugins/blocks/google-map/src/block.json
@@ -28,6 +28,13 @@
 			"type": "boolean",
 			"default": true
 		},
+		"showSearch": {
+			"type": "boolean",
+			"default": true
+		},
+		"searchFields": {
+			"type": "array",
+			"default": [ "title", "location", "meetup" ]
 		}
 	},
 	"supports": {

--- a/mu-plugins/blocks/google-map/src/components/list.js
+++ b/mu-plugins/blocks/google-map/src/components/list.js
@@ -19,7 +19,7 @@ import { formatLocation } from '../utilities/content';
  */
 export default function List( { markers } ) {
 	if ( markers.length === 0 ) {
-		return <p className="wporg-marker-list__container">{ __( 'No items available', 'wporg' ) }</p>;
+		return <p className="wporg-marker-list__container">{ __( 'No events available', 'wporg' ) }</p>;
 	}
 
 	return (

--- a/mu-plugins/blocks/google-map/src/components/main.js
+++ b/mu-plugins/blocks/google-map/src/components/main.js
@@ -1,0 +1,101 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Search from './search';
+import Map from './map';
+import List from './list';
+import { filterMarkers, speakSearchUpdates } from '../utilities/content';
+
+/**
+ *
+ * @param {Object}  props
+ * @param {boolean} props.showMap
+ * @param {boolean} props.showList
+ * @param {boolean} props.showSearch
+ * @param {string}  props.apiKey
+ * @param {Array}   props.markers
+ * @param {Object}  props.markerIcon
+ * @param {string}  props.searchIcon
+ * @param {Array}   props.searchFields
+ *
+ * @return {JSX.Element}
+ */
+export default function Main( {
+	showMap,
+	showList,
+	showSearch,
+	apiKey,
+	markers,
+	markerIcon,
+	searchIcon,
+	searchFields,
+} ) {
+	const [ searchQuery, setSearchQuery ] = useState( '' );
+	const searchQueryInitialized = useRef( false );
+
+	// This probably shouldn't be state because it can be derived from `markers` and `searchQuery`,
+	// but it also feels wrong to have the map and list components do the filtering when they could
+	// just receive it as props without having to be aware of the business logic. It has to be state
+	// somewhere for React to trigger a re-render, though.
+	const [ visibleMarkers, setVisibleMarkers ] = useState( markers );
+
+	/**
+	 * Update the search state as the user types, and make sure the map/list are visible.
+	 */
+	const onQueryChange = useCallback( ( event ) => {
+		setSearchQuery( event.target.value );
+
+		/*
+		 * Sometimes the map may be taking up most of the viewport, so the user won't see the list changing as
+		 * they type their query. This helps direct them to the results.
+		 */
+		event.target.scrollIntoView( {
+			inline: 'start',
+			behavior: 'smooth',
+		} );
+	}, [] );
+
+	/**
+	 * Update the map and list when the search query changes.
+	 */
+	useEffect( () => {
+		const filteredMarkers = filterMarkers( markers, searchQuery, searchFields );
+
+		setVisibleMarkers( filteredMarkers );
+
+		// Avoid speaking on the initial page load.
+		if ( ! searchQueryInitialized.current ) {
+			searchQueryInitialized.current = true;
+			return;
+		}
+
+		speakSearchUpdates( searchQuery, filteredMarkers.length );
+	}, [ searchQuery ] );
+
+	return (
+		<>
+			{ showSearch && (
+				<Search searchQuery={ searchQuery } onQueryChange={ onQueryChange } icon={ searchIcon } />
+			) }
+
+			{ showMap && <Map apiKey={ apiKey } markers={ visibleMarkers } icon={ markerIcon } /> }
+
+			{ showList && visibleMarkers.length > 0 && <List markers={ visibleMarkers } /> }
+
+			{ visibleMarkers.length === 0 && searchQuery.length > 0 && (
+				<p className="wporg-marker-list__container">
+					{
+						// Translators: %s is the search query.
+						sprintf( __( 'No events were found matching %s.', 'wporg' ), searchQuery )
+					}
+				</p>
+			) }
+		</>
+	);
+}

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -37,13 +37,17 @@ export default function Map( { apiKey, markers, icon } ) {
 		styles: mapStyles,
 	};
 
+	/**
+	 * Add markers to the map and cluster them.
+	 *
+	 * Callback for `onGoogleApiLoaded`.
+	 */
 	const mapLoaded = useCallback( ( { map, maps } ) => {
 		createClusteredMarkers( map, maps, markers, icon );
 		setLoaded( true );
 	}, [] );
 
 	return (
-		// Container height must be set explicitly.
 		<div className="wporg-google-map__container">
 			{ ! loaded && <Spinner /> }
 

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -6,14 +6,19 @@ import GoogleMapReact from 'google-map-react';
 /**
  * WordPress dependencies
  */
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { mapStyles } from '../utilities/map-styles';
-import { createClusteredMarkers } from '../utilities/google-maps-api';
+import {
+	assignMarkerReferences,
+	clusterMarkers,
+	panToCenter,
+	setVisibleMarkers,
+} from '../utilities/google-maps-api';
 
 /**
  * Render a Google Map with info windows for the given markers.
@@ -29,6 +34,9 @@ import { createClusteredMarkers } from '../utilities/google-maps-api';
  */
 export default function Map( { apiKey, markers, icon } ) {
 	const [ loaded, setLoaded ] = useState( false );
+	const [ clusterer, setClusterer ] = useState( null );
+	const [ googleMap, setGoogleMap ] = useState( null );
+	const [ googleMapsApi, setGoogleMapsApi ] = useState( null );
 
 	const options = {
 		zoomControl: true,
@@ -43,9 +51,40 @@ export default function Map( { apiKey, markers, icon } ) {
 	 * Callback for `onGoogleApiLoaded`.
 	 */
 	const mapLoaded = useCallback( ( { map, maps } ) => {
-		createClusteredMarkers( map, maps, markers, icon );
+		if ( ! map || ! maps ) {
+			throw 'Google Maps API is not loaded.';
+		}
+
+		setGoogleMap( map );
+		setGoogleMapsApi( maps );
+
+		markers = assignMarkerReferences( map, maps, markers, icon );
+
+		setClusterer(
+			clusterMarkers(
+				map,
+				maps,
+				markers.map( ( marker ) => marker.markerRef ),
+				icon
+			)
+		);
+
 		setLoaded( true );
 	}, [] );
+
+	/**
+	 * Update the map whenever the supplied markers change.
+	 */
+	useEffect( () => {
+		if ( ! clusterer ) {
+			return;
+		}
+
+		const markerObjects = markers.map( ( marker ) => marker.markerRef );
+
+		setVisibleMarkers( clusterer, markerObjects, googleMap );
+		panToCenter( markerObjects, googleMap, googleMapsApi );
+	}, [ clusterer, markers ] );
 
 	return (
 		<div className="wporg-google-map__container">

--- a/mu-plugins/blocks/google-map/src/components/search.js
+++ b/mu-plugins/blocks/google-map/src/components/search.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+
+/**
+ * Render a list of the map markers.
+ *
+ * @param {Object}   props
+ * @param {string}   props.searchQuery
+ * @param {Function} props.onQueryChange
+ * @param {string}   props.iconURL
+ *
+ * @return {JSX.Element}
+ */
+export default function Search( { searchQuery, onQueryChange, iconURL } ) {
+	return (
+		<form className="wporg-marker-search__container">
+			<label htmlFor="wporg-marker-search__input">
+				<span>{ __( 'Search events:', 'wporg' ) }</span>
+
+				<input
+					className="wporg-marker-search__input"
+					type="text"
+					value={ searchQuery }
+					// translators: Change this to a recognizable city in your locale.
+					placeholder={ _x( 'Springfield', 'Event query placeholder', 'wporg' ) }
+					aria-label={ __( 'Search events:', 'wporg' ) }
+					onChange={ onQueryChange }
+				/>
+			</label>
+
+			<img className="wporg-marker-search__icon" src={ iconURL } alt={ __( 'Search', 'wporg' ) } />
+		</form>
+	);
+}

--- a/mu-plugins/blocks/google-map/src/front.js
+++ b/mu-plugins/blocks/google-map/src/front.js
@@ -1,11 +1,6 @@
 /* global wporgGoogleMap */
 
 /**
- * External dependencies
- */
-import { pick } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createRoot } from '@wordpress/element';
@@ -13,8 +8,7 @@ import { createRoot } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Map from './components/map';
-import List from './components/list';
+import Main from './components/main';
 
 const init = () => {
 	const wrapper = document.getElementById( wporgGoogleMap.id );
@@ -24,16 +18,8 @@ const init = () => {
 	}
 
 	const root = createRoot( wrapper );
-	const mapArgs = pick( wporgGoogleMap, [ 'apiKey', 'markers', 'icon' ] );
-	const listArgs = pick( wporgGoogleMap, [ 'markers' ] );
 
-	root.render(
-		<>
-			{ wporgGoogleMap.showMap && <Map { ...mapArgs } /> }
-
-			{ wporgGoogleMap.showList && <List { ...listArgs } /> }
-		</>
-	);
+	root.render( <Main { ...wporgGoogleMap } /> );
 };
 
 document.addEventListener( 'DOMContentLoaded', init );

--- a/mu-plugins/blocks/google-map/src/utilities/content.js
+++ b/mu-plugins/blocks/google-map/src/utilities/content.js
@@ -1,4 +1,16 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+const debouncedSpeak = debounce( speak, 1000 );
+
+/**
+ * WordPress dependencies
+ */
+import { speak } from '@wordpress/a11y';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Format the `online` location type for display.
  *
  * @param {string} location
@@ -11,4 +23,57 @@ export function formatLocation( location ) {
 	}
 
 	return location;
+}
+
+/**
+ * Filter the list of markers based on a user's search query.
+ *
+ * @param {Array}  unfilteredMarkers
+ * @param {string} query
+ * @param {Array}  searchFields
+ */
+export function filterMarkers( unfilteredMarkers, query, searchFields ) {
+	const filteredMarkers = [];
+
+	if ( '' === query ) {
+		return unfilteredMarkers;
+	}
+
+	unfilteredMarkers.forEach( ( marker ) => {
+		let haystack = searchFields.map( ( field ) => marker[ field ] ).join( ' ' );
+
+		// Sometimes `&nbsp;` is used as a hack to prevent typographic runts. If we don't replace that then a
+		// `query` of `los angeles` wouldn't match `los&nbsp;angeles`.
+		haystack = haystack.replace( /\u00A0/g, ' ' );
+
+		const match = haystack.search( new RegExp( query, 'i' ) ) >= 0;
+
+		if ( match ) {
+			filteredMarkers.push( marker );
+		}
+	} );
+
+	return filteredMarkers;
+}
+
+/**
+ * Announce updates to the search results for screen readers.
+ *
+ * @param {string} query
+ * @param {number} foundCount
+ */
+export function speakSearchUpdates( query, foundCount ) {
+	if ( '' === query ) {
+		debouncedSpeak( __( 'Search cleared, showing all events.', 'wporg' ) );
+	} else if ( foundCount === 0 ) {
+		debouncedSpeak(
+			// Translators: %s is the search query.
+			sprintf( __( 'No events were found matching %s.', 'wporg' ), query )
+		);
+	} else {
+		debouncedSpeak(
+			// Translators: %s is the search query.
+			sprintf( __( 'Showing events that match %s.', 'wporg' ), query )
+		);
+	}
 }

--- a/mu-plugins/blocks/google-map/src/utilities/dom.js
+++ b/mu-plugins/blocks/google-map/src/utilities/dom.js
@@ -9,7 +9,7 @@ import { createRoot, flushSync } from '@wordpress/element';
  * This is useful when you need to pass an element to the Maps API. The need for it might also be a smell that
  * we're not leveraging the Google Maps React library as much as we could, though.
  *
- * @param {Object} element
+ * @param {JSX.Element} element
  *
  * @return {string}
  */

--- a/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
+++ b/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
@@ -16,10 +16,10 @@ import getElementHTML from '../utilities/dom';
  *
  * Callback for `GoogleMapReact.onGoogleApiLoaded`.
  *
- * @param {Object} map
- * @param {Object} maps
- * @param {Array}  wpEvents
- * @param {Object} rawIcon
+ * @param {google.maps.Map} map
+ * @param {google.maps}     maps
+ * @param {Array}           wpEvents
+ * @param {Object}          rawIcon
  */
 export function createClusteredMarkers( map, maps, wpEvents, rawIcon ) {
 	if ( 'undefined' === typeof google || ! google.hasOwnProperty( 'maps' ) ) {
@@ -34,9 +34,9 @@ export function createClusteredMarkers( map, maps, wpEvents, rawIcon ) {
 
 	const icon = {
 		url: rawIcon.markerUrl,
-		size: new google.maps.Size( rawIcon.markerHeight, rawIcon.markerWidth ),
-		anchor: new google.maps.Point( 34, rawIcon.markerWidth / 2 ),
-		scaledSize: new google.maps.Size( rawIcon.markerHeight / 2, rawIcon.markerWidth / 2 ),
+		size: new maps.Size( rawIcon.markerHeight, rawIcon.markerWidth ),
+		anchor: new maps.Point( 34, rawIcon.markerWidth / 2 ),
+		scaledSize: new maps.Size( rawIcon.markerHeight / 2, rawIcon.markerWidth / 2 ),
 	};
 
 	wpEvents.forEach( ( wpEvent ) => {
@@ -62,10 +62,10 @@ export function createClusteredMarkers( map, maps, wpEvents, rawIcon ) {
  *
  * A single infoWindow is used for all markers, so that only one is open at a time.
  *
- * @param {Object} infoWindow
- * @param {Object} map
- * @param {Object} markerObject
- * @param {Object} rawMarker
+ * @param {google.maps.InfoWindow} infoWindow
+ * @param {google.maps.Map}        map
+ * @param {google.maps.Marker}     markerObject
+ * @param {Array}                  rawMarker
  */
 function openInfoWindow( infoWindow, map, markerObject, rawMarker ) {
 	infoWindow.setContent( getElementHTML( <MarkerContent { ...rawMarker } /> ) );
@@ -84,26 +84,27 @@ function openInfoWindow( infoWindow, map, markerObject, rawMarker ) {
 /**
  * Cluster the markers into groups for improved performance and UX.
  *
- * @param {Object} map
- * @param {Object} markers
- * @param {Object} rawIcon
+ * @param {google.maps.Map}      map
+ * @param {google.maps}          maps
+ * @param {google.maps.Marker[]} markers
+ * @param {Object}               rawIcon
  *
  * @return {MarkerClusterer}
  */
 function clusterMarkers( map, markers, rawIcon ) {
 	const clusterIcon = {
 		url: rawIcon.clusterUrl,
-		size: new google.maps.Size( rawIcon.clusterHeight, rawIcon.clusterWidth ),
-		anchor: new google.maps.Point( rawIcon.clusterHeight, rawIcon.clusterWidth ),
-		scaledSize: new google.maps.Size( rawIcon.clusterHeight, rawIcon.clusterWidth ),
+		size: new maps.Size( rawIcon.clusterHeight, rawIcon.clusterWidth ),
+		anchor: new maps.Point( rawIcon.clusterHeight, rawIcon.clusterWidth ),
+		scaledSize: new maps.Size( rawIcon.clusterHeight, rawIcon.clusterWidth ),
 	};
 
 	const renderer = {
 		render: ( { count, position } ) => {
-			return new google.maps.Marker( {
+			return new maps.Marker( {
 				label: { text: String( count ), color: 'white', fontSize: '10px' },
 				position: position,
-				zIndex: Number( google.maps.Marker.MAX_ZINDEX ) + count, // Show above normal markers.
+				zIndex: Number( maps.Marker.MAX_ZINDEX ) + count, // Show above normal markers.
 				icon: clusterIcon,
 			} );
 		},


### PR DESCRIPTION
This adds an input field to the map for searching. When the user types, the markers on the map are filtered to only show the matches, and the map viewport is panned to the center of them. The list is also filtered to only the matched events.