### PR TITLE
Global Header: Try unsticking the global header, making local navigation sticky

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -25,11 +25,6 @@ html {
 	--wp-global-header-offset: calc(var(--wp-global-header-height, 0px) + var(--wp-admin--admin-bar--height, 0px));
 	margin-top: var(--wp-admin--admin-bar--height, 0);
 	height: unset; /* Let height use default browser height. */
-
-	@media (--tablet) {
-		scroll-padding-top: var(--wp-global-header-offset, 0);
-		margin-top: var(--wp-global-header-offset, 0);
-	}
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
@@ -5,12 +5,14 @@
 .wp-block-group.global-header {
 	& .global-header__desktop-get-wordpress,
 	& .global-header__mobile-get-wordpress a {
+		display: block;
 		background-color: var(--wp--preset--color--blueberry-1) !important; /* Override Gutenberg's !important */
 		color: var(--wp--preset--color--white) !important; /* Override the header color scheme */
 		padding: 10px 19px;
 		border-radius: 2px;
 		font-weight: 700;
 		font-size: var(--wp--preset--font-size--small);
+		line-height: 1.15;
 
 		&:hover {
 			cursor: pointer;
@@ -35,6 +37,8 @@
 	/* Desktop - `div` containing `a` */
 	& .global-header__desktop-get-wordpress-container {
 		display: none;
+		padding-top: 27px;
+		padding-bottom: 27px;
 		padding-left: var(--wp--style--block-gap);
 
 		@media (--tablet) {
@@ -42,8 +46,8 @@
 		}
 
 		@media (--short-screen) {
-			padding-top: 18px;
-			padding-bottom: 18px;
+			padding-top: 12px;
+			padding-bottom: 12px;
 		}
 
 		& a:hover,

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -26,15 +26,6 @@ html {
 	position: relative;
 	z-index: 250;
 
-	@media (--tablet) {
-		position: fixed;
-		top: var(--wp-admin--admin-bar--height, 0);
-		left: 0;
-		right: 0;
-		font-size: var(--wp--preset--font-size--small);
-		line-height: 24px;
-	}
-
 	& > * {
 		flex-shrink: 0;
 		padding-left: var(--wp--style--block-gap);

--- a/mu-plugins/blocks/local-navigation-bar/index.php
+++ b/mu-plugins/blocks/local-navigation-bar/index.php
@@ -20,12 +20,7 @@ add_filter( 'render_block', __NAMESPACE__ . '\customize_navigation_block_icon', 
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function init() {
-	register_block_type(
-		__DIR__ . '/build',
-		array(
-			'render_callback' => __NAMESPACE__ . '\render',
-		)
-	);
+	register_block_type( __DIR__ . '/build' );
 
 	// Add the Brush Stroke block style.
 	register_block_style(
@@ -34,25 +29,6 @@ function init() {
 			'name'         => 'brush-stroke',
 			'label'        => __( 'Brush Stroke', 'wporg' ),
 		)
-	);
-}
-
-/**
- * Render the block content.
- *
- * @param array    $attributes Block attributes.
- * @param string   $content    Block default content.
- * @param WP_Block $block      Block instance.
- *
- * @return string Returns the block markup.
- */
-function render( $attributes, $content, $block ) {
-	$wrapper_attributes = get_block_wrapper_attributes();
-
-	return sprintf(
-		'<div %1$s>%2$s</div>',
-		$wrapper_attributes,
-		$content
 	);
 }
 

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -55,6 +55,11 @@
 		& .global-header__wporg-logo-mark {
 			display: none;
 		}
+
+		& + .wp-block-group.is-position-sticky {
+			position: static !important;
+			z-index: 0 !important;
+		}
 	}
 
 	&.is-style-brush-stroke {

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -64,7 +64,7 @@
 
 	&.is-style-brush-stroke {
 		position: sticky;
-		padding-bottom: 0 !important; /* Override element style */
+		padding-bottom: 8px !important; /* Override element style */
 
 		&::before {
 			content: "";
@@ -79,10 +79,6 @@
 			mask-size: cover;
 			mask-position: bottom right;
 			background-color: inherit;
-		}
-
-		&.is-sticking {
-			padding-bottom: 8px !important;
 		}
 	}
 

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -11,7 +11,7 @@
 
 	/* If a sticky element is next, it needs to account for the nav bar offset. */
 	& + :where(.wp-block-group.is-position-sticky) {
-		top: calc(var(--wp-admin--admin-bar--height, 0) + 60px);
+		top: calc(var(--wp-admin--admin-bar--height, 0px) + 60px);
 	}
 }
 

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -7,7 +7,7 @@
 	padding-top: 16px;
 	padding-bottom: 16px;
 
-	top: var(--wp-global-header-offset, 0);
+	top: var(--wp-admin--admin-bar--height, 0);
 }
 
 .wp-block-wporg-local-navigation-bar {

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -4,10 +4,15 @@
 
 	padding-right: var(--wp--preset--spacing--edge-space);
 	padding-left: var(--wp--preset--spacing--edge-space);
-	padding-top: 17px;
+	padding-top: 18px;
 	padding-bottom: 18px;
 
 	top: var(--wp-admin--admin-bar--height, 0);
+
+	/* If a sticky element is next, it needs to account for the nav bar offset. */
+	& + :where(.wp-block-group.is-position-sticky) {
+		top: calc(var(--wp-admin--admin-bar--height, 0) + 60px);
+	}
 }
 
 .wp-block-wporg-local-navigation-bar {
@@ -69,13 +74,6 @@
 			mask-size: cover;
 			mask-position: bottom right;
 			background-color: inherit;
-		}
-	}
-
-	/* Make sure breadcrumbs inherit the set text color */
-	& .wp-block-wporg-site-breadcrumbs {
-		& a {
-			color: inherit;
 		}
 	}
 

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -80,6 +80,10 @@
 			mask-position: bottom right;
 			background-color: inherit;
 		}
+
+		&.is-sticking {
+			padding-bottom: 8px !important;
+		}
 	}
 
 	/* Navigation. */

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -4,8 +4,8 @@
 
 	padding-right: var(--wp--preset--spacing--edge-space);
 	padding-left: var(--wp--preset--spacing--edge-space);
-	padding-top: 16px;
-	padding-bottom: 16px;
+	padding-top: 17px;
+	padding-bottom: 18px;
 
 	top: var(--wp-admin--admin-bar--height, 0);
 }

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -11,8 +11,32 @@
 }
 
 .wp-block-wporg-local-navigation-bar {
-	& > *:nth-child(3) {
-		flex-basis: 100%;
+
+	@media (min-width: 890px) {
+		& .global-header__wporg-logo-mark {
+			position: absolute;
+			top: -5px;
+			left: 0;
+			opacity: 0;
+			padding: 16px var(--wp--style--block-gap);
+			transition: all 0.2s ease-in-out;
+			visibility: hidden;
+
+			& a {
+				display: block;
+				color: inherit;
+			}
+
+			& svg {
+				fill: currentcolor;
+			}
+		}
+
+		&.is-sticking .global-header__wporg-logo-mark {
+			opacity: 1;
+			top: 0;
+			visibility: visible;
+		}
 	}
 
 	/* Reset the sticky position on small screens. */
@@ -22,6 +46,10 @@
 
 		/* Matches the padding of the global header button. */
 		padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width)) !important;
+
+		& .global-header__wporg-logo-mark {
+			display: none;
+		}
 	}
 
 	&.is-style-brush-stroke {

--- a/mu-plugins/blocks/local-navigation-bar/render.php
+++ b/mu-plugins/blocks/local-navigation-bar/render.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Render the block content.
+ */
+
+$wrapper_attributes = get_block_wrapper_attributes();
+?>
+<div
+	<?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>
+>
+	<figure class="wp-block-image global-header__wporg-logo-mark">
+		<a href="<?php echo esc_url( get_home_url() ); ?>">
+			<?php require dirname( __DIR__ ) . '/global-header-footer/images/w-mark.svg'; ?>
+		</a>
+	</figure>
+	<?php echo $content // phpcs:ignore ?>
+</div>

--- a/mu-plugins/blocks/local-navigation-bar/render.php
+++ b/mu-plugins/blocks/local-navigation-bar/render.php
@@ -4,12 +4,9 @@
  */
 
 use function WordPressdotorg\MU_Plugins\Global_Header_Footer\get_home_url;
-
-$wrapper_attributes = get_block_wrapper_attributes();
 ?>
-<div
-	<?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>
->
+
+<div <?php echo get_block_wrapper_attributes(); // phpcs:ignore ?> >
 	<figure class="wp-block-image global-header__wporg-logo-mark">
 		<a href="<?php echo esc_url( get_home_url() ); ?>">
 			<?php require dirname( __DIR__ ) . '/global-header-footer/images/w-mark.svg'; ?>

--- a/mu-plugins/blocks/local-navigation-bar/render.php
+++ b/mu-plugins/blocks/local-navigation-bar/render.php
@@ -3,6 +3,8 @@
  * Render the block content.
  */
 
+use function WordPressdotorg\MU_Plugins\Global_Header_Footer\get_home_url;
+
 $wrapper_attributes = get_block_wrapper_attributes();
 ?>
 <div

--- a/mu-plugins/blocks/local-navigation-bar/src/block.json
+++ b/mu-plugins/blocks/local-navigation-bar/src/block.json
@@ -82,6 +82,8 @@
 		"__experimentalLayout": true
 	},
 	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
 	"editorStyle": "file:./editor-style.css",
