### PR TITLE
Block: Query Filter: Design & accessibility fixes

### DIFF
--- a/mu-plugins/blocks/query-filter/postcss/style.pcss
+++ b/mu-plugins/blocks/query-filter/postcss/style.pcss
@@ -117,6 +117,7 @@
 
 .wporg-query-filter__option {
 	--wporg-query-filter--icon-size: 24px;
+	position: relative;
 }
 
 .wporg-query-filter__option input[type] {
@@ -128,6 +129,8 @@
 	overflow: hidden;
 	padding: 0;
 	position: absolute;
+	top: 0;
+	left: 0;
 	width: 1px;
 	word-wrap: normal !important;
 

--- a/mu-plugins/blocks/query-filter/postcss/style.pcss
+++ b/mu-plugins/blocks/query-filter/postcss/style.pcss
@@ -21,8 +21,8 @@
 	border-radius: 2px;
 	color: var(--wp--custom--wporg-query-filters--toggle--color--text);
 	font-family: var(--wp--preset--font-family--inter);
-	font-size: var(--wp--custom--button--typography--font-size);
-	line-height: var(--wp--custom--button--typography--line-height);
+	font-size: var(--wp--preset--font-size--small);
+	line-height: var(--wp--custom--body--small--typography--line-height);
 	cursor: pointer;
 	white-space: nowrap;
 
@@ -92,7 +92,7 @@
 
 .wporg-query-filter__modal {
 	position: absolute;
-	top: 100%;
+	top: calc(100% + var(--wp--preset--spacing--10));
 	right: 0;
 	width: 20rem;
 	border-radius: 2px;
@@ -140,7 +140,8 @@
 		padding-block: var(--wp--custom--wporg-query-filters--spacing--padding--block);
 		padding-left: var(--wp--custom--wporg-query-filters--spacing--padding--inline-start);
 		padding-right: calc(var(--wp--custom--wporg-query-filters--spacing--padding--inline-end) * 2 + var(--wporg-query-filter--icon-size));
-		line-height: 1;
+		font-size: var(--wp--preset--font-size--small);
+		line-height: var(--wp--custom--body--small--typography--line-height);
 	}
 
 	&:focus + label {
@@ -175,10 +176,11 @@
 }
 
 .wporg-query-filter__modal-actions input {
-	padding: 12px;
+	padding-block: var(--wp--custom--wporg-query-filters--spacing--padding--block);
+	padding-inline: 12px;
 	font-weight: var(--wp--custom--button--typography--font-weight);
-	font-size: var(--wp--custom--button--typography--font-size);
-	line-height: var(--wp--custom--button--typography--line-height);
+	font-size: var(--wp--preset--font-size--small);
+	line-height: var(--wp--custom--body--small--typography--line-height);
 	color: var(--wp--custom--button--color--text);
 	background-color: var(--wp--custom--button--color--background);
 	border: none;
@@ -306,7 +308,7 @@
 	--wp--custom--wporg-query-filters--border--color: var(--wp--preset--color--light-grey-1);
 	--wp--custom--wporg-query-filters--border--style: solid;
 	--wp--custom--wporg-query-filters--border--width: 1px;
-	--wp--custom--wporg-query-filters--spacing--padding--block: var(--wp--preset--spacing--10);
+	--wp--custom--wporg-query-filters--spacing--padding--block: calc(var(--wp--preset--spacing--10) * 0.8);
 	--wp--custom--wporg-query-filters--spacing--padding--inline-start: calc(var(--wp--preset--spacing--10) * 1.5);
 	--wp--custom--wporg-query-filters--spacing--padding--inline-end: calc(var(--wp--preset--spacing--10) * 0.8);
 	--wp--custom--wporg-query-filters--toggle--color--background: var(--wp--preset--color--white);

--- a/mu-plugins/blocks/query-filter/postcss/style.pcss
+++ b/mu-plugins/blocks/query-filter/postcss/style.pcss
@@ -235,6 +235,10 @@
 
 /* Update layout to floating modal on smaller screens. */
 @media (max-width: 889px) {
+	html.is-query-filter-open {
+		overflow: hidden;
+	}
+
 	.wporg-query-filter__modal-backdrop {
 		background-color: rgba(0, 0, 0, 0.15);
 	}

--- a/mu-plugins/blocks/query-filter/postcss/style.pcss
+++ b/mu-plugins/blocks/query-filter/postcss/style.pcss
@@ -204,12 +204,21 @@
 
 	&.wporg-query-filter__modal-action-clear {
 		background-color: transparent;
-		color: #a13f2a; /* pomegrade-1 fails contrast against white. */
+		color: var(--wp--preset--color--blueberry-1);
 		font-weight: 400;
 
 		&:hover,
 		&:active {
 			background-color: var(--wp--preset--color--light-grey-2);
+		}
+
+		&[aria-disabled="true"] {
+			color: var(--wp--preset--color--charcoal-4);
+
+			&:hover,
+			&:active {
+				background-color: transparent;
+			}
 		}
 	}
 }

--- a/mu-plugins/blocks/query-filter/postcss/style.pcss
+++ b/mu-plugins/blocks/query-filter/postcss/style.pcss
@@ -142,6 +142,14 @@
 		padding-right: calc(var(--wp--custom--wporg-query-filters--spacing--padding--inline-end) * 2 + var(--wporg-query-filter--icon-size));
 		font-size: var(--wp--preset--font-size--small);
 		line-height: var(--wp--custom--body--small--typography--line-height);
+		transition:
+			background-color 0.2s ease-in-out,
+			color 0.2s ease-in-out;
+
+		&:hover {
+			background-color: var(--wp--custom--wporg-query-filters--option--active--color--background);
+			color: var(--wp--custom--wporg-query-filters--option--active--color--text);
+		}
 	}
 
 	&:focus + label {

--- a/mu-plugins/blocks/query-filter/postcss/style.pcss
+++ b/mu-plugins/blocks/query-filter/postcss/style.pcss
@@ -148,6 +148,7 @@
 		outline: 1.5px solid var(--wp--custom--wporg-query-filters--toggle--focus--color--outline);
 		outline-offset: -1.5px;
 		box-shadow: inset 0 0 0 3px var(--wp--custom--wporg-query-filters--toggle--focus--color--inset);
+		border-radius: 2px;
 	}
 
 	&:checked + label {

--- a/mu-plugins/blocks/query-filter/postcss/style.pcss
+++ b/mu-plugins/blocks/query-filter/postcss/style.pcss
@@ -142,6 +142,7 @@
 		padding-right: calc(var(--wp--custom--wporg-query-filters--spacing--padding--inline-end) * 2 + var(--wporg-query-filter--icon-size));
 		font-size: var(--wp--preset--font-size--small);
 		line-height: var(--wp--custom--body--small--typography--line-height);
+		border-radius: 2px;
 		transition:
 			background-color 0.2s ease-in-out,
 			color 0.2s ease-in-out;
@@ -156,11 +157,9 @@
 		outline: 1.5px solid var(--wp--custom--wporg-query-filters--toggle--focus--color--outline);
 		outline-offset: -1.5px;
 		box-shadow: inset 0 0 0 3px var(--wp--custom--wporg-query-filters--toggle--focus--color--inset);
-		border-radius: 2px;
 	}
 
 	&:checked + label {
-		border-radius: 2px;
 		background-color: var(--wp--custom--wporg-query-filters--option--active--color--background);
 		color: var(--wp--custom--wporg-query-filters--option--active--color--text);
 	}

--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -46,7 +46,7 @@ $encoded_state = wp_json_encode( [ 'wporg' => [ 'queryFilter' => $init_state ] ]
 // Set up a unique ID for this filter.
 $html_id = wp_unique_id( "filter-{$settings['key']}-" );
 
-$selected_count = count( $settings['selected'] );
+$selected_count = count( array_filter( $settings['selected'] ) );
 $button_classes = array_keys(
 	array_filter(
 		array(

--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -45,15 +45,23 @@ $has_multiple = isset( $attributes['multiple'] ) && $attributes['multiple'];
 // Set up a unique ID for this filter.
 $html_id = wp_unique_id( "filter-{$settings['key']}-" );
 
+$selected_count = count( $settings['selected'] );
 $button_classes = array_keys(
 	array_filter(
 		array(
 			'wporg-query-filter__toggle' => true,
-			'has-no-filter-applied' => ! count( $settings['selected'] ),
+			'has-no-filter-applied' => ! $selected_count,
 			'is-single-select' => ! $has_multiple,
 		)
 	)
 );
+
+if ( $selected_count ) {
+	/* translators: %s is count of currently selected filters. */
+	$apply_label = sprintf( __( 'Apply (%s)', 'wporg' ), $selected_count );
+} else {
+	$apply_label = __( 'Apply', 'wporg' );
+}
 ?>
 <div
 	<?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>
@@ -138,10 +146,11 @@ $button_classes = array_keys(
 					class="wporg-query-filter__modal-action-clear"
 					value="<?php esc_attr_e( 'Clear', 'wporg' ); ?>"
 					data-wp-on--click="actions.wporg.queryFilter.clearSelection"
+					aria-disabled="<?php echo $selected_count ? 'false' : 'true'; ?>"
 				/>
 				<input
 					type="submit"
-					value="<?php esc_html_e( 'Apply', 'wporg' ); ?>"
+					value="<?php echo esc_html( $apply_label ); ?>"
 				/>
 			</div> <!-- /.wporg-query-filter__modal-actions -->
 		</form>

--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -33,14 +33,15 @@ if ( ! isset( $settings['options'] ) || ! count( $settings['options'] ) ) {
 	return;
 }
 
+$has_multiple = isset( $attributes['multiple'] ) && $attributes['multiple'];
+
 // Initial state to pass to Interactivity API.
 $init_state = [
 	'isOpen' => false,
 	'hasHover' => false,
+	'hasMultiple' => $has_multiple,
 ];
 $encoded_state = wp_json_encode( [ 'wporg' => [ 'queryFilter' => $init_state ] ] );
-
-$has_multiple = isset( $attributes['multiple'] ) && $attributes['multiple'];
 
 // Set up a unique ID for this filter.
 $html_id = wp_unique_id( "filter-{$settings['key']}-" );
@@ -56,7 +57,7 @@ $button_classes = array_keys(
 	)
 );
 
-if ( $selected_count ) {
+if ( $selected_count && $has_multiple ) {
 	/* translators: %s is count of currently selected filters. */
 	$apply_label = sprintf( __( 'Apply (%s)', 'wporg' ), $selected_count );
 } else {

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -33,7 +33,7 @@ function updateButtons( store, count ) {
 	const applyButton = context.wporg.queryFilter.form.querySelector( 'input[type="submit"]' );
 	const clearButton = context.wporg.queryFilter.form.querySelector( '.wporg-query-filter__modal-action-clear' );
 
-	if ( count ) {
+	if ( count && context.wporg.queryFilter.hasMultiple ) {
 		/* translators: %s is count of currently selected filters. */
 		applyButton.value = sprintf( __( 'Apply (%s)', 'wporg' ), count );
 		clearButton.setAttribute( 'aria-disabled', 'false' );

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { store as wpStore } from '@wordpress/interactivity';
 
 // See https://github.com/WordPress/gutenberg/blob/37f52ae884a40f7cb77ac2484648b4e4ad973b59/packages/block-library/src/navigation/view-interactivity.js
@@ -20,22 +21,25 @@ function closeDropdown( store ) {
 	context.wporg.queryFilter.form?.reset();
 
 	const count = context.wporg.queryFilter.form?.querySelectorAll( 'input:checked' ).length;
-	updateToggleLabel( store, count );
+	updateButtons( store, count );
 }
 
-function updateToggleLabel( store, count ) {
+function updateButtons( store, count ) {
 	const { context } = store;
-	const toggle = context.wporg.queryFilter.toggleButton;
-	if ( ! toggle ) {
+	if ( ! context.wporg.queryFilter.form ) {
 		return;
 	}
-	if ( toggle.querySelector( 'span' ) ) {
-		toggle.querySelector( 'span' ).innerText = count;
-	}
+
+	const applyButton = context.wporg.queryFilter.form.querySelector( 'input[type="submit"]' );
+	const clearButton = context.wporg.queryFilter.form.querySelector( '.wporg-query-filter__modal-action-clear' );
+
 	if ( count ) {
-		toggle.classList.remove( 'has-no-filter-applied' );
+		/* translators: %s is count of currently selected filters. */
+		applyButton.value = sprintf( __( 'Apply (%s)', 'wporg' ), count );
+		clearButton.setAttribute( 'aria-disabled', 'false' );
 	} else {
-		toggle.classList.add( 'has-no-filter-applied' );
+		applyButton.value = __( 'Apply', 'wporg' );
+		clearButton.setAttribute( 'aria-disabled', 'true' );
 	}
 }
 
@@ -81,14 +85,17 @@ wpStore( {
 				handleFormChange: ( store ) => {
 					const { context } = store;
 					const count = context.wporg.queryFilter.form.querySelectorAll( 'input:checked' ).length;
-					updateToggleLabel( store, count );
+					updateButtons( store, count );
 				},
 				clearSelection: ( store ) => {
-					const { context } = store;
+					const { context, ref } = store;
+					if ( 'true' === ref.getAttribute( 'aria-disabled' ) ) {
+						return;
+					}
 					context.wporg.queryFilter.form
 						.querySelectorAll( 'input' )
 						.forEach( ( input ) => ( input.checked = false ) );
-					updateToggleLabel( store, 0 );
+					updateButtons( store, 0 );
 				},
 			},
 		},

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -33,14 +33,17 @@ function updateButtons( store, count ) {
 	const applyButton = context.wporg.queryFilter.form.querySelector( 'input[type="submit"]' );
 	const clearButton = context.wporg.queryFilter.form.querySelector( '.wporg-query-filter__modal-action-clear' );
 
-	if ( count && context.wporg.queryFilter.hasMultiple ) {
-		/* translators: %s is count of currently selected filters. */
-		applyButton.value = sprintf( __( 'Apply (%s)', 'wporg' ), count );
-		clearButton.setAttribute( 'aria-disabled', 'false' );
-	} else {
-		applyButton.value = __( 'Apply', 'wporg' );
-		clearButton.setAttribute( 'aria-disabled', 'true' );
+	// Only update the apply button if multiple selections are allowed.
+	if ( context.wporg.queryFilter.hasMultiple ) {
+		if ( count ) {
+			/* translators: %s is count of currently selected filters. */
+			applyButton.value = sprintf( __( 'Apply (%s)', 'wporg' ), count );
+		} else {
+			applyButton.value = __( 'Apply', 'wporg' );
+		}
 	}
+
+	clearButton.setAttribute( 'aria-disabled', count ? 'false' : 'true' );
 }
 
 wpStore( {

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -22,6 +22,7 @@ function closeDropdown( store ) {
 
 	const count = context.wporg.queryFilter.form?.querySelectorAll( 'input:checked' ).length;
 	updateButtons( store, count );
+	document.documentElement.classList.remove( 'is-query-filter-open' );
 }
 
 function updateButtons( store, count ) {
@@ -56,6 +57,7 @@ wpStore( {
 						closeDropdown( store );
 					} else {
 						context.wporg.queryFilter.isOpen = true;
+						document.documentElement.classList.add( 'is-query-filter-open' );
 					}
 				},
 				handleKeydown: ( store ) => {


### PR DESCRIPTION
See #419 & https://github.com/WordPress/wporg-showcase-2022/issues/151. This PR addresses the design & accessibility feedback for the Query Filter block. 

- Fix the input position to fix scroll issues (tabbing to items off screen moves them into view, selecting items does not scroll the whole page).
- Add the currently selected count to the Apply button when it's a multiple-select dropdown.
- Updates the font size, line height, and padding across the buttons and options to match the design.
- Add a hover state to options, add border radius to all option states (hover, checked, focus).
- Move dropdown down 10px.
- Update the Clear button to be `aria-disabled` when no items are selected, use that to style it as grey.
- When items are selected, Clear is now blueberry.

Thanks for the feedback @jasmussen & @joedolson!

## Screenshots

| | Screenshot |
|---|---|
| Multiple select, "e-commerce" selected, "Design" hovered | ![qf-selected-hover](https://github.com/WordPress/wporg-mu-plugins/assets/541093/ec922521-75ab-4184-8381-54fe159bf0a5) |
| Single select, none selected so Clear is disabled | ![qf-clear](https://github.com/WordPress/wporg-mu-plugins/assets/541093/42f8dec4-4113-42e3-b902-c75c69c24734) |

**To test**

Use this with Showcase to have something set up already.

No specific test instructions, just try interacting with the filters and make sure it matches the feedback & design.