### PR TITLE
Change footer Twitter icon to X

### DIFF
--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -98,7 +98,7 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 	<!-- wp:social-links {"className":"is-style-logos-only"} -->
 	<ul class="wp-block-social-links is-style-logos-only">
 		<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook","label":"<?php echo esc_html_x( 'Visit our Facebook page', 'Menu item title', 'wporg' ); ?>"} /-->
-		<!-- wp:social-link {"url":"https://www.x.com/WordPress","service":"x","label":"<?php echo esc_html_x( 'Visit our X account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://www.x.com/WordPress","service":"x","label":"<?php echo esc_html_x( 'Visit our X (formerly Twitter) account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.instagram.com/wordpress/","service":"instagram","label":"<?php echo esc_html_x( 'Visit our Instagram account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin","label":"<?php echo esc_html_x( 'Visit our LinkedIn account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.youtube.com/wordpress","service":"youtube","label":"<?php echo esc_html_x( 'Visit our YouTube channel', 'Menu item title', 'wporg' ); ?>"} /-->

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -98,7 +98,7 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 	<!-- wp:social-links {"className":"is-style-logos-only"} -->
 	<ul class="wp-block-social-links is-style-logos-only">
 		<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook","label":"<?php echo esc_html_x( 'Visit our Facebook page', 'Menu item title', 'wporg' ); ?>"} /-->
-		<!-- wp:social-link {"url":"https://twitter.com/WordPress","service":"twitter","label":"<?php echo esc_html_x( 'Visit our Twitter account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://www.x.com/WordPress","service":"x","label":"<?php echo esc_html_x( 'Visit our X account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.instagram.com/wordpress/","service":"instagram","label":"<?php echo esc_html_x( 'Visit our Instagram account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin","label":"<?php echo esc_html_x( 'Visit our LinkedIn account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.youtube.com/wordpress","service":"youtube","label":"<?php echo esc_html_x( 'Visit our YouTube channel', 'Menu item title', 'wporg' ); ?>"} /-->


### PR DESCRIPTION
To correspond with X's new [branding guidelines](https://about.twitter.com/en/who-we-are/brand-toolkit), let's switch out the old Twitter logo with X. 

The footer links are powered by the Core Social Links block. This block will get the X icon in Gutenberg 16.7, set to be released on 9/27 per https://github.com/WordPress/gutenberg/pull/54092. 

**This PR should only be merged after 16.7 is deployed across WordPress.org.** 

| Before | After (w/ Gutenberg 16.7+) |
| ---- | ---- |
| <img width="366" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/105cd868-4f6d-429d-93f7-7a6bcb7445a1"> | <img width="364" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/20646441-196c-4db9-9288-c4695a0325c3"> | 