### PR TITLE
Block: Query Filters: Enable single-select options in filter block

### DIFF
--- a/mu-plugins/blocks/query-filter/postcss/style.pcss
+++ b/mu-plugins/blocks/query-filter/postcss/style.pcss
@@ -26,7 +26,8 @@
 	cursor: pointer;
 	white-space: nowrap;
 
-	&.has-no-filter-applied {
+	&.has-no-filter-applied,
+	&.is-single-select {
 		/* stylelint-disable-next-line function-url-quotes */
 		background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M15.9899 10.8889L12.0018 14.3073L8.01367 10.8889L8.98986 9.75L12.0018 12.3316L15.0137 9.75L15.9899 10.8889Z' fill='%231E1E1E'/%3E%3C/svg%3E%0A");
 		background-size: var(--wporg-query-filter--icon-size);
@@ -70,7 +71,8 @@
 			color: var(--wp--custom--wporg-query-filters--toggle--count--active--color--text);
 		}
 
-		&.has-no-filter-applied {
+		&.has-no-filter-applied,
+		&.is-single-select {
 			/* stylelint-disable-next-line function-url-quotes */
 			background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M15.9899 10.8889L12.0018 14.3073L8.01367 10.8889L8.98986 9.75L12.0018 12.3316L15.0137 9.75L15.9899 10.8889Z' fill='%23fff'/%3E%3C/svg%3E%0A");
 		}
@@ -117,7 +119,7 @@
 	--wporg-query-filter--icon-size: 24px;
 }
 
-.wporg-query-filter__option input[type="checkbox"] {
+.wporg-query-filter__option input[type] {
 	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
@@ -135,6 +137,7 @@
 		padding-block: var(--wp--custom--wporg-query-filters--spacing--padding--block);
 		padding-left: var(--wp--custom--wporg-query-filters--spacing--padding--inline-start);
 		padding-right: calc(var(--wp--custom--wporg-query-filters--spacing--padding--inline-end) * 2 + var(--wporg-query-filter--icon-size));
+		line-height: 1;
 	}
 
 	&:focus + label {
@@ -147,6 +150,10 @@
 		border-radius: 2px;
 		background-color: var(--wp--custom--wporg-query-filters--option--active--color--background);
 		color: var(--wp--custom--wporg-query-filters--option--active--color--text);
+	}
+
+	/* Only checkboxes can be cleared with a second click. */
+	&[type="checkbox"]:checked + label {
 		/* stylelint-disable-next-line function-url-quotes */
 		background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 13.0607L15.7123 16.773L16.773 15.7123L13.0607 12L16.773 8.28772L15.7123 7.22706L12 10.9394L8.28771 7.22705L7.22705 8.28771L10.9394 12L7.22706 15.7123L8.28772 16.773L12 13.0607Z' fill='%231E1E1E'/%3E%3C/svg%3E%0A");
 		background-repeat: no-repeat;

--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -40,8 +40,20 @@ $init_state = [
 ];
 $encoded_state = wp_json_encode( [ 'wporg' => [ 'queryFilter' => $init_state ] ] );
 
+$has_multiple = isset( $attributes['multiple'] ) && $attributes['multiple'];
+
 // Set up a unique ID for this filter.
 $html_id = wp_unique_id( "filter-{$settings['key']}-" );
+
+$button_classes = array_keys(
+	array_filter(
+		array(
+			'wporg-query-filter__toggle' => true,
+			'has-no-filter-applied' => ! count( $settings['selected'] ),
+			'is-single-select' => ! $has_multiple,
+		)
+	)
+);
 ?>
 <div
 	<?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>
@@ -52,7 +64,7 @@ $html_id = wp_unique_id( "filter-{$settings['key']}-" );
 	data-wp-on--keydown="actions.wporg.queryFilter.handleKeydown"
 >
 	<button
-		class="wporg-query-filter__toggle <?php echo count( $settings['selected'] ) ? '' : 'has-no-filter-applied'; ?>"
+		class="<?php echo esc_attr( implode( ' ', $button_classes ) ); ?>"
 		data-wp-class--is-active="context.wporg.queryFilter.isOpen"
 		data-wp-on--click="actions.wporg.queryFilter.toggle"
 		data-wp-bind--aria-expanded="context.wporg.queryFilter.isOpen"
@@ -88,6 +100,15 @@ $html_id = wp_unique_id( "filter-{$settings['key']}-" );
 				<legend class="screen-reader-text"><?php echo wp_kses_post( $settings['title'] ); ?></legend>
 				<?php foreach ( $settings['options'] as $value => $label ) : ?>
 				<div class="wporg-query-filter__option">
+					<?php if ( ! $has_multiple ) : ?>
+					<input
+						type="radio"
+						name="<?php echo esc_attr( $settings['key'] ); ?>"
+						value="<?php echo esc_attr( $value ); ?>"
+						id="<?php echo esc_attr( $html_id . '-' . $value ); ?>"
+						<?php checked( in_array( $value, $settings['selected'] ) ); ?>
+					/>
+					<?php else : ?>
 					<input
 						type="checkbox"
 						name="<?php echo esc_attr( $settings['key'] ); ?>[]"
@@ -95,6 +116,7 @@ $html_id = wp_unique_id( "filter-{$settings['key']}-" );
 						id="<?php echo esc_attr( $html_id . '-' . $value ); ?>"
 						<?php checked( in_array( $value, $settings['selected'] ) ); ?>
 					/>
+					<?php endif; ?>
 					<label for="<?php echo esc_attr( $html_id . '-' . $value ); ?>"><?php echo esc_html( $label ); ?></label>
 				</div>
 				<?php endforeach; ?>

--- a/mu-plugins/blocks/query-filter/src/block.json
+++ b/mu-plugins/blocks/query-filter/src/block.json
@@ -10,6 +10,10 @@
 	"attributes": {
 		"key": {
 			"type": "string"
+		},
+		"multiple": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -19,7 +19,7 @@ function closeDropdown( store ) {
 	context.wporg.queryFilter.isOpen = false;
 	context.wporg.queryFilter.form?.reset();
 
-	const count = context.wporg.queryFilter.form?.querySelectorAll( 'input[type="checkbox"]:checked' ).length;
+	const count = context.wporg.queryFilter.form?.querySelectorAll( 'input:checked' ).length;
 	updateToggleLabel( store, count );
 }
 
@@ -80,15 +80,13 @@ wpStore( {
 				},
 				handleFormChange: ( store ) => {
 					const { context } = store;
-					const count = context.wporg.queryFilter.form.querySelectorAll(
-						'input[type="checkbox"]:checked'
-					).length;
+					const count = context.wporg.queryFilter.form.querySelectorAll( 'input:checked' ).length;
 					updateToggleLabel( store, count );
 				},
 				clearSelection: ( store ) => {
 					const { context } = store;
 					context.wporg.queryFilter.form
-						.querySelectorAll( 'input[type="checkbox"]' )
+						.querySelectorAll( 'input' )
 						.forEach( ( input ) => ( input.checked = false ) );
 					updateToggleLabel( store, 0 );
 				},


### PR DESCRIPTION
This is built on top of the filter block added in #441 — this adds a setting to enable single-select (radio button) behavior for the options, for filters that can't accept multiple values. For example, sorting — this can use the same toggle/dropdown behavior, but you can only sort by one value at a time (at least, that's all we'll allow).

Now, if a filter is set up with `multiple: false`, it will use this single-select version. For example:

```
<!-- wp:wporg/query-filter {"key":"sort","multiple":false} /-->
```

See https://github.com/WordPress/wporg-showcase-2022/pull/147

| | Screenshot |
|---|---|
| Closed, the filter looks like the other toggles, but doesn't flag that there's a selected element (page is currently sorted by title) | ![sort-closed](https://github.com/WordPress/wporg-mu-plugins/assets/541093/30b7df84-a4c0-4fca-bdcb-0d3b9ec68814) |
| Opened, the dropdown looks pretty similar to the multi-select versions, but you can't clear an item by clicking it again (because it's a radio button behind the scenes, for a11y) — clear still works to clear the selection though. | ![sort-date](https://github.com/WordPress/wporg-mu-plugins/assets/541093/5e5f6018-1c5d-48b6-9f08-f678a3680f71) |

**To test**

Try this with the showcase PR: https://github.com/WordPress/wporg-showcase-2022/pull/147