### PR TITLE
Use wp_date instead of DateTime format to allow localization of latest news dates

### DIFF
--- a/mu-plugins/blocks/latest-news/latest-news.php
+++ b/mu-plugins/blocks/latest-news/latest-news.php
@@ -86,7 +86,7 @@ function render_block( $attributes ) {
 		$date_element = sprintf(
 			'<time datetime="%1$s">%2$s</time>',
 			$date->format( 'c' ),
-			$date->format( 'F j, Y' )
+			wp_date( get_option( 'date_format' ), $date->getTimestamp(), null )
 		);
 
 		$list_items .= sprintf(


### PR DESCRIPTION
Changes behaviour to use wp_date instead of DateTime->format() in the "Latest news"-block. This allows the string to be localized on Rosetta/lang.wordpress.org sites.

Closes #493