### PR TITLE
Remove h4 headings from table of contents

### DIFF
--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -113,7 +113,7 @@ function render( $attributes, $content, $block ) {
  * @return array A list of heading objects.
  */
 function get_headings( $content ) {
-	$tag = 'h(?P<level>[1-4])';
+	$tag = 'h(?P<level>[1-3])';
 	preg_match_all( "/(?P<tag><{$tag}(?P<attrs>[^>]*)>)(?P<title>.*?)(<\/{$tag}>)/iJ", $content, $matches, PREG_SET_ORDER );
 
 	foreach ( $matches as $i => $item ) {


### PR DESCRIPTION
Closes #530 

Example page which has h4s: https://developer.wordpress.org/redesign-test/block-editor/how-to-guides/platform/custom-block-editor/

### Screenshots

| Before | After |
|-|-|
| ![Screenshot 2023-12-04 at 3 24 55 PM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/1a9d401c-6a01-427b-8973-79d224eea309) | ![Screenshot 2023-12-04 at 3 24 31 PM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/3d0106bb-5938-4b54-9c2f-1cb936c432df) |
