### PR TITLE
Make top margin of sidebar container configurable via theme.json

### DIFF
--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -21,7 +21,7 @@
 		/* Right offset should be "edge spacing" at minimum, otherwise calculate it to be centered. */
 		right: max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2));
 		width: var(--local--block-end-sidebar--width);
-		margin-top: var(--wp--preset--spacing--edge-space) !important;
+		margin-top: var(--wp--custom--wporg-sidebar-container--spacing--margin--top) !important;
 
 		&.is-fixed-sidebar {
 			position: fixed;
@@ -43,4 +43,9 @@
 	#wp--skip-link--target {
 		scroll-margin-top: var(--wp-local-header-offset, 0);
 	}
+}
+
+/* Set up the custom properties. These can be overridden by settings in theme.json. */
+:where(body) {
+	--wp--custom--wporg-sidebar-container--spacing--margin--top: var(--wp--preset--spacing--edge-space);
 }

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -36,7 +36,7 @@ function onScroll() {
 	const mainEl = document.getElementById( 'wp--skip-link--target' );
 	const footerStart = mainEl.offsetTop + mainEl.offsetHeight;
 
-	const gap = parseInt( window.getComputedStyle( sidebarContainer ).marginTop, 10 );
+	const gap = getCustomPropValue( '--wp--custom--wporg-sidebar-container--spacing--margin--top' );
 	const viewportYOffset = window
 		.getComputedStyle( document.documentElement )
 		.getPropertyValue( 'margin-top' )
@@ -71,7 +71,7 @@ function onScroll() {
 
 function isSidebarWithinViewport( container ) {
 	// Margin offset from the top of the sidebar.
-	const gap = parseInt( window.getComputedStyle( container ).marginTop, 10 );
+	const gap = getCustomPropValue( '--wp--custom--wporg-sidebar-container--spacing--margin--top' );
 	// Usable viewport height.
 	const viewHeight = window.innerHeight - FIXED_HEADER_HEIGHT;
 	// Get the height of the sidebar, plus the top margin and 50px for the

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -36,7 +36,7 @@ function onScroll() {
 	const mainEl = document.getElementById( 'wp--skip-link--target' );
 	const footerStart = mainEl.offsetTop + mainEl.offsetHeight;
 
-	const gap = getCustomPropValue( '--wp--preset--spacing--edge-space' );
+	const gap = parseInt( window.getComputedStyle( sidebarContainer ).marginTop, 10 );
 	const viewportYOffset = window
 		.getComputedStyle( document.documentElement )
 		.getPropertyValue( 'margin-top' )
@@ -71,7 +71,7 @@ function onScroll() {
 
 function isSidebarWithinViewport( container ) {
 	// Margin offset from the top of the sidebar.
-	const gap = getCustomPropValue( '--wp--preset--spacing--edge-space' );
+	const gap = parseInt( window.getComputedStyle( container ).marginTop, 10 );
 	// Usable viewport height.
 	const viewHeight = window.innerHeight - FIXED_HEADER_HEIGHT;
 	// Get the height of the sidebar, plus the top margin and 50px for the


### PR DESCRIPTION
Closes #483 

Makes the top margin of the sidebar container configurable, so that it can be changed for the redesigned Developer site.

Keeps the existing value as the default so that the Documentation site isn't affected.

### Testing

Easiest to use the [Developer PR](https://github.com/WordPress/wporg-developer/pull/299), see testing instructions there.