-	"style": "file:./style.css"
+	"style": "file:./style.css",
+	"render": "file:../render.php"
 }

--- a/mu-plugins/blocks/local-navigation-bar/src/view.js
+++ b/mu-plugins/blocks/local-navigation-bar/src/view.js
@@ -1,4 +1,4 @@
-function debounce( fn ) {
+function debounce( callback ) {
 	// This holds the requestAnimationFrame reference, so we can cancel it if we wish
 	let frame;
 
@@ -6,13 +6,13 @@ function debounce( fn ) {
 	return ( ...params ) => {
 		// If the frame variable has been defined, clear it now, and queue for next frame
 		if ( frame ) {
-			cancelAnimationFrame( frame );
+			window.cancelAnimationFrame( frame );
 		}
 
 		// Queue our function call for the next frame
-		frame = requestAnimationFrame( () => {
+		frame = window.requestAnimationFrame( () => {
 			// Call our function and pass any params we received
-			fn( ...params );
+			callback( ...params );
 		} );
 	};
 }

--- a/mu-plugins/blocks/local-navigation-bar/src/view.js
+++ b/mu-plugins/blocks/local-navigation-bar/src/view.js
@@ -19,10 +19,15 @@ function debounce( callback ) {
 
 function init() {
 	const container = document.querySelector( '.wp-block-wporg-local-navigation-bar' );
+	// The div will hit the "sticky" position when the top offset is 0, or if
+	// the admin bar exists, 32px (height of admin bar). The bar unstickies
+	// on smaller screens, so the admin bar height change does not affect this.
+	const topOffset = document.body.classList.contains( 'admin-bar' ) ? 32 : 0;
 	if ( container ) {
 		const onScroll = () => {
 			const { top } = container.getBoundingClientRect();
-			if ( top <= 32 ) {
+
+			if ( top <= topOffset ) {
 				container.classList.add( 'is-sticking' );
 			} else {
 				container.classList.remove( 'is-sticking' );

--- a/mu-plugins/blocks/local-navigation-bar/src/view.js
+++ b/mu-plugins/blocks/local-navigation-bar/src/view.js
@@ -1,0 +1,36 @@
+function debounce( fn ) {
+	// This holds the requestAnimationFrame reference, so we can cancel it if we wish
+	let frame;
+
+	// The debounce function returns a new function that can receive a variable number of arguments
+	return ( ...params ) => {
+		// If the frame variable has been defined, clear it now, and queue for next frame
+		if ( frame ) {
+			cancelAnimationFrame( frame );
+		}
+
+		// Queue our function call for the next frame
+		frame = requestAnimationFrame( () => {
+			// Call our function and pass any params we received
+			fn( ...params );
+		} );
+	};
+}
+
+function init() {
+	const container = document.querySelector( '.wp-block-wporg-local-navigation-bar' );
+	if ( container ) {
+		const onScroll = () => {
+			const { top } = container.getBoundingClientRect();
+			if ( top <= 32 ) {
+				container.classList.add( 'is-sticking' );
+			} else {
+				container.classList.remove( 'is-sticking' );
+			}
+		};
+
+		document.addEventListener( 'scroll', debounce( onScroll ), { passive: true } );
+		onScroll();
+	}
+}
+window.addEventListener( 'load', init );

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -25,8 +25,4 @@
 			}
 		}
 	}
-
-	& .is-current-page {
-		color: var(--wp--preset--color--charcoal-1);
-	}
 }


### PR DESCRIPTION
See #465, specifically the conversation after [this comment](https://github.com/WordPress/wporg-mu-plugins/issues/465#issuecomment-1743859797). @fcoveram proposed an update to the header where the header does not stick on scroll, but the local nav bar does. There was some discussion and feedback about which bars should stick when. I took @jasmussen's double "I'm into it" comments to mean this is approved for building, and polished up my prototype code.

Since this is a change that at least visually changes the "functionality" of the header, it would need to be announced. I think it could be bundled into the [upcoming header & footer changes](https://github.com/WordPress/wporg-mu-plugins/milestone/6) (cc @ndiego). But we should be sure this is the correct approach, changing it and rolling it back would likely generate negative community feedback.

**Screencasts**

Showcase - this is the ideal case right now. For the breadcrumbs to be sticky, they need to have `"position":{"type":"sticky"}`, which has been added with https://github.com/WordPress/wporg-showcase-2022/pull/218/

https://github.com/WordPress/wporg-mu-plugins/assets/541093/030262d0-bc8f-4d16-b91a-8f64ca0d91a1

Next up I click through a few other pages: Home, Download, a download subpage, About, an about subpage, and Documentation — the last one highlights that the other redesign sites will need some adjustments. The same thing happens on the Developers staging site, cc @adamwoodnz 

https://github.com/WordPress/wporg-mu-plugins/assets/541093/9fc64b0d-8e71-44cb-93ff-d618cd3b6903

Finally, clicking through a classic theme. This doesn't have a local nav bar, so there are no sticky bars here.

https://github.com/WordPress/wporg-mu-plugins/assets/541093/a8d4aa04-ee15-4ab2-b88e-2eaaeb973919

**To test**

This is easiest to test on a sandbox, but if you set it up locally just viewing any site should let you test it.

Try at different screen sizes, various pages, etc.