### PR TITLE
Global Header/Footer: Hide the arrow emoji for screen reader users

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -17,6 +17,8 @@ add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
 add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
 add_filter( 'render_block_core/navigation-link', __NAMESPACE__ . '\swap_submenu_arrow_svg' );
 add_filter( 'render_block_core/search', __NAMESPACE__ . '\swap_header_search_action', 10, 2 );
+add_filter( 'render_block_wporg/global-header', __NAMESPACE__ . '\add_aria_hidden_to_arrows', 19 );
+add_filter( 'render_block_wporg/global-footer', __NAMESPACE__ . '\add_aria_hidden_to_arrows', 19 );
 add_filter( 'render_block_data', __NAMESPACE__ . '\update_block_style_colors' );
 
 /**
@@ -996,6 +998,17 @@ function swap_header_search_action( $block_content, $block ) {
 	}
 
 	return $block_content;
+}
+
+/**
+ * Wrap the arrow emoji in an aria-hidden span tag, to prevent screen readers
+ * from trying to read them.
+ *
+ * @param string $content Content of the block.
+ * @return string The updated content.
+ */
+function add_aria_hidden_to_arrows( $content ) {
+	return preg_replace( '/([←↑→↓↔↕↖↗↘↙])/u', '<span aria-hidden="true">\1</span>', $content );
 }
 
 /**


### PR DESCRIPTION
Fixes #453 — The arrows are primarily decorative, and screen readers can be overly verbose when encountering special characters. This brings over the function from https://github.com/WordPress/wporg-parent-2021/pull/94 to wrap the arrows in `aria-hidden`.

<img width="477" alt="Screenshot 2023-09-25 at 12 53 05 PM" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/568fd1b4-a9ff-4024-ae31-be9440cd5b95">

**To test**

- View source/inspect a list item with an arrow
- It should be wrapped in a span

Or

- Try using a screen reader, navigate through to the menu items with arrows
- Only the text should be read, not the arrows
