### PR TITLE
Map: Pass attributes to InnerBlock to fix rendering in admin 

### DIFF
--- a/mu-plugins/blocks/google-map-event-filters/src/index.js
+++ b/mu-plugins/blocks/google-map-event-filters/src/index.js
@@ -9,12 +9,12 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
  */
 import metadata from './block.json';
 
-function Edit() {
+function Edit( { attributes } ) {
 	return (
 		<div { ...useBlockProps() }>
 			<InnerBlocks
 				allowedBlocks={ [ 'wporg/google-map' ] }
-				template={ [ [ 'wporg/google-map' ] ] }
+				template={ [ [ 'wporg/google-map', attributes.googleMapBlockAttributes ] ] }
 				templateLock="all"
 			/>
 		</div>

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -74,6 +74,12 @@ export default function Map( { apiKey, markers: rawMarkers, icon } ) {
 			icon
 		);
 
+		panToCenter(
+			combinedMarkers.map( ( marker ) => marker.markerRef ),
+			googleMap.current,
+			googleMapsApi.current
+		);
+
 		setLoaded( true );
 	}, [] );
 


### PR DESCRIPTION
After #498  the `all-upcoming` filter would not render because the markers weren't being passed.