### PR TITLE
Map: Apply datetime format to info windows, add external link indicator

### DIFF
--- a/mu-plugins/blocks/google-map/postcss/style.pcss
+++ b/mu-plugins/blocks/google-map/postcss/style.pcss
@@ -45,7 +45,7 @@
 	& .wporg-map-marker__url a {
 		text-decoration: none;
 
-		&:after {
+		&::after {
 			content: "↗";
 			margin-left: 5px;
 			font-family: var(--wp--preset--font-family--inter);

--- a/mu-plugins/blocks/google-map/postcss/style.pcss
+++ b/mu-plugins/blocks/google-map/postcss/style.pcss
@@ -28,6 +28,10 @@
 			/* Make sure there's enough room to scroll past it using mobile gestures. */
 			max-height: 90vh;
 		}
+
+		& .wporg-map-marker__title {
+			margin: 0;
+		}
 	}
 
 	& .wporg-marker-list__container {
@@ -35,19 +39,32 @@
 		& p {
 			margin: 0;
 		}
+	}
 
-		& .wporg-marker-list-item__date-time {
-			display: flex;
-			align-items: center;
-			gap: 10px;
-		}
+	& .wporg-marker-list-item__title a,
+	& .wporg-map-marker__url a {
+		text-decoration: none;
 
-		& .wporg-google-map__date-time-separator {
-			width: 3px;
-			height: 4px;
-			background-image: url(../images/separator-dot.svg);
-			background-repeat: no-repeat;
+		&:after {
+			content: "↗";
+			margin-left: 5px;
+			font-family: var(--wp--preset--font-family--inter);
 		}
+	}
+
+
+	& .wporg-marker-list-item__date-time,
+	& .wporg-map-marker__date-time {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+	}
+
+	& .wporg-google-map__date-time-separator {
+		width: 3px;
+		height: 4px;
+		background-image: url(../images/separator-dot.svg);
+		background-repeat: no-repeat;
 	}
 }
 

--- a/mu-plugins/blocks/google-map/src/components/list.js
+++ b/mu-plugins/blocks/google-map/src/components/list.js
@@ -15,8 +15,6 @@ import { formatLocation } from '../utilities/content';
  * @param {Object} props
  * @param {Array}  props.markers
  * @param {number} props.displayLimit
- *
- * @return {JSX.Element}
  */
 export default function List( { markers, displayLimit } ) {
 	if ( markers.length === 0 ) {

--- a/mu-plugins/blocks/google-map/src/components/main.js
+++ b/mu-plugins/blocks/google-map/src/components/main.js
@@ -32,8 +32,6 @@ import { getValidMarkers } from '../utilities/google-maps-api';
  * @param {string}  props.searchIcon
  * @param {Array}   props.searchFields
  * @param {number}  props.listDisplayLimit
- *
- * @return {JSX.Element}
  */
 export default function Main( {
 	blockStyle,

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -31,8 +31,6 @@ import {
  * @param {Array}  props.markers
  * @param {string} props.blockStyle
  * @param {Object} props.icon
- *
- * @return {JSX.Element}
  */
 export default function Map( { apiKey, markers: rawMarkers, icon, blockStyle } ) {
 	const [ loaded, setLoaded ] = useState( false );

--- a/mu-plugins/blocks/google-map/src/components/marker-content.js
+++ b/mu-plugins/blocks/google-map/src/components/marker-content.js
@@ -47,7 +47,7 @@ function WordCampMarker( { id, title, url, timestamp, location } ) {
 			<h3 className="wporg-map-marker__title">{ title }</h3>
 
 			<p className="wporg-map-marker__url">
-				<a href={ url }>{ title }</a>
+				<a href={ url }>Open event site</a>
 			</p>
 
 			<p className="wporg-map-marker__location">{ formatLocation( location ) }</p>

--- a/mu-plugins/blocks/google-map/src/components/marker-content.js
+++ b/mu-plugins/blocks/google-map/src/components/marker-content.js
@@ -8,8 +8,6 @@ import { formatLocation } from '../utilities/content';
  * Render the content for a map marker.
  *
  * @param {Object} props
- *
- * @return {JSX.Element}
  */
 export default function MarkerContent( props ) {
 	const { type } = props;
@@ -38,8 +36,6 @@ export default function MarkerContent( props ) {
  * @param {string} props.url
  * @param {string} props.timestamp
  * @param {string} props.location
- *
- * @return {JSX.Element}
  */
 function WordCampMarker( { id, title, url, timestamp, location } ) {
 	return (
@@ -67,8 +63,6 @@ function WordCampMarker( { id, title, url, timestamp, location } ) {
  * @param {string} props.meetup
  * @param {string} props.timestamp
  * @param {string} props.location
- *
- * @return {JSX.Element}
  */
 function MeetupMarker( { id, title, url, meetup, timestamp, location } ) {
 	return (

--- a/mu-plugins/blocks/google-map/src/components/search.js
+++ b/mu-plugins/blocks/google-map/src/components/search.js
@@ -10,8 +10,6 @@ import { __, _x } from '@wordpress/i18n';
  * @param {string}   props.searchQuery
  * @param {Function} props.onQueryChange
  * @param {string}   props.iconURL
- *
- * @return {JSX.Element}
  */
 export default function Search( { searchQuery, onQueryChange, iconURL } ) {
 	return (

--- a/mu-plugins/blocks/google-map/src/utilities/content.js
+++ b/mu-plugins/blocks/google-map/src/utilities/content.js
@@ -15,7 +15,7 @@ import { __, sprintf } from '@wordpress/i18n';
  *
  * @param {string} location
  *
- * @return {string}
+ * @return {string} The formatted location.
  */
 export function formatLocation( location ) {
 	if ( 'online' === location ) {

--- a/mu-plugins/blocks/google-map/src/utilities/date-time.js
+++ b/mu-plugins/blocks/google-map/src/utilities/date-time.js
@@ -10,7 +10,7 @@
  *
  * @param {number} timestamp
  *
- * @return {string}
+ * @return {string} The formatted date and time.
  */
 export function getEventDateTime( timestamp ) {
 	const eventDate = new Date( timestamp * 1000 );

--- a/mu-plugins/blocks/google-map/src/utilities/dom.js
+++ b/mu-plugins/blocks/google-map/src/utilities/dom.js
@@ -11,7 +11,7 @@ import { createRoot, flushSync } from '@wordpress/element';
  *
  * @param {JSX.Element} element
  *
- * @return {string}
+ * @return {string} The HTML for the given element.
  */
 export default function getElementHTML( element ) {
 	const div = document.createElement( 'div' );

--- a/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
+++ b/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
@@ -18,7 +18,7 @@ import getElementHTML from '../utilities/dom';
  *
  * @param {Array} markers
  *
- * @return {Array}
+ * @return {Array} Valid markers.
  */
 export function getValidMarkers( markers ) {
 	markers = markers.map( ( marker ) => {
@@ -40,7 +40,7 @@ export function getValidMarkers( markers ) {
  *
  * @param {Array} rawMarkers
  *
- * @return {Array}
+ * @return {Array} The original markers, with events in the same location combined into a single marker.
  */
 export function combineDuplicateLocations( rawMarkers ) {
 	const combinedMarkers = {};
@@ -144,7 +144,7 @@ function openInfoWindow( infoWindow, map, markerObject, rawMarker ) {
  * @param {Object}               rawIcon
  * @param {string}               blockStyle
  *
- * @return {MarkerClusterer}
+ * @return {MarkerClusterer} The clusterer object.
  */
 export function clusterMarkers( map, maps, markers, rawIcon, blockStyle ) {
 	const clusterIcon = {

--- a/mu-plugins/blocks/google-map/src/utilities/map-styles.js
+++ b/mu-plugins/blocks/google-map/src/utilities/map-styles.js
@@ -463,7 +463,8 @@ const sotw2023 = [
  * This shouldn't be needed if https://github.com/WordPress/gutenberg/issues/56278 is resolved.
  *
  * @param { string } className
- * @return { string }
+ *
+ * @return { string } The slug of the block style.
  */
 export function getBlockStyle( className ) {
 	let blockStyle = 'wp20';


### PR DESCRIPTION
See https://www.figma.com/file/jdMk5ssz2Av7KFfEaeK7de/Events?type=design&node-id=1366-8700&mode=dev

<img width="371" alt="Screenshot 2023-11-29 at 5 00 53 PM" src="https://github.com/WordPress/wporg-mu-plugins/assets/484068/cdbf21b5-63f1-4cdc-a461-8bea9f864fc1">
