### PR TITLE
Global header: Update navigation menu items

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -15,7 +15,6 @@ add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_block_assets', 200 
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles', 5 ); // Before any theme CSS.
 add_action( 'wp_head', __NAMESPACE__ . '\preload_google_fonts' );
 add_filter( 'style_loader_src', __NAMESPACE__ . '\update_google_fonts_url', 10, 2 );
-add_filter( 'render_block_core/navigation-link', __NAMESPACE__ . '\swap_submenu_arrow_svg' );
 add_filter( 'render_block_core/search', __NAMESPACE__ . '\swap_header_search_action', 10, 2 );
 add_filter( 'render_block_data', __NAMESPACE__ . '\update_block_style_colors' );
 
@@ -465,7 +464,7 @@ function get_global_menu_items() {
 		),
 		array(
 			'title'   => esc_html_x( 'Learn', 'Menu item title', 'wporg' ),
-			'url'     => 'https://learn.wordpress.org/',
+			'url'     => '#',
 			'type'    => 'custom',
 			'submenu' => array(
 				array(
@@ -497,7 +496,7 @@ function get_global_menu_items() {
 		),
 		array(
 			'title'   => esc_html_x( 'Community', 'Menu item title', 'wporg' ),
-			'url'     => 'https://make.wordpress.org/',
+			'url'     => '#',
 			'type'    => 'custom',
 			'submenu' => array(
 				array(
@@ -534,7 +533,7 @@ function get_global_menu_items() {
 		),
 		array(
 			'title'   => esc_html_x( 'About', 'Menu item title', 'wporg' ),
-			'url'     => 'https://wordpress.org/about/',
+			'url'     => '#',
 			'type'    => 'custom',
 			'submenu' => array(
 				array(
@@ -962,16 +961,6 @@ function set_current_item_class( $menu_items ) {
 	}
 
 	return $menu_items;
-}
-
-/**
- * Replace the current submenu down-arrow with a custom icon.
- *
- * @param string $block_content The block content about to be appended.
- * @return string The filtered block content.
- */
-function swap_submenu_arrow_svg( $block_content ) {
-	return str_replace( block_core_navigation_link_render_submenu_icon(), "<svg width='10' height='7' viewBox='0 0 10 7' stroke-width='1.2' xmlns='http://www.w3.org/2000/svg'><path d='M0.416667 1.33325L5 5.49992L9.58331 1.33325'></path></svg>", $block_content );
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -422,23 +422,23 @@ function get_global_menu_items() {
 			'type'    => 'custom',
 		),
 		array(
-			'title'   => esc_html_x( 'Download & Extend', 'Menu item title', 'wporg' ),
-			'url'     => 'https://wordpress.org/download/',
+			'title' => esc_html_x( 'Showcase', 'Menu item title', 'wporg' ),
+			'url'   => 'https://wordpress.org/showcase/',
+			'type'  => 'custom',
+		),
+		array(
+			'title' => esc_html_x( 'Hosting', 'Menu item title', 'wporg' ),
+			'url'   => 'https://wordpress.org/hosting/',
+			'type'  => 'custom',
+		),
+		array(
+			'title'   => esc_html_x( 'Extend', 'Menu item title', 'wporg' ),
+			'url'     => '#',
 			'type'    => 'custom',
 			'submenu' => array(
 				array(
-					'title' => esc_html_x( 'Get WordPress', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/download/',
-					'type'  => 'custom',
-				),
-				array(
 					'title' => esc_html_x( 'Themes', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/themes/',
-					'type'  => 'custom',
-				),
-				array(
-					'title' => esc_html_x( 'Patterns', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/patterns/',
 					'type'  => 'custom',
 				),
 				array(
@@ -447,13 +447,13 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'Mobile', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/mobile/',
+					'title' => esc_html_x( 'Patterns', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/patterns/',
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'Hosting', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/hosting/',
+					'title' => esc_html_x( 'Blocks', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/blocks/',
 					'type'  => 'custom',
 				),
 				array(
@@ -543,11 +543,6 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'Showcase', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/showcase/',
-					'type'  => 'custom',
-				),
-				array(
 					'title' => esc_html_x( 'Enterprise', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/enterprise/',
 					'type'  => 'custom',
@@ -558,7 +553,7 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'WordPress Swag Store ↗︎', 'Menu item title', 'wporg' ),
+					'title' => esc_html_x( 'Swag Store ↗︎', 'Menu item title', 'wporg' ),
 					'url'   => 'https://mercantile.wordpress.org/',
 					'type'  => 'custom',
 				),

--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -81,7 +81,7 @@ function recursive_menu( $menu_item, $top_level = true ) {
 <!-- /wp:paragraph -->
 <?php endif; ?>
 
-<!-- wp:navigation {"className":"global-header__navigation","layout":{"type":"flex","orientation":"horizontal"}} -->
+<!-- wp:navigation {"openSubmenusOnClick":true,"className":"global-header__navigation","layout":{"type":"flex","orientation":"horizontal"}} -->
 	<?php
 	/*
 	* Loop though menu items and create navigation item blocks. Recurses through any submenu items to output dropdowns.

--- a/mu-plugins/blocks/global-header-footer/js/view.js
+++ b/mu-plugins/blocks/global-header-footer/js/view.js
@@ -103,21 +103,25 @@
 					'wp-block-navigation-item',
 					'wp-block-navigation-submenu',
 					'has-child',
-					'open-on-hover-click',
+					'open-on-click',
 					'global-header__overflow-menu'
 				);
 
 				const newButton = document.createElement( 'button' );
-				newButton.classList.add(
-					'wp-block-navigation__submenu-icon',
-					'wp-block-navigation-submenu__toggle'
-				);
-				newButton.appendChild( document.createTextNode( '...' ) );
+				newButton.classList.add( 'wp-block-navigation-submenu__toggle' );
+				newButton.appendChild( document.createTextNode( '…' ) );
 				newButton.setAttribute( 'aria-label', labels.overflowMenuLabel );
 				newButton.setAttribute( 'aria-expanded', 'false' );
 				newButton.addEventListener( 'click', function ( event ) {
 					const isOpen = event.target.getAttribute( 'aria-expanded' ) === 'true';
 					event.target.setAttribute( 'aria-expanded', isOpen ? 'false' : 'true' );
+				} );
+				newItem.addEventListener( 'focusout', function ( event ) {
+					if ( ! newItem.contains( event.relatedTarget ) ) {
+						itemsContainer
+							.querySelector( '.global-header__overflow-menu button' )
+							.setAttribute( 'aria-expanded', 'false' );
+					}
 				} );
 				newItem.appendChild( newButton );
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -277,7 +277,6 @@
 			}
 		}
 
-		&:hover .wp-block-navigation__submenu-container,
 		& [aria-expanded="true"] ~ .wp-block-navigation__submenu-container,
 		& [aria-expanded="true"] ~ .wp-block-navigation__submenu-container .wp-block-navigation__submenu-container {
 			visibility: visible;

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -65,10 +65,6 @@
 				width: 100%;
 			}
 
-			& .wp-block-navigation__submenu-icon {
-				display: none;
-			}
-
 			& .wp-block-navigation__responsive-container-content {
 				padding-top: 2em;
 				padding-left: calc(var(--wp--style--block-gap) / 2);
@@ -167,12 +163,27 @@
 
 			@media (--tablet) {
 				margin: 0;
-				padding-left: calc(var(--wp--style--block-gap) / 6);
 				padding-right: calc(var(--wp--style--block-gap) / 2);
 				height: 24px;
-				width: 12px;
 				box-sizing: content-box;
+
+				&::after {
+					content: "";
+					display: inline-block;
+					margin-left: 9px;
+					height: 10px;
+					width: 12px;
+					/* stylelint-disable-next-line function-url-quotes */
+					mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none' aria-hidden='true' focusable='false'%3E%3Cpath d='M1.50002 4L6.00002 8L10.5 4' stroke='black' stroke-width='1.5'%3E%3C/path%3E%3C/svg%3E");
+					mask-repeat: no-repeat;
+					mask-position: center;
+					background-color: var(--wp-global-header--text-color);
+				}
 			}
+		}
+
+		& .wp-block-navigation__submenu-icon {
+			display: none;
 		}
 
 		& .wp-block-navigation-item.has-child a {
@@ -221,7 +232,12 @@
 				margin: 0;
 				padding-left: var(--wp--style--block-gap);
 				padding-right: var(--wp--style--block-gap);
+				color: inherit;
 			}
+		}
+
+		& .wp-block-navigation-submenu__toggle::after {
+			display: none;
 		}
 
 		& .global-header__overflow-item {
@@ -274,16 +290,6 @@
 
 	& .wp-block-navigation-item {
 		padding-bottom: 0;
-	}
-
-	& .wp-block-navigation__submenu-icon {
-		margin-left: 0;
-		padding-right: 22px;
-
-		& svg {
-			fill: none;
-			stroke: currentcolor;
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes #316, fixes #360, fixes #440, fixes #417. This updates the menu structure to match the layout in this comment: https://github.com/WordPress/wporg-mu-plugins/issues/360#issuecomment-1732619788

Additionally, this changes the menu behavior to "open on click", rather than hover, which avoids the duplicate menu items. Changing this required some more CSS and JS changes than expected, so it would be good to get another  👀  on that just in case.

There should be no major visual changes, the main visible difference is that now the focus goes around both the title and dropdown icon.

<img width="334" alt="Screenshot 2023-09-26 at 6 25 27 PM" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/b178dda5-7986-46cd-beeb-1a0deb6e07f3">

| | Screenshot |
|---|---|
| Showcase, no menus open | ![new-header-showcase](https://github.com/WordPress/wporg-mu-plugins/assets/541093/beee0d9d-127d-42f2-af58-87a02639238c) |
| Showcase, small screens | ![new-header-mobile](https://github.com/WordPress/wporg-mu-plugins/assets/541093/9798e376-c166-48d6-b9c2-c19bade8e378) |
| Blue header, with a menu open | ![new-header-blue](https://github.com/WordPress/wporg-mu-plugins/assets/541093/b52bb5e0-105c-4033-be24-b0e1b2449663) |

**To test**

- Try on a sandbox or with one of the redesign projects
- The menu items should match the issue comment
- Items with submenus should have chevron icons
- Hovering over items will highlight them but not open submenus
- Clicking an item with a submenu should open the menu, not change page navigation
- Non-submenu items should behave as expected too

Try on Rosetta sites if you can sandbox.

> [!WARNING]
> This should not be merged until Showcase is ready to be moved to the top-level, once the new theme launches.