### PR TITLE
Blocks: Notice: The `$content` parameter is a required parameter.

### DIFF
--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -34,7 +34,7 @@ function init() {
  *
  * @return string Shortcode output as HTML markup.
  */
-function render_shortcode( $attr, $content = '', $tag ) {
+function render_shortcode( $attr, $content, $tag ) {
 	$shortcode_mapping = array(
 		'info'     => 'info',
 		'tip'      => 'tip',


### PR DESCRIPTION
This removes a PHP Deprecated notice, as a optional parameter was declared before a required parameter.

```
Deprecated: Optional parameter $content declared before required parameter $tag is implicitly treated as a required parameter in mu-plugins/blocks/notice/index.php on line 37
```

Not pushing this (yet) because I'm not sure if this function is called directly anywhere, which I don't think it should, but I haven't checked.