### PR TITLE
Local Navigation: Add custom height for local-navigation-bar

### DIFF
--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -16,6 +16,7 @@
 }
 
 .wp-block-wporg-local-navigation-bar {
+	height: var(--wp--custom--local-navigation-bar--spacing--height, auto);
 
 	@media (min-width: 890px) {
 		& .global-header__wporg-logo-mark {

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -14,7 +14,7 @@
 }
 
 .wp-block-wporg-local-navigation-bar {
-	height: var(--wp--custom--local-navigation-bar--spacing--height, auto);
+	height: var(--wp--custom--local-navigation-bar--spacing--height, 60px);
 
 	@media (min-width: 890px) {
 		& .global-header__wporg-logo-mark {

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -4,8 +4,6 @@
 
 	padding-right: var(--wp--preset--spacing--edge-space);
 	padding-left: var(--wp--preset--spacing--edge-space);
-	padding-top: 18px;
-	padding-bottom: 18px;
 
 	top: var(--wp-admin--admin-bar--height, 0);
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-developer/issues/373

This PR adds customizability to local-navigation-bar block so that themes that use the block can adjust the height according to different needs.