### PR TITLE
Global footer: Add Events and remove WordCamp link

### DIFF
--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -86,13 +86,13 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 		<li><a href="https://make.wordpress.org/"><?php echo esc_html_x( 'Get Involved', 'Menu item title', 'wporg' ); ?></a></li>
 		<!-- /wp:list-item -->
 		<!-- wp:list-item -->
+		<li><a href="https://events.wordpress.org/"><?php echo esc_html_x( 'Events', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
 		<li><a href="https://wordpressfoundation.org/donate/"><?php echo esc_html_x( 'Donate ↗', 'Menu item title', 'wporg' ); ?></a></li>
 		<!-- /wp:list-item -->
 		<!-- wp:list-item -->
 		<li><a href="https://mercantile.wordpress.org/"><?php echo esc_html_x( 'Swag Store ↗', 'Menu item title', 'wporg' ); ?></a></li>
-		<!-- /wp:list-item -->
-		<!-- wp:list-item -->
-		<li><a href="https://central.wordcamp.org/"><?php echo esc_html_x( 'WordCamp ↗', 'Menu item title', 'wporg' ); ?></a></li>
 		<!-- /wp:list-item -->
 	</ul>
 	<!-- /wp:list -->


### PR DESCRIPTION
This PR adds Events ([events.wordpress.org](https://events.wordpress.org/)) to the global footer navigation on WordPress.org. It also removes the WordCamp link.

This corresponds to the new landing page https://github.com/WordPress/wordcamp.org/issues/1009, and **should only be merged once the new page is live**.

| Before |
|-|
|<img width="1167" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/91557efa-1622-4b9e-8b9c-dc743ba45eac">|

| After |
|-|
|<img width="1225" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/c58059a2-0901-4f04-844d-51f89d7d4114">|

cc @dorsvenabili