### PR TITLE
Global Footer: Switch multiple nav blocks to lists inside a nav wrapper.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -810,7 +810,6 @@ function render_global_footer( $attributes, $content, $block ) {
 
 	if ( is_rosetta_site() ) {
 		$locale_title = get_rosetta_name();
-		add_filter( 'render_block_data', __NAMESPACE__ . '\localize_nav_links' );
 	} else {
 		$locale_title = '';
 	}
@@ -831,8 +830,6 @@ function render_global_footer( $attributes, $content, $block ) {
 		require_once __DIR__ . '/classic-footer.php';
 		$footer_markup = ob_get_clean();
 	}
-
-	remove_filter( 'render_block_data', __NAMESPACE__ . '\localize_nav_links' );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array( 'class' => 'global-footer wp-block-group' )
@@ -870,29 +867,6 @@ function update_block_style_colors( $block ) {
 	return $block;
 }
 
-
-/**
- * Localise a `core/navigation-link` block link to point to the Rosetta site resource.
- *
- * Unfortunately WordPress doesn't have a block-specific pre- filter, only a block-specific post-filter.
- * That's why we specifically check for the blockName here.
- *
- * @param array $block The parsed block data.
- *
- * @return array
- */
-function localize_nav_links( $block ) {
-	if (
-		! empty( $block['blockName'] ) &&
-		'core/navigation-link' === $block['blockName'] &&
-		! empty( $block['attrs']['url'] )
-	) {
-		$block['attrs']['url'] = get_localized_footer_link( $block['attrs']['url'] );
-	}
-
-	return $block;
-}
-
 /**
  * Get a localized variant of a link included in the global footer.
  *
@@ -900,7 +874,7 @@ function localize_nav_links( $block ) {
  *
  * @return string Replacement URL, which may be localised.
  */
-function get_localized_footer_link( $url ) {
+function get_localized_link( $url ) {
 	global $rosetta;
 	if ( empty( $rosetta->current_site_domain ) ) {
 		return $url;

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -22,7 +22,7 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 ?>
 
 <!-- wp:group {"tagName":"nav","align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"global-footer__navigation-container","layout":{"type":"grid","minimumColumnWidth":"150px"}} -->
-<nav class="wp-block-group alignfull global-footer__navigation-container">
+<nav class="wp-block-group alignfull global-footer__navigation-container" aria-label="<?php esc_html_e( 'Footer', 'wporg' ); ?>">
 	<!-- wp:list -->
 	<ul>
 		<!-- wp:list-item -->

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\MU_Plugins\Global_Header_Footer\Footer;
 
-use function WordPressdotorg\MU_Plugins\Global_Header_Footer\{ get_cip_text, get_home_url, get_container_classes, is_rosetta_site };
+use function WordPressdotorg\MU_Plugins\Global_Header_Footer\{ get_cip_text, get_home_url, get_container_classes, is_rosetta_site, get_localized_link };
 
 defined( 'WPINC' ) || die();
 
@@ -21,48 +21,103 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 
 ?>
 
-<!-- wp:group {"className":"global-footer__navigation-container"} -->
-<div class="wp-block-group global-footer__navigation-container">
-	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-important","overlayMenu":"never"} -->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'About', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/about/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'News', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/news/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Hosting', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/hosting/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Donate', 'Menu item title', 'wporg' ); ?>","url":"https://wordpressfoundation.org/donate/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Swag', 'Menu item title', 'wporg' ); ?>","url":"https://mercantile.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-	<!-- /wp:navigation -->
+<!-- wp:group {"tagName":"nav","align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"className":"global-footer__navigation-container","layout":{"type":"grid","minimumColumnWidth":"150px"}} -->
+<nav class="wp-block-group alignfull global-footer__navigation-container">
+	<!-- wp:list -->
+	<ul>
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/about/' ) ); ?>"><?php echo esc_html_x( 'About', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/news/' ) ); ?>"><?php echo esc_html_x( 'News', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/hosting/' ) ); ?>"><?php echo esc_html_x( 'Hosting', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://wordpressfoundation.org/donate/"><?php echo esc_html_x( 'Donate', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://mercantile.wordpress.org/"><?php echo esc_html_x( 'Swag', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+	</ul>
+	<!-- /wp:list -->
 
-	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-information","overlayMenu":"never"} -->
+	<!-- wp:list -->
+	<ul>
 		<?php if ( is_rosetta_site() ) { ?>
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Support', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/support/","kind":"custom","isTopLevelLink":true} /-->
+			<!-- wp:list-item -->
+			<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/support/' ) ); ?>"><?php echo esc_html_x( 'Support', 'Menu item title', 'wporg' ); ?></a></li>
+			<!-- /wp:list-item -->
 		<?php } else { ?>
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Documentation', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/documentation/","kind":"custom","isTopLevelLink":true} /-->
+			<!-- wp:list-item -->
+			<li><a href="https://wordpress.org/documentation/"><?php echo esc_html_x( 'Documentation', 'Menu item title', 'wporg' ); ?></a></li>
+			<!-- /wp:list-item -->
 		<?php } ?>
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Developers', 'Menu item title', 'wporg' ); ?>","url":"https://developer.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Get Involved', 'Menu item title', 'wporg' ); ?>","url":"https://make.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Learn', 'Menu item title', 'wporg' ); ?>","url":"https://learn.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->
-	<!-- /wp:navigation -->
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://developer.wordpress.org/' ) ); ?>"><?php echo esc_html_x( 'Developers', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://make.wordpress.org/"><?php echo esc_html_x( 'Get Involved', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://learn.wordpress.org/' ) ); ?>"><?php echo esc_html_x( 'Learn', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+	</ul>
+	<!-- /wp:list -->
 
-	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-resources","overlayMenu":"never"} -->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Showcase', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/showcase/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Plugins', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/plugins/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Themes', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/themes/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Patterns', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/patterns/","kind":"custom","isTopLevelLink":true} /-->
-	<!-- /wp:navigation -->
+	<!-- wp:list -->
+	<ul>
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/showcase/' ) ); ?>"><?php echo esc_html_x( 'Showcase', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/plugins/' ) ); ?>"><?php echo esc_html_x( 'Plugins', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/themes/' ) ); ?>"><?php echo esc_html_x( 'Themes', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/patterns/' ) ); ?>"><?php echo esc_html_x( 'Patterns', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+	</ul>
+	<!-- /wp:list -->
 
-	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-community","overlayMenu":"never"} -->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordCamp', 'Menu item title', 'wporg' ); ?>","url":"https://central.wordcamp.org/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordPress.TV', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.tv/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'BuddyPress', 'Menu item title', 'wporg' ); ?>","url":"https://buddypress.org/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'bbPress', 'Menu item title', 'wporg' ); ?>","url":"https://bbpress.org/","kind":"custom","isTopLevelLink":true} /-->
-	<!-- /wp:navigation -->
+	<!-- wp:list -->
+	<ul>
+		<!-- wp:list-item -->
+		<li><a href="https://central.wordcamp.org/"><?php echo esc_html_x( 'WordCamp', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://wordpress.tv/"><?php echo esc_html_x( 'WordPress.TV', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://buddypress.org/"><?php echo esc_html_x( 'BuddyPress', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://bbpress.org/"><?php echo esc_html_x( 'bbPress', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+	</ul>
+	<!-- /wp:list -->
 
-	<!-- wp:navigation {"orientation":"vertical","className":"global-footer__navigation-external","overlayMenu":"never"} -->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'WordPress.com', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.com/?ref=wporg-footer","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Matt', 'Menu item title', 'wporg' ); ?>","url":"https://ma.tt/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Privacy', 'Menu item title', 'wporg' ); ?>","url":"https://wordpress.org/about/privacy/","kind":"custom","isTopLevelLink":true} /-->
-		<!-- wp:navigation-link {"label":"<?php echo esc_html_x( 'Public Code', 'Menu item title', 'wporg' ); ?>","url":"https://publiccode.eu/","kind":"custom","isTopLevelLink":true} /-->
-	<!-- /wp:navigation -->
-</div> <!-- /wp:group -->
+	<!-- wp:list -->
+	<ul>
+		<!-- wp:list-item -->
+		<li><a href="https://wordpress.com/?ref=wporg-footer"><?php echo esc_html_x( 'WordPress.com', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://ma.tt/"><?php echo esc_html_x( 'Matt', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="<?php echo esc_url( get_localized_link( 'https://wordpress.org/about/privacy/' ) ); ?>"><?php echo esc_html_x( 'Privacy', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://publiccode.eu/"><?php echo esc_html_x( 'Public Code', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+	</ul>
+	<!-- /wp:list -->
+</nav>
+<!-- /wp:group -->
 
 <!-- wp:group {"className":"global-footer__logos-container"} -->
 <div class="wp-block-group global-footer__logos-container">

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -203,7 +203,6 @@ html {
 }
 
 /* The scrollbar covers up part of the edge padding, so this offsets that. */
-.wp-block-group.global-header,
-.wp-block-group.global-footer > * {
+.wp-block-group.global-header {
 	padding-right: var(--wp--custom--alignment--scroll-bar-width);
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/footer.pcss
@@ -10,23 +10,28 @@
 	}
 
 	& > .global-footer__navigation-container {
-		max-width: 100%;
-		display: grid;
 		align-items: start;
-		column-gap: 20px;
 		row-gap: 35px;
 
 		/* Create columns automatically, make them equal widths, wrap when needed. */
 		grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-	}
-
-	& .wp-block-navigation__container {
-		flex-direction: column;
-		gap: 5px;
-		align-items: self-start;
 
 		@media (--tablet) {
 			font-size: var(--wp--preset--font-size--small);
 		}
+
+		& ul {
+			list-style: none;
+			padding: 0;
+
+			& li + li {
+				margin-top: 5px;
+			}
+		}
+	}
+
+	& .wp-block-navigation__container {
+		flex-direction: column;
+		align-items: self-start;
 	}
 }


### PR DESCRIPTION
Fixes #402 — This switches to the global footer block to use a `nav` group block around 5 lists, instead of 5 separate nav blocks. Additionally, the label "Footer" has been added to the `nav`, so it now appears as "Footer navigation" when browsing by landmark.

This also had to change the way menu items were localized, removing the filter on nav-link blocks in favor of directly calling the function on appropriate links. 

Props @joedolson for the report

**Screenshots**

| | Production | Branch |
|---|---|---|
| Home, wide screen | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/e5ca0ff8-bfab-474e-9e96-eb1517963e8e) | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/e2bb35bf-2a41-4717-adbd-b9b9c10136c7) |
| Home, small screen | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/54ae9263-824d-4a61-af49-a5b24a1fbd6c) | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/00658dea-4a5f-4d5d-aec1-8d60686ee179) |
| Rosetta, wide screen | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/058af94b-ff48-4b1c-87f3-08a4eecf87e0) | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/849e5559-c540-471b-b8b5-cf97a400edb7) |
| Rosetta, small screen | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/284dfb73-c31b-40fe-9948-56f127beddcd) | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/022d4b0a-5f10-45e8-b539-d87813b912dc) |
| Classic theme, wide screen | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/814f6563-34c3-4668-abfe-1684232d8c64) | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/31130e79-5adc-4822-90cd-1ddc7fdba905) |
| Classic theme, small screen | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/76ae1998-b76d-4697-b293-91842d4e8823) | ![](https://github.com/WordPress/wporg-mu-plugins/assets/541093/bebee94e-db99-457a-b09e-b9a9ec9d1e21) |

**To test**

1. If you can, apply this to a sandbox and test on various sites— new & old themes, rosetta, etc.
2. Otherwise, use with one of the redesign sites (main, showcase, etc) to test locally
3. The footer is now one single `nav` element, individual items are lists
4. There should be no visual changes in the footer

Optionally test with a screen reader to see the single Footer navigation landmark.