### PR TITLE
Add Events to submenu

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -544,13 +544,8 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'WordCamp ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://central.wordcamp.org/',
-					'type'  => 'custom',
-				),
-				array(
-					'title' => esc_html_x( 'Meetups ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://www.meetup.com/pro/wordpress/',
+					'title' => esc_html_x( 'Events', 'Menu item title', 'wporg' ),
+					'url'   => 'https://events.wordpress.org/',
 					'type'  => 'custom',
 				),
 				array(


### PR DESCRIPTION
Removes WordCamp and Meetups link, and replaces with Events site.