### PR TITLE
Combine markers in the same location for better UX

### DIFF
--- a/mu-plugins/blocks/google-map/README.md
+++ b/mu-plugins/blocks/google-map/README.md
@@ -9,7 +9,7 @@ This doesn't currently utilize all the abilities of the `google-map-react` lib, 
 
 ## Usage
 
-Place something like this in a pattern:
+Place something like the following in a block or pattern. If you're pulling events from a database, a block is better because Gutenberg loads all patterns at `init` on all pages, regardless of whether or not they're used on that page.
 
 ```php
 <?php

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -17,7 +17,7 @@ import {
 	assignMarkerReferences,
 	clusterMarkers,
 	panToCenter,
-	setVisibleMarkers,
+	updateMapMarkers,
 } from '../utilities/google-maps-api';
 
 /**
@@ -82,7 +82,7 @@ export default function Map( { apiKey, markers, icon } ) {
 
 		const markerObjects = markers.map( ( marker ) => marker.markerRef );
 
-		setVisibleMarkers( clusterer, markerObjects, googleMap );
+		updateMapMarkers( clusterer, markerObjects, googleMap );
 		panToCenter( markerObjects, googleMap, googleMapsApi );
 	}, [ clusterer, markers ] );
 

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -35,9 +35,9 @@ import {
  */
 export default function Map( { apiKey, markers: rawMarkers, icon } ) {
 	const [ loaded, setLoaded ] = useState( false );
-	const [ clusterer, setClusterer ] = useState( null );
-	const [ googleMap, setGoogleMap ] = useState( null );
-	const [ googleMapsApi, setGoogleMapsApi ] = useState( null );
+	const clusterer = useRef( null );
+	const googleMap = useRef( null );
+	const googleMapsApi = useRef( null );
 	const infoWindow = useRef( null );
 	let combinedMarkers = [];
 
@@ -58,8 +58,8 @@ export default function Map( { apiKey, markers: rawMarkers, icon } ) {
 			throw 'Google Maps API is not loaded.';
 		}
 
-		setGoogleMap( map );
-		setGoogleMapsApi( maps );
+		googleMap.current = map;
+		googleMapsApi.current = maps;
 
 		infoWindow.current = new maps.InfoWindow( {
 			pixelOffset: new maps.Size( -icon.markerIconAnchorXOffset, 0 ),
@@ -68,13 +68,11 @@ export default function Map( { apiKey, markers: rawMarkers, icon } ) {
 		combinedMarkers = combineDuplicateLocations( rawMarkers );
 		combinedMarkers = assignMarkerReferences( map, maps, infoWindow.current, combinedMarkers, icon );
 
-		setClusterer(
-			clusterMarkers(
-				map,
-				maps,
-				combinedMarkers.map( ( marker ) => marker.markerRef ),
-				icon
-			)
+		clusterer.current = clusterMarkers(
+			map,
+			maps,
+			combinedMarkers.map( ( marker ) => marker.markerRef ),
+			icon
 		);
 
 		setLoaded( true );
@@ -84,7 +82,7 @@ export default function Map( { apiKey, markers: rawMarkers, icon } ) {
 	 * Update the map whenever the supplied markers change.
 	 */
 	useEffect( () => {
-		if ( ! clusterer ) {
+		if ( ! clusterer.current ) {
 			return;
 		}
 
@@ -92,8 +90,8 @@ export default function Map( { apiKey, markers: rawMarkers, icon } ) {
 
 		combinedMarkers = combineDuplicateLocations( rawMarkers );
 		combinedMarkers = assignMarkerReferences(
-			googleMap,
-			googleMapsApi,
+			googleMap.current,
+			googleMapsApi.current,
 			infoWindow.current,
 			combinedMarkers,
 			icon
@@ -101,9 +99,9 @@ export default function Map( { apiKey, markers: rawMarkers, icon } ) {
 
 		const markerObjects = combinedMarkers.map( ( marker ) => marker.markerRef );
 
-		updateMapMarkers( clusterer, markerObjects, googleMap );
-		panToCenter( markerObjects, googleMap, googleMapsApi );
-	}, [ clusterer, rawMarkers ] );
+		updateMapMarkers( clusterer.current, markerObjects, googleMap.current );
+		panToCenter( markerObjects, googleMap.current, googleMapsApi.current );
+	}, [ rawMarkers ] );
 
 	return (
 		<div className="wporg-google-map__container">

--- a/mu-plugins/blocks/google-map/src/components/marker-content.js
+++ b/mu-plugins/blocks/google-map/src/components/marker-content.js
@@ -21,6 +21,9 @@ export default function MarkerContent( props ) {
 		case 'meetup':
 			return <MeetupMarker { ...props } />;
 
+		case 'combined':
+			return <CombinedMarker { ...props } />;
+
 		default:
 			throw 'Component not defined for marker type: ' + type;
 	}
@@ -79,6 +82,47 @@ function MeetupMarker( { id, title, url, meetup, timestamp, location } ) {
 			<p className="wporg-map-marker__location">{ formatLocation( location ) }</p>
 
 			<p className="wporg-map-marker__date-time">{ getEventDateTime( timestamp ) }</p>
+		</div>
+	);
+}
+
+/**
+ * Render a marker that combines multiple events.
+ *
+ * This currently assumes that all of the events are from the same meetup group, but could be made more flexible
+ * in the future if needed.
+ *
+ * @param {Object} props
+ * @param {Array}  props.events
+ */
+function CombinedMarker( { events } ) {
+	const combinedId = events.map( ( { id } ) => id ).join( '-' );
+	let combinedTitle;
+
+	if ( 'online' !== events[ 0 ].location.toLowerCase() ) {
+		combinedTitle = events[ 0 ].location;
+	} else {
+		combinedTitle = events[ 0 ].meetup && events[ 0 ].meetup.length ? events[ 0 ].meetup : events[ 0 ].title;
+	}
+
+	return (
+		<div id={ 'wporg-map-marker__id-' + combinedId } className="wporg-map-marker">
+			<h3 className="wporg-map-marker__title">{ combinedTitle }</h3>
+			<ul>
+				{ events.map( ( { id, url, title, location, timestamp } ) => {
+					return (
+						<li key={ id }>
+							<p className="wporg-map-marker__url">
+								<a href={ url }>{ title }</a>
+							</p>
+
+							<p className="wporg-map-marker__location">{ formatLocation( location ) }</p>
+
+							<p className="wporg-map-marker__date-time">{ getEventDateTime( timestamp ) }</p>
+						</li>
+					);
+				} ) }
+			</ul>
 		</div>
 	);
 }

--- a/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
+++ b/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
@@ -130,12 +130,12 @@ export function clusterMarkers( map, maps, markers, rawIcon ) {
 }
 
 /**
- * Filter the markers on a map to the given ones.
+ * Clear the map and add the given markers.
  *
  * @param {MarkerClusterer}      clusterer
  * @param {google.maps.Marker[]} markers
  */
-export function setVisibleMarkers( clusterer, markers ) {
+export function updateMapMarkers( clusterer, markers ) {
 	// Prevent re-drawing the map when clearing, because we'll redraw it when adding markers.
 	clusterer.clearMarkers( true );
 	clusterer.addMarkers( markers );


### PR DESCRIPTION
Fixes #431 

If we did nothing, then the markers would overlap and only 1 would be accessible. Spreading the markers out is a common solution, but then the user would have to click on each one to know which ones are relevant to them. In many cases, it's a recurring event, so they really only need to know about the next one.

This way the user only has to click once, and they can see all of the info they need.

See https://ux.stackexchange.com/a/112281/13828