### PR TITLE
Google Map: Optimize dependencies

### DIFF
--- a/mu-plugins/blocks/google-map/postcss/style.pcss
+++ b/mu-plugins/blocks/google-map/postcss/style.pcss
@@ -6,7 +6,6 @@
 	& .wporg-marker-search__container {
 		display: flex;
 
-		/* Enqueuing the `wp-components` stylesheet add too much to the page load just for these styles, so they're duplicated here. */
 		& button.is-tertiary {
 			background: none;
 			border: none;

--- a/mu-plugins/blocks/google-map/postcss/style.pcss
+++ b/mu-plugins/blocks/google-map/postcss/style.pcss
@@ -83,7 +83,7 @@
 		position: absolute;
 		left: var(--local-position);
 		top: var(--local-position);
-		color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		color: var(--wp--custom--google-map--spinner--color);
 		overflow: visible;
 		opacity: 1;
 		background-color: transparent;
@@ -125,4 +125,9 @@
 			color: #ff2b2b;
 		}
 	}
+}
+
+/* Set up the custom properties. These can be overridden by settings in theme.json. */
+:where(body) {
+	--wp--custom--google-map--spinner--color: var(--wp--preset--color--blueberry-1, var(--wp-admin-theme-color, #3858e9));
 }

--- a/mu-plugins/blocks/google-map/postcss/style.pcss
+++ b/mu-plugins/blocks/google-map/postcss/style.pcss
@@ -74,8 +74,47 @@
 		background-image: url(../images/separator-dot.svg);
 		background-repeat: no-repeat;
 	}
+
+	& .wporg-google-map__spinner {
+		--local-size: 16px;
+		--local-position: calc(50% - (var(--local-size) / 2));
+
+		width: var(--local-size);
+		height: var(--local-size);
+		position: absolute;
+		left: var(--local-position);
+		top: var(--local-position);
+		color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		overflow: visible;
+		opacity: 1;
+		background-color: transparent;
+
+		& > circle {
+			fill: transparent;
+			stroke-width: 1.5px;
+			stroke: rgb(221, 221, 221);
+		}
+
+		& > path {
+			fill: transparent;
+			stroke-width: 1.5px;
+			stroke: currentcolor;
+			stroke-linecap: round;
+			transform-origin: 50% 50%;
+			animation: 1.4s linear 0s infinite normal both running wp-block-wporg-google-map-spinner-animation;
+		}
+	}
 }
 
+@keyframes wp-block-wporg-google-map-spinner-animation {
+	0% {
+		transform: rotate(0deg);
+	}
+
+	100% {
+		transform: rotate(360deg);
+	}
+}
 
 /*
  * State of the Word 2023 block style

--- a/mu-plugins/blocks/google-map/src/components/main.js
+++ b/mu-plugins/blocks/google-map/src/components/main.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { throttle } from 'lodash';
+import throttle from 'lodash.throttle';
 
 /**
  * WordPress dependencies

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -7,7 +7,6 @@ import GoogleMapReact from 'google-map-react';
  * WordPress dependencies
  */
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -20,6 +19,7 @@ import {
 	panToCenter,
 	updateMapMarkers,
 } from '../utilities/google-maps-api';
+import Spinner from './spinner';
 
 /**
  * Render a Google Map with info windows for the given markers.

--- a/mu-plugins/blocks/google-map/src/components/search.js
+++ b/mu-plugins/blocks/google-map/src/components/search.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 
 /**
@@ -52,13 +51,13 @@ export default function Search( { formAction, searchQuery, onQueryChange, iconUR
 				/>
 			</label>
 
-			{ formAction && (
-				<Button type="submit" variant="tertiary">
+			{ formAction ? (
+				<button type="submit" className="is-tertiary">
 					{ searchIcon }
-				</Button>
+				</button>
+			) : (
+				searchIcon
 			) }
-
-			{ ! formAction && searchIcon }
 		</form>
 	);
 }

--- a/mu-plugins/blocks/google-map/src/components/spinner.js
+++ b/mu-plugins/blocks/google-map/src/components/spinner.js
@@ -1,0 +1,16 @@
+export default function Spinner() {
+	return (
+		<svg
+			className="wporg-google-map__spinner"
+			viewBox="0 0 100 100"
+			width="16"
+			height="16"
+			xmlns="http://www.w3.org/2000/svg"
+			role="presentation"
+			focusable="false"
+		>
+			<circle cx="50" cy="50" r="50" vectorEffect="non-scaling-stroke"></circle>
+			<path d="m 50 0 a 50 50 0 0 1 50 50" vectorEffect="non-scaling-stroke"></path>
+		</svg>
+	);
+}

--- a/mu-plugins/blocks/google-map/src/utilities/content.js
+++ b/mu-plugins/blocks/google-map/src/utilities/content.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
+import debounce from 'lodash.debounce';
 const debouncedSpeak = debounce( speak, 1000 );
 
 /**

--- a/mu-plugins/blocks/screenshot-preview/src/in-view.js
+++ b/mu-plugins/blocks/screenshot-preview/src/in-view.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
+import debounce from 'lodash.debounce';
 
 /**
  * WordPress dependencies

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 		"chalk": "4.1.2",
 		"cross-spawn": "7.0.3",
 		"cssnano": "5.1.11",
-		"lodash": "^4.17.21",
 		"node-watch": "^0.7.3",
 		"postcss": "8.4.14",
 		"postcss-cli": "9.1.0",
@@ -67,6 +66,8 @@
 	"dependencies": {
 		"@googlemaps/markerclusterer": "^2.4.0",
 		"google-map-react": "^2.2.1",
-		"locutus": "^2.0.16"
+		"locutus": "^2.0.16",
+		"lodash.debounce": "^4.0.8",
+		"lodash.throttle": "^4.1.1"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6416,7 +6416,7 @@ locutus@^2.0.16:
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
-  resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.escape@^4.0.1:
@@ -6443,6 +6443,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
Fixes #537 
Related: https://github.com/WordPress/wordcamp.org/issues/1128

Moves lighthouse perf score from ~68 to ~82 on localhost for the Events landing page.

Removes dependency on WordPress Components package and shifts lodash dependencies to individual packages (throttle and debounce).

### Spinner

#### Before

![Screenshot 2023-12-08 at 10 08 19 AM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/a5e819a2-710e-4de3-b898-319535ce5dcc)

#### After

![events spinner](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/7f263e56-c271-445b-a16f-9e79b90d5dc1) |

### Scripts

#### Before (All (3.6 MiB), Unused Bytes (1.8 MiB))

![Screenshot 2023-12-08 at 9 56 10 AM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/d6663fb2-1a1b-4185-b17f-cd963df37e64)

#### After (All (1.9 MiB), Unused Bytes (810.6 KiB))

![Screenshot 2023-12-08 at 9 59 14 AM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/b5b9b0f7-dc95-4d77-be00-280f02b793bd)

### Testing

Should be tested with a site using the Screenshot Preview block, as it has dependency changes (Showcase?), and Events for the Google Map block.
