### PR TITLE
Query filters: Fix scrollbar overlaying dropdown menu

### DIFF
--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -31,9 +31,9 @@ function toggleOverflowX() {
 	if ( filtersElement ) {
 		const currentOverflowX = window.getComputedStyle( filtersElement ).overflowX;
 
-		if ( currentOverflowX === 'hidden' ) {
+		if ( 'hidden' === currentOverflowX ) {
 			filtersElement.style.overflowX = 'scroll';
-		} else if ( currentOverflowX === 'scroll' ) {
+		} else if ( 'scroll' === currentOverflowX || 'auto' === currentOverflowX ) {
 			filtersElement.style.overflowX = 'hidden';
 		}
 	}

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -15,6 +15,30 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
+/**
+ * Toggles the overflow-x style of the query filter between 'hidden' and 'scroll'.
+ *
+ * In certain themes (e.g., showcase), an 'overflow-x: scroll' is added on mobile screens to always display
+ * the horizontal scrollbar, indicating to users that there's more content to the right.
+ * However, this persistent display feature causes the dropdown menu to be overlaid by the scrollbar
+ * when opened (See issue https://github.com/WordPress/wporg-mu-plugins/issues/467#issuecomment-1754349676).
+ * This function serves to address that issue.
+ *
+ */
+function toggleOverflowX() {
+	const filtersElement = document.querySelector( '.wporg-query-filters' );
+
+	if ( filtersElement ) {
+		const currentOverflowX = window.getComputedStyle( filtersElement ).overflowX;
+
+		if ( currentOverflowX === 'hidden' ) {
+			filtersElement.style.overflowX = 'scroll';
+		} else if ( currentOverflowX === 'scroll' ) {
+			filtersElement.style.overflowX = 'hidden';
+		}
+	}
+}
+
 function closeDropdown( store ) {
 	const { context } = store;
 	context.wporg.queryFilter.isOpen = false;
@@ -23,6 +47,8 @@ function closeDropdown( store ) {
 	const count = context.wporg.queryFilter.form?.querySelectorAll( 'input:checked' ).length;
 	updateButtons( store, count );
 	document.documentElement.classList.remove( 'is-query-filter-open' );
+
+	toggleOverflowX();
 }
 
 function updateButtons( store, count ) {
@@ -58,6 +84,7 @@ wpStore( {
 					} else {
 						context.wporg.queryFilter.isOpen = true;
 						document.documentElement.classList.add( 'is-query-filter-open' );
+						toggleOverflowX();
 					}
 				},
 				handleKeydown: ( store ) => {


### PR DESCRIPTION
Fixes #467 (To be specific, https://github.com/WordPress/wporg-mu-plugins/issues/467#issuecomment-1754349676)

Related: https://github.com/WordPress/wporg-showcase-2022/pull/248

This PR adds a toggle function for `overflow-x`. When a theme assigns `overflow-x: scroll` to the query filter, change it to `overflow-x: hidden` when the dropdown menu is opened. And if it's closed, change it back to `scroll`.

Approach here was employed due to the overlapping issue can't be easily resolved just by adjusting the `z-index` or `position` of the query filter and the dropdown menu for a few potential reasons:
1. Query Filter is the parent of Dropdown Menu.
2. Dropdown menu uses position: fixed.
3. Behavior of the Scrollbar is determined by browser or OS.

#### Screenshots
| Before | After |
| ------ | -----|
| ![before](https://github.com/WordPress/wporg-mu-plugins/assets/18050944/565a7dec-a3d9-4b42-993a-e6431561cf00) | ![after](https://github.com/WordPress/wporg-mu-plugins/assets/18050944/ee6aa407-6164-43d9-8196-3c6ad9a58c79) |


