### PR TITLE
Add hover color for `charcoal-1` headers

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -110,6 +110,10 @@ html {
 	--wp-global-header--link-color--active: var(--wp--preset--color--white);
 }
 
+.has-charcoal-1-background-color {
+	--wp-global-header--background-color--hover: var(--wp--preset--color--charcoal-2);
+}
+
 .has-white-background-color {
 	--wp-global-header--background-color: var(--wp--preset--color--white);
 	--wp-global-header--background-color--hover: var(--wp--preset--color--light-grey-2);


### PR DESCRIPTION
Fixes #451 

The header for [Showcase v2](https://wordpress.org/showcase-v2/) has a background color set to `--wp--preset--color--charcoal-1` via the class `has-charcoal-1-background-color`, and there was no designated hover color set for Navigation block submenus. This PR sets the hover color to `--wp--preset--color--charcoal-2`, allowing the menu to stand out more on hover.

| Before | After |
| ---- | ---- |
| <img width="377" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/4832319/a5e2b82f-ae73-4bbf-b481-d5e5b67f52b7"> | <img width="410" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/936e3ee7-5b2c-40f2-806b-b7e070eadf24"> | 

