### PR TITLE
Map: Cleanup cron jobs

### DIFF
--- a/mu-plugins/blocks/google-map/inc/event-filters.php
+++ b/mu-plugins/blocks/google-map/inc/event-filters.php
@@ -210,7 +210,9 @@ function is_cacheable( array $facets, int $page ): bool {
 function get_cache_key( array $parts ): string {
 	$parts = array_filter( $parts ); // Remove empty so that cache key is normalized.
 	$items = apply_filters( 'google_map_event_filters_cache_key_parts', $parts );
-	$key   = 'google-map-event-filters-' . md5( wp_json_encode( $items ) );
+	ksort( $items ); // Normalize top-level items.
+
+	$key = 'google-map-event-filters-' . md5( wp_json_encode( $items ) );
 
 	return $key;
 }


### PR DESCRIPTION
This moves facet validation from the theme to the map, where it's centralized and has more context for what is valid. Previously pentest requests like `event_type[]=fsssiedxo\\'sssiedx` would result in an extra cron being scheduled. The invalid parameters were ignored, so the request returned results and was therefore cached.

This also purges cron tasks weekly to avoid buildup.

Related https://github.com/WordPress/wordcamp.org/pull/1179