### PR TITLE
Time Block: Optional link and format.

### DIFF
--- a/mu-plugins/blocks/time/src/view.js
+++ b/mu-plugins/blocks/time/src/view.js
@@ -16,7 +16,7 @@ function convertTimes() {
 
 	const formatTime = function (
 		date,
-		timeFormat = {
+		dateFormat = {
 			weekday: 'long',
 			month: 'long',
 			day: 'numeric',
@@ -26,7 +26,7 @@ function convertTimes() {
 			timeZoneName: 'short',
 		}
 	) {
-		return date.toLocaleTimeString( window.navigator.language, timeFormat );
+		return date.toLocaleTimeString( window.navigator.language, dateFormat );
 	};
 
 	const formatDate = function ( date ) {
@@ -53,7 +53,7 @@ function convertTimes() {
 		let localTime = '';
 		const datetime = dateElement.getAttribute( 'datetime' );
 		const datetimeISO = dateElement.getAttribute( 'data-iso' );
-		const timeFormat = dateElement.getAttribute( 'data-time-format' );
+		const dateFormat = dateElement.getAttribute( 'data-date-format' );
 		const date = datetime && parseDate( datetime );
 
 		if ( date ) {
@@ -62,8 +62,8 @@ function convertTimes() {
 				localTime += ' ';
 			}
 
-			if( !! timeFormat ) {
-				localTime += formatTime( date, JSON.parse( timeFormat ) );
+			if( !! dateFormat ) {
+				localTime += formatTime( date, JSON.parse( dateFormat ) );
 			} else {
 				localTime += formatTime( date );
 			}

--- a/mu-plugins/blocks/time/src/view.js
+++ b/mu-plugins/blocks/time/src/view.js
@@ -14,8 +14,9 @@ function convertTimes() {
 		);
 	};
 
-	const formatTime = function ( date ) {
-		return date.toLocaleTimeString( window.navigator.language, {
+	const formatTime = function (
+		date,
+		timeFormat = {
 			weekday: 'long',
 			month: 'long',
 			day: 'numeric',
@@ -23,7 +24,9 @@ function convertTimes() {
 			hour: '2-digit',
 			minute: '2-digit',
 			timeZoneName: 'short',
-		} );
+		}
+	) {
+		return date.toLocaleTimeString( window.navigator.language, timeFormat );
 	};
 
 	const formatDate = function ( date ) {
@@ -50,30 +53,39 @@ function convertTimes() {
 		let localTime = '';
 		const datetime = dateElement.getAttribute( 'datetime' );
 		const datetimeISO = dateElement.getAttribute( 'data-iso' );
+		const timeFormat = dateElement.getAttribute( 'data-time-format' );
 		const date = datetime && parseDate( datetime );
 
-		if ( date && !! datetimeISO ) {
+		if ( date ) {
 			if ( ! toLocaleTimeStringSupportsLocales ) {
 				localTime += formatDate( date );
 				localTime += ' ';
 			}
 
-			localTime += formatTime( date );
+			if( !! timeFormat ) {
+				localTime += formatTime( date, JSON.parse( timeFormat ) );
+			} else {
+				localTime += formatTime( date );
+			}
 
 			dateElement.innerText = localTime;
-			dateElement.removeAttribute( 'data-iso' );
-			// Remove the dotted underline style applied for the editor only
-			dateElement.style.textDecoration = '';
-			dateElement.style.textDecorationStyle = '';
 
-			const linkElement = document.createElement( 'a' );
-			linkElement.setAttribute(
-				'href',
-				`https://www.timeanddate.com/worldclock/fixedtime.html?iso=${ datetimeISO }`
-			);
+			if ( !! datetimeISO ) {
+				dateElement.removeAttribute( 'data-iso' );
+				// Remove the dotted underline style applied for the editor only
+				dateElement.style.textDecoration = '';
+				dateElement.style.textDecorationStyle = '';
 
-			linkElement.appendChild( dateElement.cloneNode( true ) );
-			dateElement.parentNode.replaceChild( linkElement, dateElement );
+				const linkElement = document.createElement( 'a' );
+				linkElement.setAttribute(
+					'href',
+					`https://www.timeanddate.com/worldclock/fixedtime.html?iso=${ datetimeISO }`
+				);
+
+				linkElement.appendChild( dateElement.cloneNode( true ) );
+
+				dateElement.parentNode.replaceChild( linkElement, dateElement );
+			}
 		}
 	} );
 }

--- a/mu-plugins/blocks/time/src/view.js
+++ b/mu-plugins/blocks/time/src/view.js
@@ -83,7 +83,6 @@ function convertTimes() {
 				);
 
 				linkElement.appendChild( dateElement.cloneNode( true ) );
-
 				dateElement.parentNode.replaceChild( linkElement, dateElement );
 			}
 		}

--- a/mu-plugins/blocks/time/src/view.js
+++ b/mu-plugins/blocks/time/src/view.js
@@ -62,7 +62,7 @@ function convertTimes() {
 				localTime += ' ';
 			}
 
-			if( !! dateFormat ) {
+			if ( !! dateFormat ) {
 				localTime += formatTime( date, JSON.parse( dateFormat ) );
 			} else {
 				localTime += formatTime( date );


### PR DESCRIPTION
In building https://github.com/WordPress/wordcamp.org/pull/1124, we need a front-end time block to display a more user-friendly block. There are 2 things that don't work with the current time block:
- It links to the WorldClock
- It doesn't allow you to update formatting.

This PR makes the WordClock link optional based on the presence of the `data-iso` property and allows you to pass in the data format in via `data-date-format`.

