### PR TITLE
Global Header: Add top-level Events link to primary navigation and remove WordCamp and Meetups links

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -544,16 +544,6 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'WordCamp ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://central.wordcamp.org/',
-					'type'  => 'custom',
-				),
-				array(
-					'title' => esc_html_x( 'Meetups ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://www.meetup.com/pro/wordpress/',
-					'type'  => 'custom',
-				),
-				array(
 					'title' => esc_html_x( 'Job Board ↗︎', 'Menu item title', 'wporg' ),
 					'url'   => 'https://jobs.wordpress.net/',
 					'type'  => 'custom',

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -586,6 +586,11 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 			),
+			array(
+				'title' => esc_html_x( 'Events', 'Menu item title', 'wporg' ),
+				'url'   => 'https://events.wordpress.org/',
+				'type'  => 'custom',
+			),
 		),
 	);
 

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -524,6 +524,11 @@ function get_global_menu_items() {
 			),
 		),
 		array(
+			'title' => esc_html_x( 'Events', 'Menu item title', 'wporg' ),
+			'url'   => 'https://events.wordpress.org/',
+			'type'  => 'custom',
+		),
+		array(
 			'title'   => esc_html_x( 'Community', 'Menu item title', 'wporg' ),
 			'url'     => '#',
 			'type'    => 'custom',
@@ -575,11 +580,6 @@ function get_global_menu_items() {
 					'url'   => 'https://mercantile.wordpress.org/',
 					'type'  => 'custom',
 				),
-			),
-			array(
-				'title' => esc_html_x( 'Events', 'Menu item title', 'wporg' ),
-				'url'   => 'https://events.wordpress.org/',
-				'type'  => 'custom',
 			),
 		),
 	);


### PR DESCRIPTION
This PR adds Events ([events.wordpress.org](https://events.wordpress.org/)) as a top-level item in the header navigation on WordPress.org. It also removes the WordCamp and Meetups links. 

This corresponds to the new landing page [proposed here](https://github.com/WordPress/wordcamp.org/issues/1009), and **should only be merged once the new page is live**. 

| Before | After |
|-|-|
|<img width="700" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/4fb38e64-f403-4265-880c-eb42095ab1ca">|<img width="800" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/233202a8-a933-442c-85ea-9f43a02a603c">| 

~~@dorsvenabili do you think the Events link should be placed between the Community and About items?~~

**Edit:** I have updated the After preview to reflect the [comment](https://github.com/WordPress/wporg-mu-plugins/pull/515#issuecomment-1822638728) below