### PR TITLE
Add map filter for all upcoming events

### DIFF
--- a/mu-plugins/blocks/google-map-event-filters/README.md
+++ b/mu-plugins/blocks/google-map-event-filters/README.md
@@ -32,6 +32,8 @@ It uses the `wporg/google-map` block to display a searchable list and/or map of 
 	Alternatively, you could take that JSON and manually put it in the post source like this:
 
 	```html
+	<!-- wp:wporg/google-map-event-filters {"filterSlug":"sotw","startDate":"December 10, 2023","endDate":"January 12, 2024","googleMapBlockAttributes":{"id":"sotw-2023","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY"}} /-->
+
 	<!-- wp:wporg/google-map-event-filters {"filterSlug":"wp20","startDate":"April 21, 2023","endDate":"May 30, 2023","googleMapBlockAttributes":{"id":"wp20","apiKey":"WORDCAMP_DEV_GOOGLE_MAPS_API_KEY"}} /-->
 	```
 

--- a/mu-plugins/blocks/google-map-event-filters/google-map-event-filters.php
+++ b/mu-plugins/blocks/google-map-event-filters/google-map-event-filters.php
@@ -108,6 +108,15 @@ function get_events_between_dates( int $start_timestamp, int $end_timestamp ) : 
 		$events = get_latin1_results_with_prepared_query( $query );
 	}
 
+	$events = prepare_events( $events );
+
+	return $events;
+}
+
+/**
+ * Clean up events
+ */
+function prepare_events( array $events ): array {
 	foreach ( $events as $event ) {
 		// `capital_P_dangit()` won't work here because the current filter isn't `the_title` and there isn't a safelisted prefix before `$text`.
 		$event->title = str_replace( 'Wordpress', 'WordPress', $event->title );

--- a/mu-plugins/blocks/google-map-event-filters/google-map-event-filters.php
+++ b/mu-plugins/blocks/google-map-event-filters/google-map-event-filters.php
@@ -65,7 +65,7 @@ function render( array $attributes, string $content, WP_Block $block ): string {
  */
 function get_events( string $filter_slug, int $start_timestamp, int $end_timestamp, bool $force_refresh = false ) : array {
 	$events        = array();
-	$cache_key     = 'google-map-event-filters-' . md5( wp_json_encode( func_get_args() ) );
+	$cache_key     = 'google-map-event-filters-' . md5( wp_json_encode( $filter_slug . $start_timestamp . $end_timestamp ) );
 	$cached_events = get_transient( $cache_key );
 
 	if ( $cached_events && ! $force_refresh ) {


### PR DESCRIPTION
This is needed for the events.w.org landing page. 

Migrated from https://github.com/WordPress/wordcamp.org/tree/67578117690a82b1e35d4cc4e962be92c2c32532/public_html/wp-content/themes/wporg-events-2023/blocks/events-landing-page so that that theme can take advantage of this block rather than having to duplicate its features.