### PR TITLE
Map: Add attribute to limit list length

### DIFF
--- a/mu-plugins/blocks/google-map/src/block.json
+++ b/mu-plugins/blocks/google-map/src/block.json
@@ -44,6 +44,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"listDisplayLimit": {
+			"type": "number",
+			"default": -1
+		},
 		"searchFields": {
 			"type": "array",
 			"default": [ "title", "location", "meetup" ]

--- a/mu-plugins/blocks/google-map/src/components/list.js
+++ b/mu-plugins/blocks/google-map/src/components/list.js
@@ -14,12 +14,17 @@ import { formatLocation } from '../utilities/content';
  *
  * @param {Object} props
  * @param {Array}  props.markers
+ * @param {number} props.displayLimit
  *
  * @return {JSX.Element}
  */
-export default function List( { markers } ) {
+export default function List( { markers, displayLimit } ) {
 	if ( markers.length === 0 ) {
 		return <p className="wporg-marker-list__container">{ __( 'No events available', 'wporg' ) }</p>;
+	}
+
+	if ( displayLimit > 0 ) {
+		markers = markers.slice( 0, displayLimit );
 	}
 
 	return (

--- a/mu-plugins/blocks/google-map/src/components/main.js
+++ b/mu-plugins/blocks/google-map/src/components/main.js
@@ -19,6 +19,7 @@ import { filterMarkers, speakSearchUpdates } from '../utilities/content';
 import { getValidMarkers } from '../utilities/google-maps-api';
 
 /**
+ * Primary entry point and rendering component for the block.
  *
  * @param {Object}  props
  * @param {string}  props.blockStyle
@@ -30,6 +31,7 @@ import { getValidMarkers } from '../utilities/google-maps-api';
  * @param {Object}  props.markerIcon
  * @param {string}  props.searchIcon
  * @param {Array}   props.searchFields
+ * @param {number}  props.listDisplayLimit
  *
  * @return {JSX.Element}
  */
@@ -37,6 +39,7 @@ export default function Main( {
 	blockStyle,
 	showMap,
 	showList,
+	listDisplayLimit,
 	showSearch,
 	apiKey,
 	markers: rawMarkers,
@@ -115,7 +118,9 @@ export default function Main( {
 				<Map apiKey={ apiKey } markers={ visibleMarkers } icon={ markerIcon } blockStyle={ blockStyle } />
 			) }
 
-			{ showList && visibleMarkers.length > 0 && <List markers={ visibleMarkers } /> }
+			{ showList && visibleMarkers.length > 0 && (
+				<List markers={ visibleMarkers } displayLimit={ listDisplayLimit } />
+			) }
 
 			{ visibleMarkers.length === 0 && searchQuery.length > 0 && (
 				<p className="wporg-marker-list__container">


### PR DESCRIPTION
This doesn't affect the data query, only the number of items that are displayed. The query limit is contextual to the query itself, and limiting that to the `listDisplayLimit` may distort the results.

Caching and priming is in place for the queries, so applying the limit to the query wouldn't have any benefit, and would make the code more complex.