### PR TITLE
Fix broken TOC (sidebar) when main content is expanded then collapsed

### DIFF
--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -136,6 +136,23 @@ function init() {
 			container.classList.add( 'is-fixed-sidebar' );
 			onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).
 			window.addEventListener( 'scroll', onScroll );
+
+			// eslint-disable-next-line no-undef
+			const observer = new ResizeObserver( () => {
+				// When the mainEl includes class "is-bottom-sidebar" and undergoes resizes,
+				// it means that the sidebar is positioned at its bottommost location.
+				// In this case, It is necessary to manually trigger the resize
+				// under the condition (footerStart - gap < sidebarBottom) to adjust the position appropriately.
+				// Otherwise, the sidebar will remain at the bottom of the page, leading to a broken page layout.
+				if ( container.classList.contains( 'is-bottom-sidebar' ) ) {
+					container.classList.remove( 'is-bottom-sidebar' );
+					container.style.removeProperty( 'top' );
+					onScroll();
+				}
+			} );
+
+			const mainEl = document.getElementById( 'wp--skip-link--target' );
+			observer.observe( mainEl );
 		}
 	}
 

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -147,7 +147,15 @@ function init() {
 				if ( container.classList.contains( 'is-bottom-sidebar' ) ) {
 					container.classList.remove( 'is-bottom-sidebar' );
 					container.style.removeProperty( 'top' );
-					onScroll();
+					const isBottom = onScroll();
+					// After the sidebar is repositioned, also adjusts the scroll position
+					// to a point where the sidebar is visible.
+					if ( isBottom ) {
+						window.scrollTo( {
+							top: container.offsetTop - FIXED_HEADER_HEIGHT,
+							behavior: 'instant',
+						} );
+					}
 				}
 			} );
 

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -137,13 +137,10 @@ function init() {
 			onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).
 			window.addEventListener( 'scroll', onScroll );
 
-			// eslint-disable-next-line no-undef
-			const observer = new ResizeObserver( () => {
-				// When the mainEl includes class "is-bottom-sidebar" and undergoes resizes,
-				// it means that the sidebar is positioned at its bottommost location.
-				// In this case, It is necessary to manually trigger the resize
-				// under the condition (footerStart - gap < sidebarBottom) to adjust the position appropriately.
-				// Otherwise, the sidebar will remain at the bottom of the page, leading to a broken page layout.
+			const observer = new window.ResizeObserver( () => {
+				// If the sidebar is positioned at the bottom and mainEl resizes,
+				// it will remain fixed at the previous bottom position, leading to a broken page layout.
+				// In this case manually trigger the scroll handler to reposition.
 				if ( container.classList.contains( 'is-bottom-sidebar' ) ) {
 					container.classList.remove( 'is-bottom-sidebar' );
 					container.style.removeProperty( 'top' );


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-developer/issues/372

This PR fixes the broken TOC. Changes:

**Sidebar Repositioning Logic:**

Implemented a check within the ResizeObserver to detect if the sidebar is positioned at its bottommost location (is-bottom-sidebar class). On detection, the sidebar's position is dynamically adjusted to align correctly with the resized content.

**Scroll Position Adjustment:**

Following the repositioning of the sidebar, the scroll position is then altered.
This adjustment ensures that the sidebar remains visible to the user.

## Screenshot

https://d.pr/i/O1iLY7