### PR TITLE
Map: Add separator between date and time for readability

### DIFF
--- a/mu-plugins/blocks/google-map/images/separator-dot.svg
+++ b/mu-plugins/blocks/google-map/images/separator-dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="3" height="4" viewBox="0 0 3 4" fill="none">
+  <circle cx="1.5" cy="2" r="1.5" fill="#979AA2"/>
+</svg>

--- a/mu-plugins/blocks/google-map/postcss/style.pcss
+++ b/mu-plugins/blocks/google-map/postcss/style.pcss
@@ -35,6 +35,19 @@
 		& p {
 			margin: 0;
 		}
+
+		& .wporg-marker-list-item__date-time {
+			display: flex;
+			align-items: center;
+			gap: 10px;
+		}
+
+		& .wporg-google-map__date-time-separator {
+			width: 3px;
+			height: 4px;
+			background-image: url(../images/separator-dot.svg);
+			background-repeat: no-repeat;
+		}
 	}
 }
 

--- a/mu-plugins/blocks/google-map/src/utilities/date-time.js
+++ b/mu-plugins/blocks/google-map/src/utilities/date-time.js
@@ -18,7 +18,7 @@ export function getEventDateTime( timestamp ) {
 	const localeDate = eventDate.toLocaleDateString( [], {
 		weekday: 'long',
 		year: 'numeric',
-		month: 'long',
+		month: 'short',
 		day: 'numeric',
 	} );
 
@@ -28,5 +28,11 @@ export function getEventDateTime( timestamp ) {
 		minute: '2-digit',
 	} );
 
-	return `${ localeDate } ${ localeTime }`;
+	return (
+		<>
+			<span className="wporg-google-map__date">{ localeDate }</span>
+			<span className="wporg-google-map__date-time-separator"></span>
+			<span className="wporg-google-map__time">{ localeTime }</span>
+		</>
+	);
 }


### PR DESCRIPTION
See https://www.figma.com/file/jdMk5ssz2Av7KFfEaeK7de/Events?type=design&node-id=1366-8712&mode=dev

<img width="738" alt="Screenshot 2023-11-29 at 11 02 40 AM" src="https://github.com/WordPress/wporg-mu-plugins/assets/484068/d9595488-2096-420f-a713-acfe21350d0e">
