### PR TITLE
Google Map:  Disable infoWindow focus so it remains on search input

### DIFF
--- a/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
+++ b/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
@@ -132,7 +132,8 @@ export function clusterMarkers( map, maps, markers, rawIcon ) {
  * @param {google.maps.Marker[]} markers
  */
 export function setVisibleMarkers( clusterer, markers ) {
-	clusterer.clearMarkers();
+	// Prevent re-drawing the map when clearing, because we'll redraw it when adding markers.
+	clusterer.clearMarkers( true );
 	clusterer.addMarkers( markers );
 }
 

--- a/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
+++ b/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
@@ -90,7 +90,11 @@ export function assignMarkerReferences( map, maps, wpEvents, rawIcon ) {
  */
 function openInfoWindow( infoWindow, map, markerObject, rawMarker ) {
 	infoWindow.setContent( getElementHTML( <MarkerContent { ...rawMarker } /> ) );
-	infoWindow.open( map, markerObject );
+	infoWindow.open( {
+		anchor: markerObject,
+		map: map,
+		shouldFocus: false, // Don't steal focus from the search <input>.
+	} );
 }
 
 /**


### PR DESCRIPTION
Fixes #434 

This sets `shouldFocus: false` when opening the `infoWindow`s, so that the focus isn't stolen from the search `<input>`