### PR TITLE
Fix/325 responsive breadcrumb

### DIFF
--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -1,6 +1,6 @@
 .wp-block-wporg-site-breadcrumbs {
 	& a {
-		color: var(--wp--preset--color--charcoal-1);
+		color: var(--wp--preset--color--charcoal-4);
 		text-decoration-line: none;
 
 		&:hover {
@@ -20,12 +20,13 @@
 				content: "/";
 				display: inline-block;
 				font-weight: 400;
-			margin: 0 0.5rem;
+				margin: 0 var(--wp--preset--spacing--10);
+				color: var(--wp--preset--color--light-grey-1);
 			}
 		}
 	}
 
 	& .is-current-page {
-		font-weight: 700;
+		color: var(--wp--preset--color--charcoal-1);
 	}
 }

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -1,7 +1,4 @@
 .wp-block-wporg-site-breadcrumbs {
-	display: flex;
-	align-items: center;
-
 	& a {
 		color: var(--wp--preset--color--charcoal-1);
 		text-decoration-line: none;
@@ -11,18 +8,20 @@
 		}
 	}
 
-	& > span:not(:first-child) {
+	& > span {
+		display: inline-block;
 
-		/* This ensures that the square separator is reliably centered. */
-		display: flex;
-		align-items: center;
-		margin-top: 0;
+		&:not(:last-child) {
 
-		&::before {
-			content: "/";
-			display: inline-block;
-			font-weight: 400;
+			/* This ensures that the square separator is reliably centered. */
+			margin-top: 0;
+
+			&::after {
+				content: "/";
+				display: inline-block;
+				font-weight: 400;
 			margin: 0 0.5rem;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #325 

Alternative to #348, which rather than truncating the central breadcrumbs, simply lets them stack, see [comment](https://github.com/WordPress/wporg-mu-plugins/pull/348#issuecomment-1700400250).

It also updates the styles to match the Developer [designs](https://www.figma.com/file/2WxlJFzMJvqPfZL1EkAOVp/Developer-Resources?node-id=3223%3A26526&mode=dev).

### Screenshots

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_coding-standards_inline-documentation-standards_php_(Desktop)](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/d2c99215-11c8-4a5e-9d84-dc4414bc7461) | ![localhost_8888_coding-standards_inline-documentation-standards_php_(iPad)](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/c3947bcb-c857-4e69-8484-26f48d174808) | ![localhost_8888_coding-standards_inline-documentation-standards_php_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/255da4c8-8de7-43fe-85a8-1f27f6d70aa1) |