### PR TITLE
Event Filters: Add docs for using in raw post content.

### DIFF
--- a/mu-plugins/blocks/google-map-event-filters/README.md
+++ b/mu-plugins/blocks/google-map-event-filters/README.md
@@ -29,5 +29,11 @@ It uses the `wporg/google-map` block to display a searchable list and/or map of 
 	<!-- wp:wporg/google-map-event-filters <?php echo wp_json_encode( $filter_options ); ?> /-->
 	```
 
+	Alternatively, you could take that JSON and manually put it in the post source like this:
+
+	```html
+	<!-- wp:wporg/google-map-event-filters {"filterSlug":"wp20","startDate":"April 21, 2023","endDate":"May 30, 2023","googleMapBlockAttributes":{"id":"wp20","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY"}} /-->
+	```
+
 1. View the page where the block is used. That will create the cron job that updates the data automatically in the future.
 1. Run `wp cron event run prime_event_filters` to test the filtering. Look at each title, and add any false positives to `$false_positives` in `filter_potential_events()`. If any events that should be included were ignored, add a keyword from the title to `$keywords`. Run the command after those changes and make sure it's correct now.

--- a/mu-plugins/blocks/google-map-event-filters/src/index.js
+++ b/mu-plugins/blocks/google-map-event-filters/src/index.js
@@ -14,7 +14,7 @@ function Edit() {
 	return (
 		<Placeholder
 			instructions={ __(
-				'This is a placeholder for the editor. Data is supplied to this block via the pattern that includes it.',
+				'This is a placeholder for the editor until a back-end UI is built. See the README for instructions on supplying data.',
 				'wporg'
 			) }
 			label={ __( 'Google Map Event Filters', 'wporg' ) }

--- a/mu-plugins/blocks/google-map/src/components/main.js
+++ b/mu-plugins/blocks/google-map/src/components/main.js
@@ -67,8 +67,8 @@ export default function Main( {
 			behavior: 'smooth',
 		} );
 
-		// This is passing the value directly, instead of using, state because the throttled function only has
-		// access to the versionof state that existed at the time the function was created. Updating the
+		// This is passing the value directly, instead of using state, because the throttled function only has
+		// access to the version of state that existed at the time the function was created. Updating the
 		// function with something like `useCallback` is more complicated than you'd think.
 		throttledRedrawMap( event.target.value );
 	}, [] );


### PR DESCRIPTION
This gives instructions for setting the block up without adding a pattern to the theme.