### PR TITLE
Query filters: Add taxonomy to apply button of query filter block

### DIFF
--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -62,7 +62,7 @@ if ( $selected_count && $has_multiple ) {
 		/* translators: 1: the count of currently selected filters. 2: taxonomy being filtered */
 		__( 'Apply (%1$s) %2$s', 'wporg' ),
 		$selected_count,
-		strtolower( explode( ' ', wp_kses_post( $settings['label'] ) )[0] )
+		strtolower( preg_replace( '/\s\d+$/', '', strip_tags( wp_kses_post( $settings['label'] ) ) ) )
 	);
 } else {
 	$apply_label = __( 'Apply', 'wporg' );

--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -58,11 +58,24 @@ $button_classes = array_keys(
 );
 
 if ( $selected_count && $has_multiple ) {
+	$special_singular_mappings = array(
+		'categories' => 'category',
+	);
+
+	// Possible Input: 'popular tags <span>1</span>'
+	// Expected Output: 'popular tags'
+	$label = strtolower( preg_replace( '/\s\d+$/', '', strip_tags( $settings['label'] ) ) );
+	$label_form = 1 === $selected_count
+		? ( isset( $special_singular_mappings[ $label ] )
+			? $special_singular_mappings[ $label ]
+			: substr( $label, 0, -1 ) )
+		: $label;
+
 	$apply_label = sprintf(
 		/* translators: 1: the count of currently selected filters. 2: taxonomy being filtered */
 		__( 'Apply %1$s %2$s', 'wporg' ),
 		$selected_count,
-		strtolower( preg_replace( '/\s\d+$/', '', strip_tags( wp_kses_post( $settings['label'] ) ) ) )
+		$label_form
 	);
 } else {
 	$apply_label = __( 'Apply', 'wporg' );

--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -59,7 +59,7 @@ $button_classes = array_keys(
 
 if ( $selected_count && $has_multiple ) {
 	$apply_label = sprintf(
-		/* translators: 1: the count of currently selected filters. 2: post taxonomy */
+		/* translators: 1: the count of currently selected filters. 2: taxonomy being filtered */
 		__( 'Apply (%1$s) %2$s', 'wporg' ),
 		$selected_count,
 		strtolower( explode( ' ', wp_kses_post( $settings['label'] ) )[0] )

--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -58,8 +58,12 @@ $button_classes = array_keys(
 );
 
 if ( $selected_count && $has_multiple ) {
-	/* translators: %s is count of currently selected filters. */
-	$apply_label = sprintf( __( 'Apply (%s)', 'wporg' ), $selected_count );
+	$apply_label = sprintf(
+		/* translators: 1: the count of currently selected filters. 2: post taxonomy */
+		__( 'Apply (%1$s) %2$s', 'wporg' ),
+		$selected_count,
+		strtolower( explode( ' ', wp_kses_post( $settings['label'] ) )[0] )
+	);
 } else {
 	$apply_label = __( 'Apply', 'wporg' );
 }

--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -60,7 +60,7 @@ $button_classes = array_keys(
 if ( $selected_count && $has_multiple ) {
 	$apply_label = sprintf(
 		/* translators: 1: the count of currently selected filters. 2: taxonomy being filtered */
-		__( 'Apply (%1$s) %2$s', 'wporg' ),
+		__( 'Apply %1$s %2$s', 'wporg' ),
 		$selected_count,
 		strtolower( preg_replace( '/\s\d+$/', '', strip_tags( wp_kses_post( $settings['label'] ) ) ) )
 	);

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -38,7 +38,7 @@ function updateButtons( store, count ) {
 	// Only update the apply button if multiple selections are allowed.
 	if ( context.wporg.queryFilter.hasMultiple ) {
 		if ( count ) {
-			/* translators: 1: the count of currently selected filters. 2: post taxonomy */
+			/* translators: 1: the count of currently selected filters. 2: taxonomy being filtered */
 			applyButton.value = sprintf( __( 'Apply (%1$s) %2$s', 'wporg' ), count, taxonomy );
 		} else {
 			applyButton.value = __( 'Apply', 'wporg' );

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -33,12 +33,13 @@ function updateButtons( store, count ) {
 
 	const applyButton = context.wporg.queryFilter.form.querySelector( 'input[type="submit"]' );
 	const clearButton = context.wporg.queryFilter.form.querySelector( '.wporg-query-filter__modal-action-clear' );
+	const taxonomy = context.wporg.queryFilter.toggleButton.textContent.split( ' ' )[ 0 ].toLowerCase();
 
 	// Only update the apply button if multiple selections are allowed.
 	if ( context.wporg.queryFilter.hasMultiple ) {
 		if ( count ) {
-			/* translators: %s is count of currently selected filters. */
-			applyButton.value = sprintf( __( 'Apply (%s)', 'wporg' ), count );
+			/* translators: 1: the count of currently selected filters. 2: post taxonomy */
+			applyButton.value = sprintf( __( 'Apply (%1$s) %2$s', 'wporg' ), count, taxonomy );
 		} else {
 			applyButton.value = __( 'Apply', 'wporg' );
 		}

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -33,7 +33,7 @@ function updateButtons( store, count ) {
 
 	const applyButton = context.wporg.queryFilter.form.querySelector( 'input[type="submit"]' );
 	const clearButton = context.wporg.queryFilter.form.querySelector( '.wporg-query-filter__modal-action-clear' );
-	const taxonomy = context.wporg.queryFilter.toggleButton.textContent.split( ' ' )[ 0 ].toLowerCase();
+	const taxonomy = context.wporg.queryFilter.toggleButton.textContent.replace( /\s\d+$/, '' ).toLowerCase();
 
 	// Only update the apply button if multiple selections are allowed.
 	if ( context.wporg.queryFilter.hasMultiple ) {

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -39,7 +39,7 @@ function updateButtons( store, count ) {
 	if ( context.wporg.queryFilter.hasMultiple ) {
 		if ( count ) {
 			/* translators: 1: the count of currently selected filters. 2: taxonomy being filtered */
-			applyButton.value = sprintf( __( 'Apply (%1$s) %2$s', 'wporg' ), count, taxonomy );
+			applyButton.value = sprintf( __( 'Apply %1$s %2$s', 'wporg' ), count, taxonomy );
 		} else {
 			applyButton.value = __( 'Apply', 'wporg' );
 		}

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -25,6 +25,15 @@ function closeDropdown( store ) {
 	document.documentElement.classList.remove( 'is-query-filter-open' );
 }
 
+function getTaxonomyForm( count, pluralTaxonomy ) {
+	const specialSingularMappings = {
+		categories: 'category',
+	};
+	return count === 1
+		? specialSingularMappings[ pluralTaxonomy ] || pluralTaxonomy.slice( 0, -1 )
+		: pluralTaxonomy;
+}
+
 function updateButtons( store, count ) {
 	const { context } = store;
 	if ( ! context.wporg.queryFilter.form ) {
@@ -38,8 +47,12 @@ function updateButtons( store, count ) {
 	// Only update the apply button if multiple selections are allowed.
 	if ( context.wporg.queryFilter.hasMultiple ) {
 		if ( count ) {
-			/* translators: 1: the count of currently selected filters. 2: taxonomy being filtered */
-			applyButton.value = sprintf( __( 'Apply %1$s %2$s', 'wporg' ), count, taxonomy );
+			applyButton.value = sprintf(
+				/* translators: 1: the count of currently selected filters. 2: taxonomy being filtered */
+				__( 'Apply %1$s %2$s', 'wporg' ),
+				count,
+				getTaxonomyForm( count, taxonomy )
+			);
 		} else {
 			applyButton.value = __( 'Apply', 'wporg' );
 		}


### PR DESCRIPTION
Closes https://github.com/WordPress/wporg-showcase-2022/issues/225

This PR adds taxonomy to query-filter block apply button as per the discussion [here](https://github.com/WordPress/wporg-showcase-2022/issues/225#issuecomment-1749041605). 

<img width="322" alt="Screen Shot 2023-10-09 at 3 59 21 AM" src="https://github.com/WordPress/wporg-mu-plugins/assets/18050944/d5b3696f-f752-46be-ae83-5cc4dd8388c7">
