### PR TITLE
Make sidebar container scroll internally

### DIFF
--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -123,6 +123,13 @@
 	}
 }
 
+@media (min-width: 890px) {
+	/* stylelint-disable selector-id-pattern */
+	#wp--skip-link--target {
+		scroll-margin-top: var(--wp--custom--local-navigation-bar--spacing--height, 0);
+	}
+}
+
 /* Set up the custom properties. These can be overridden by settings in theme.json. */
 :where(body) {
 	--wp--custom--local-navigation-bar--spacing--height: 60px;

--- a/mu-plugins/blocks/sidebar-container/index.php
+++ b/mu-plugins/blocks/sidebar-container/index.php
@@ -45,11 +45,13 @@ function render( $attributes, $content, $block ) {
 			esc_html__( '↑ Back to top', 'wporg' )
 		)
 		: '';
+	$inlineBreakpoint = $attributes['inlineBreakpoint'];
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
-		'<div %1$s>%2$s%3$s</div>',
+		'<div %1$s data-breakpoint="%2$s">%3$s%4$s</div>',
 		$wrapper_attributes,
+		esc_attr( $inlineBreakpoint ),
 		$content,
 		$back_to_top
 	);

--- a/mu-plugins/blocks/sidebar-container/index.php
+++ b/mu-plugins/blocks/sidebar-container/index.php
@@ -39,10 +39,12 @@ function init() {
  * @return string Returns the block markup.
  */
 function render( $attributes, $content, $block ) {
-	$back_to_top = sprintf(
-		'<p class="has-small-font-size is-link-to-top"><a href="#wp--skip-link--target">%s</a></p>',
-		esc_html__( '↑ Back to top', 'wporg' )
-	);
+	$back_to_top = $attributes['hasBackToTop']
+		? sprintf(
+			'<p class="has-small-font-size is-link-to-top"><a href="#wp--skip-link--target">%s</a></p>',
+			esc_html__( '↑ Back to top', 'wporg' )
+		)
+		: '';
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(

--- a/mu-plugins/blocks/sidebar-container/index.php
+++ b/mu-plugins/blocks/sidebar-container/index.php
@@ -39,19 +39,19 @@ function init() {
  * @return string Returns the block markup.
  */
 function render( $attributes, $content, $block ) {
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$inline_breakpoint = $attributes['inlineBreakpoint'];
 	$back_to_top = $attributes['hasBackToTop']
 		? sprintf(
 			'<p class="has-small-font-size is-link-to-top"><a href="#wp--skip-link--target">%s</a></p>',
 			esc_html__( '↑ Back to top', 'wporg' )
 		)
 		: '';
-	$inlineBreakpoint = $attributes['inlineBreakpoint'];
 
-	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
 		'<div %1$s data-breakpoint="%2$s">%3$s%4$s</div>',
 		$wrapper_attributes,
-		esc_attr( $inlineBreakpoint ),
+		esc_attr( $inline_breakpoint ),
 		$content,
 		$back_to_top
 	);

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -20,15 +20,6 @@
 		margin-bottom: 0 !important;
 		padding: var(--wp--preset--spacing--20) 0;
 
-		main & {
-			position: absolute;
-			top: calc(var(--wp-global-header-offset, 90px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
-			margin-top: var(--wp--custom--wporg-sidebar-container--spacing--margin--top);
-
-			/* Right offset should be "edge spacing" at minimum, otherwise calculate it to be centered. */
-			right: max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2));
-		}
-
 		&:not(.is-fixed-sidebar) {
 
 			/* Match width of custom scrollbar when fixed, stops content width changing */
@@ -68,6 +59,15 @@
 		& * + .is-link-to-top {
 			border-top: 1px solid var(--wp--preset--color--light-grey-1);
 		}
+	}
+
+	main .wp-block-wporg-sidebar-container {
+		position: absolute;
+		top: calc(var(--wp-global-header-offset, 90px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
+		margin-top: var(--wp--custom--wporg-sidebar-container--spacing--margin--top);
+
+		/* Right offset should be "edge spacing" at minimum, otherwise calculate it to be centered. */
+		right: max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2));
 	}
 }
 

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -48,7 +48,6 @@
 
 			& .is-link-to-top {
 				display: block;
-				padding-top: var(--wp--preset--spacing--20);
 
 				& a {
 					color: var(--wp--preset--color--charcoal-4);
@@ -57,6 +56,7 @@
 		}
 
 		& * + .is-link-to-top {
+			padding-top: var(--wp--preset--spacing--20);
 			border-top: 1px solid var(--wp--preset--color--light-grey-1);
 		}
 	}

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -18,7 +18,7 @@
 
 		width: var(--local--block-end-sidebar--width);
 		margin-bottom: 0 !important;
-		padding-top: var(--wp--preset--spacing--20);
+		padding: var(--wp--preset--spacing--20) 0;
 
 		main & {
 			position: absolute;
@@ -67,7 +67,6 @@
 
 		* + .is-link-to-top {
 			border-top: 1px solid var(--wp--preset--color--light-grey-1);
-			padding-bottom: var(--wp--preset--spacing--20);
 		}
 	}
 }

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -29,6 +29,7 @@
 		--local--block-end-sidebar--width: 356px;
 
 		width: var(--local--block-end-sidebar--width);
+		padding-bottom: var(--local--padding);
 		overflow-y: scroll;
 		overscroll-behavior: contain;
 		scrollbar-color: var(--wp--preset--color--charcoal-5) transparent;

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -26,13 +26,39 @@
 
 	/* Slot the search & table of contents into a floating sidebar on large screens. */
 	&.is-floating-sidebar {
-		--local--block-end-sidebar--width: 340px;
+		--local--block-end-sidebar--width: 356px;
 
 		width: var(--local--block-end-sidebar--width);
+		overflow-y: scroll;
+		overscroll-behavior: contain;
+		scrollbar-color: var(--wp--preset--color--charcoal-5) transparent;
 
-		&:not(.is-fixed-sidebar) {
+		/* Custom scrollbar so that it can be made visible on hover */
+		&::-webkit-scrollbar,
+		&::-webkit-scrollbar-track {
+			background-color: transparent;
+		}
 
-			/* Match width of custom scrollbar when fixed, stops content width changing */
+		&::-webkit-scrollbar-thumb {
+			&:active,
+			&:hover {
+				background-color: var(--wp--preset--color--charcoal-4) !important;
+			}
+		}
+
+		&:active,
+		&:focus-within,
+		&:focus,
+		&:hover {
+			&::-webkit-scrollbar-thumb {
+				background-color: var(--wp--preset--color--charcoal-5);
+				border: 4px solid transparent;
+				background-clip: content-box;
+				border-radius: 10px;
+			}
+		}
+
+		& > * {
 			padding-right: 16px;
 		}
 
@@ -42,20 +68,6 @@
 			height: calc(100vh - var(--local--offset-top));
 			margin-top: var(--local--offset-top) !important;
 			padding: var(--local--padding) 0;
-			overflow-y: scroll;
-
-			/* Custom scrollbar so that it can be made visible on hover */
-			&::-webkit-scrollbar,
-			&::-webkit-scrollbar-thumb {
-				background-color: transparent;
-			}
-
-			&:hover::-webkit-scrollbar-thumb {
-				background-color: var(--wp--preset--color--charcoal-4);
-				border: 4.5px solid transparent;
-				background-clip: content-box;
-				border-radius: 10px;
-			}
 
 			& .is-link-to-top {
 				display: block;

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -7,8 +7,7 @@
 
 	/* Account for local nav height on larger screens where it becomes fixed. */
 	@media (min-width: 890px) {
-		/* stylelint-disable-next-line length-zero-no-unit */
-		--local--nav--offset: 0px;
+		--local--nav--offset: 0;
 		--local--offset-top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
 	}
 

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -62,7 +62,7 @@
 			}
 		}
 
-		.wp-block-wporg-table-of-contents + .is-link-to-top {
+		* + .is-link-to-top {
 			border-top: 1px solid var(--wp--preset--color--light-grey-1);
 			padding-bottom: var(--wp--preset--spacing--20);
 		}

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -1,5 +1,6 @@
 .wp-block-wporg-sidebar-container {
-	--local--offset-top: var(--wp-admin--admin-bar--height, 0);
+	/* stylelint-disable-next-line length-zero-no-unit */
+	--local--offset-top: var(--wp-admin--admin-bar--height, 0px);
 
 	/* These vars are used in JS calcs */
 	--local--nav--offset: var(--wp--custom--local-navigation-bar--spacing--height, 60px);

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -1,21 +1,32 @@
-.wp-block-wporg-sidebar-container .is-link-to-top {
-	display: none;
+.wp-block-wporg-sidebar-container {
+	--local--offset-top: var(--wp-admin--admin-bar--height, 0);
 
-	& a {
-		text-decoration-line: none;
+	/* These vars are used in JS calcs */
+	--local--nav--offset: var(--wp--custom--local-navigation-bar--spacing--height, 60px);
+	--local--padding: var(--wp--preset--spacing--20);
 
-		&:hover {
-			text-decoration-line: underline;
+	/* Account for local nav height on larger screens where it becomes fixed. */
+	@media (min-width: 890px) {
+		/* stylelint-disable-next-line length-zero-no-unit */
+		--local--nav--offset: 0px;
+		--local--offset-top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
+	}
+
+	& .is-link-to-top {
+		display: none;
+
+		& a {
+			text-decoration-line: none;
+
+			&:hover {
+				text-decoration-line: underline;
+			}
 		}
 	}
-}
 
-/* Slot the search & table of contents into a floating sidebar on large screens. */
-@media (min-width: 1200px) {
-	.wp-block-wporg-sidebar-container {
+	/* Slot the search & table of contents into a floating sidebar on large screens. */
+	&.is-floating-sidebar {
 		--local--block-end-sidebar--width: 340px;
-		--local--offset-top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
-		--local--padding-top: var(--wp--preset--spacing--20);
 
 		width: var(--local--block-end-sidebar--width);
 
@@ -30,7 +41,7 @@
 			top: 0;
 			height: calc(100vh - var(--local--offset-top));
 			margin-top: var(--local--offset-top) !important;
-			padding: var(--local--padding-top) 0;
+			padding: var(--local--padding) 0;
 			overflow-y: scroll;
 
 			/* Custom scrollbar so that it can be made visible on hover */
@@ -60,8 +71,14 @@
 			border-top: 1px solid var(--wp--preset--color--light-grey-1);
 		}
 	}
+}
 
-	main .wp-block-wporg-sidebar-container {
+main .wp-block-wporg-sidebar-container {
+
+	/* Hide the main sidebar until layout classes have been applied, to avoid FOUC */
+	display: none;
+
+	&.is-floating-sidebar {
 		position: absolute;
 		top: calc(var(--wp-global-header-offset, 90px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
 		margin-top: var(--wp--custom--wporg-sidebar-container--spacing--margin--top);

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -55,7 +55,7 @@
 				border-radius: 10px;
 			}
 
-			.is-link-to-top {
+			& .is-link-to-top {
 				display: block;
 				padding-top: var(--wp--preset--spacing--20);
 

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -19,7 +19,6 @@
 		width: var(--local--block-end-sidebar--width);
 		margin-bottom: 0 !important;
 		padding-top: var(--wp--preset--spacing--20);
-		background: red;
 
 		main & {
 			position: absolute;

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -14,6 +14,7 @@
 @media (min-width: 1200px) {
 	.wp-block-wporg-sidebar-container {
 		--local--block-end-sidebar--width: 340px;
+		--local--top-offset: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
 
 		position: absolute;
 		top: calc(var(--wp-global-header-offset, 90px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
@@ -23,32 +24,47 @@
 		width: var(--local--block-end-sidebar--width);
 		margin-top: var(--wp--custom--wporg-sidebar-container--spacing--margin--top);
 		margin-bottom: 0 !important;
+		padding-top: var(--wp--preset--spacing--20);
+
+		&:not(.is-fixed-sidebar) {
+
+			/* Match width of custom scrollbar when fixed, stops content width changing */
+			padding-right: 16px;
+		}
 
 		&.is-fixed-sidebar {
 			position: fixed;
 			top: 0;
+			height: calc(100vh - var(--local--top-offset));
+			margin-top: var(--local--top-offset);
+			overflow-y: scroll;
 
-			/* Make the space above the sidebar the same as the height of the local nav. */
-			margin-top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px) * 2);
-		}
+			/* Custom scrollbar so that it can be made visible on hover */
+			&::-webkit-scrollbar,
+			&::-webkit-scrollbar-thumb {
+				background-color: transparent;
+			}
 
-		&.is-bottom-sidebar {
-			position: absolute;
-		}
+			&:hover::-webkit-scrollbar-thumb {
+				background-color: var(--wp--preset--color--charcoal-4);
+				border: 4.5px solid transparent;
+				background-clip: content-box;
+				border-radius: 10px;
+			}
 
-		&.is-fixed-sidebar .is-link-to-top,
-		&.is-bottom-sidebar .is-link-to-top {
-			display: block;
-			margin-top: 0;
+			.is-link-to-top {
+				display: block;
+				padding-top: var(--wp--preset--spacing--20);
 
-			& a {
-				color: var(--wp--preset--color--charcoal-4);
+				& a {
+					color: var(--wp--preset--color--charcoal-4);
+				}
 			}
 		}
 
 		.wp-block-wporg-table-of-contents + .is-link-to-top {
 			border-top: 1px solid var(--wp--preset--color--light-grey-1);
-			padding-top: var(--wp--preset--spacing--20);
+			padding-bottom: var(--wp--preset--spacing--20);
 		}
 	}
 }

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -71,13 +71,6 @@
 	}
 }
 
-@media (min-width: 890px) {
-	/* stylelint-disable selector-id-pattern */
-	#wp--skip-link--target {
-		scroll-margin-top: var(--wp--custom--local-navigation-bar--spacing--height, 0);
-	}
-}
-
 /* Set up the custom properties. These can be overridden by settings in theme.json. */
 :where(body) {
 	--wp--custom--wporg-sidebar-container--spacing--margin--top: var(--wp--preset--spacing--edge-space);

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -14,11 +14,10 @@
 @media (min-width: 1200px) {
 	.wp-block-wporg-sidebar-container {
 		--local--block-end-sidebar--width: 340px;
-		--local--top-offset: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
+		--local--offset-top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
+		--local--padding-top: var(--wp--preset--spacing--20);
 
 		width: var(--local--block-end-sidebar--width);
-		margin-bottom: 0 !important;
-		padding: var(--wp--preset--spacing--20) 0;
 
 		&:not(.is-fixed-sidebar) {
 
@@ -29,8 +28,9 @@
 		&.is-fixed-sidebar {
 			position: fixed;
 			top: 0;
-			height: calc(100vh - var(--local--top-offset));
-			margin-top: var(--local--top-offset);
+			height: calc(100vh - var(--local--offset-top));
+			margin-top: var(--local--offset-top) !important;
+			padding: var(--local--padding-top) 0;
 			overflow-y: scroll;
 
 			/* Custom scrollbar so that it can be made visible on hover */

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -16,15 +16,19 @@
 		--local--block-end-sidebar--width: 340px;
 		--local--top-offset: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
 
-		position: absolute;
-		top: calc(var(--wp-global-header-offset, 90px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
-
-		/* Right offset should be "edge spacing" at minimum, otherwise calculate it to be centered. */
-		right: max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2));
 		width: var(--local--block-end-sidebar--width);
-		margin-top: var(--wp--custom--wporg-sidebar-container--spacing--margin--top);
 		margin-bottom: 0 !important;
 		padding-top: var(--wp--preset--spacing--20);
+		background: red;
+
+		main & {
+			position: absolute;
+			top: calc(var(--wp-global-header-offset, 90px) + var(--wp--custom--local-navigation-bar--spacing--height, 60px));
+			margin-top: var(--wp--custom--wporg-sidebar-container--spacing--margin--top);
+
+			/* Right offset should be "edge spacing" at minimum, otherwise calculate it to be centered. */
+			right: max(var(--wp--preset--spacing--edge-space), calc((100% - var(--wp--style--global--wide-size)) / 2));
+		}
 
 		&:not(.is-fixed-sidebar) {
 

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -65,7 +65,7 @@
 			}
 		}
 
-		* + .is-link-to-top {
+		& * + .is-link-to-top {
 			border-top: 1px solid var(--wp--preset--color--light-grey-1);
 		}
 	}

--- a/mu-plugins/blocks/sidebar-container/src/block.json
+++ b/mu-plugins/blocks/sidebar-container/src/block.json
@@ -11,6 +11,10 @@
 		"hasBackToTop": {
 			"type": "boolean",
 			"default": true
+		},
+		"inlineBreakpoint": {
+			"type": "string",
+			"default": "1200px"
 		}
 	},
 	"supports": {

--- a/mu-plugins/blocks/sidebar-container/src/block.json
+++ b/mu-plugins/blocks/sidebar-container/src/block.json
@@ -7,7 +7,12 @@
 	"category": "layout",
 	"description": "A sticky container to be used in 2-column layouts.",
 	"textdomain": "wporg",
-	"attributes": {},
+	"attributes": {
+		"hasBackToTop": {
+			"type": "boolean",
+			"default": true
+		}
+	},
 	"supports": {
 		"inserter": false,
 		"__experimentalLayout": true,

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -50,15 +50,13 @@ function createScrollHandler( container ) {
 
 		// Toggle the fixed position based on whether the scrollPosition is greater than the
 		// initial gap from the top minus the padding applied when fixed.
-		container.classList.toggle(
-			'is-fixed-sidebar',
-			scrollPosition > SPACE_TO_TOP + globalNavHeight + localNavOffset - adminBarHeight - paddingTop
-		);
+		const shouldFix =
+			scrollPosition > SPACE_TO_TOP + globalNavHeight + localNavOffset - adminBarHeight - paddingTop;
+		container.classList.toggle( 'is-fixed-sidebar', shouldFix );
 
+		// If the sidebar is fixed and the footer is visible in the viewport, reduce the height to stop overlap.
 		const footerStart = mainEl.offsetTop + mainEl.offsetHeight;
-
-		// Is the footer visible in the viewport?
-		if ( footerStart < scrollPosition + windowHeight ) {
+		if ( shouldFix && footerStart < scrollPosition + windowHeight ) {
 			container.style.setProperty( 'height', `${ footerStart - scrollPosition - container.offsetTop }px` );
 		} else {
 			container.style.removeProperty( 'height' );

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -19,6 +19,9 @@ const scrollHandlers = [];
  */
 function getCustomPropValue( name, element = document.body ) {
 	const value = window.getComputedStyle( element ).getPropertyValue( name );
+	if ( '0' === value ) {
+		return 0;
+	}
 	if ( 'px' === value.slice( -2 ) ) {
 		return Number( value.replace( 'px', '' ) );
 	}

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -100,12 +100,6 @@ function init() {
 	// Avoids footer collisions (ex, when linked to #reply-title).
 	onResize();
 	window.addEventListener( 'resize', onResize );
-
-	// If there is no table of contents, hide the heading.
-	if ( ! document.querySelector( '.wp-block-wporg-table-of-contents' ) ) {
-		const heading = document.querySelector( '.wp-block-wporg-sidebar-container h2' );
-		heading?.style.setProperty( 'display', 'none' );
-	}
 }
 
 window.addEventListener( 'load', init );

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -33,7 +33,8 @@ function getCustomPropValue( name, element = document.body ) {
  * and toggle the "fixed" class at a certain point.
  * Reduce the height of the sidebar to stop it overlapping the footer.
  *
- * @param {HTMLElement} container
+ * @param {HTMLElement} container The sidebar container.
+ * @return {Function}   onScroll  The sidebar scroll handler.
  */
 function createScrollHandler( container ) {
 	return function onScroll() {
@@ -67,7 +68,7 @@ function createScrollHandler( container ) {
 
 /**
  * Set the height for the admin bar and global nav vars.
- * Set the floating sidebar class on each container based on their breakpoint.
+ * Set the floating sidebar class on each container based on its breakpoint.
  * Show hidden containers after layout.
  */
 function onResize() {

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -60,20 +60,6 @@ function onScroll() {
 function init() {
 	container = document.querySelector( '.wp-block-wporg-sidebar-container' );
 	mainEl = document.getElementById( 'wp--skip-link--target' );
-	const toggleButton = container?.querySelector( '.wporg-table-of-contents__toggle' );
-	const list = container?.querySelector( '.wporg-table-of-contents__list' );
-
-	if ( toggleButton && list ) {
-		toggleButton.addEventListener( 'click', function () {
-			if ( toggleButton.getAttribute( 'aria-expanded' ) === 'true' ) {
-				toggleButton.setAttribute( 'aria-expanded', false );
-				list.removeAttribute( 'style' );
-			} else {
-				toggleButton.setAttribute( 'aria-expanded', true );
-				list.setAttribute( 'style', 'display:block;' );
-			}
-		} );
-	}
 
 	if ( mainEl && container ) {
 		onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -1,17 +1,14 @@
 /**
  * Fallback values for custom properties match CSS defaults.
  */
-const globalNavHeight = 90;
 
-const LOCAL_NAV_HEIGHT = getCustomPropValue( '--wp--custom--local-navigation-bar--spacing--height' ) || 60;
+const GLOBAL_NAV_HEIGHT = getCustomPropValue( '--wp-global-header-height' ) || 90;
 const ADMIN_BAR_HEIGHT = parseInt(
 	window.getComputedStyle( document.documentElement ).getPropertyValue( 'margin-top' ),
 	10
 );
-const SPACE_FROM_BOTTOM = getCustomPropValue( '--wp--preset--spacing--edge-space' ) || 80;
 const SPACE_TO_TOP = getCustomPropValue( '--wp--custom--wporg-sidebar-container--spacing--margin--top' ) || 80;
-const FIXED_HEADER_HEIGHT = globalNavHeight + LOCAL_NAV_HEIGHT + ADMIN_BAR_HEIGHT;
-const SCROLL_POSITION_TO_FIX = globalNavHeight + SPACE_TO_TOP - LOCAL_NAV_HEIGHT - ADMIN_BAR_HEIGHT;
+const SCROLL_POSITION_TO_FIX = GLOBAL_NAV_HEIGHT + SPACE_TO_TOP - ADMIN_BAR_HEIGHT;
 
 let container;
 let mainEl;
@@ -36,59 +33,28 @@ function getCustomPropValue( name, element = document.body ) {
  * Check the position of the sidebar vs the height of the viewport & page
  * container, and toggle the "bottom" class to position the sidebar without
  * overlapping the footer.
- *
- * @return {boolean} True if the sidebar is at the bottom of the page.
  */
 function onScroll() {
 	// Only run the scroll code if the sidebar is floating on a wide screen.
-	if ( ! mainEl || ! container || ! window.matchMedia( '(min-width: 1200px)' ).matches ) {
-		return false;
+	if ( ! window.matchMedia( '(min-width: 1200px)' ).matches ) {
+		return;
 	}
 
-	const scrollPosition = window.scrollY - ADMIN_BAR_HEIGHT;
-
-	if ( ! container.classList.contains( 'is-bottom-sidebar' ) ) {
-		const footerStart = mainEl.offsetTop + mainEl.offsetHeight;
-		// The pixel location of the bottom of the sidebar, relative to the top of the page.
-		const sidebarBottom = scrollPosition + container.offsetHeight + container.offsetTop - ADMIN_BAR_HEIGHT;
-
-		// Is the sidebar bottom crashing into the footer?
-		if ( footerStart - SPACE_FROM_BOTTOM < sidebarBottom ) {
-			container.classList.add( 'is-bottom-sidebar' );
-
-			// Bottom sidebar is absolutely positioned, so we need to set the top relative to the page origin.
-			// The pixel location of the top of the sidebar, relative to the footer.
-			const sidebarTop =
-				footerStart - container.offsetHeight - LOCAL_NAV_HEIGHT * 2 + ADMIN_BAR_HEIGHT - SPACE_FROM_BOTTOM;
-			container.style.setProperty( 'top', `${ sidebarTop }px` );
-
-			return true;
-		}
-	} else if ( container.getBoundingClientRect().top > LOCAL_NAV_HEIGHT * 2 + ADMIN_BAR_HEIGHT ) {
-		// If the top of the sidebar is above the top fixing position, switch back to just a fixed sidebar.
-		container.classList.remove( 'is-bottom-sidebar' );
-		container.style.removeProperty( 'top' );
-	}
+	const { scrollY, innerHeight: windowHeight } = window;
+	// const footerTop = footer.getBoundingClientRect().top;
+	const scrollPosition = scrollY - ADMIN_BAR_HEIGHT;
 
 	// Toggle the fixed position based on whether the scrollPosition is greater than the initial gap from the top.
 	container.classList.toggle( 'is-fixed-sidebar', scrollPosition > SCROLL_POSITION_TO_FIX );
 
-	return false;
-}
+	const footerStart = mainEl.offsetTop + mainEl.offsetHeight;
 
-function isSidebarWithinViewport() {
-	if ( ! container ) {
-		return false;
+	// Is footerStart visible in the viewport?
+	if ( footerStart < scrollPosition + windowHeight ) {
+		container.style.setProperty( 'height', `${ footerStart - scrollPosition - container.offsetTop }px` );
+	} else {
+		container.style.removeProperty( 'height' );
 	}
-	// Usable viewport height.
-	const viewHeight = window.innerHeight - LOCAL_NAV_HEIGHT + ADMIN_BAR_HEIGHT;
-	// Get the height of the sidebar, plus the top offset and 60px for the
-	// "Back to top" link, which isn't visible until `is-fixed-sidebar` is
-	// added, therefore not included in the offsetHeight value.
-	const sidebarHeight = container.offsetHeight + LOCAL_NAV_HEIGHT + 60;
-	// If the sidebar is shorter than the view area, apply the class so
-	// that it's fixed and scrolls with the page content.
-	return sidebarHeight < viewHeight;
 }
 
 function init() {
@@ -109,30 +75,9 @@ function init() {
 		} );
 	}
 
-	if ( isSidebarWithinViewport() ) {
+	if ( mainEl && container ) {
 		onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).
 		window.addEventListener( 'scroll', onScroll );
-
-		const observer = new window.ResizeObserver( () => {
-			// If the sidebar is positioned at the bottom and mainEl resizes,
-			// it will remain fixed at the previous bottom position, leading to a broken page layout.
-			// In this case manually trigger the scroll handler to reposition.
-			if ( container.classList.contains( 'is-bottom-sidebar' ) ) {
-				container.classList.remove( 'is-bottom-sidebar' );
-				container.style.removeProperty( 'top' );
-				const isBottom = onScroll();
-				// After the sidebar is repositioned, also adjusts the scroll position
-				// to a point where the sidebar is visible.
-				if ( isBottom ) {
-					window.scrollTo( {
-						top: container.offsetTop - FIXED_HEADER_HEIGHT,
-						behavior: 'instant',
-					} );
-				}
-			}
-		} );
-
-		observer.observe( mainEl );
 	}
 
 	// If there is no table of contents, hide the heading.

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -10,7 +10,7 @@ const ADMIN_BAR_HEIGHT = parseInt(
 const SPACE_TO_TOP = getCustomPropValue( '--wp--custom--wporg-sidebar-container--spacing--margin--top' ) || 80;
 const SCROLL_POSITION_TO_FIX = GLOBAL_NAV_HEIGHT + SPACE_TO_TOP - ADMIN_BAR_HEIGHT;
 
-let container;
+let containers;
 let mainEl;
 
 /**
@@ -45,23 +45,29 @@ function onScroll() {
 	const scrollPosition = scrollY - ADMIN_BAR_HEIGHT;
 
 	// Toggle the fixed position based on whether the scrollPosition is greater than the initial gap from the top.
-	container.classList.toggle( 'is-fixed-sidebar', scrollPosition > SCROLL_POSITION_TO_FIX );
+	containers.forEach( ( container ) => {
+		container.classList.toggle( 'is-fixed-sidebar', scrollPosition > SCROLL_POSITION_TO_FIX );
+	} );
 
 	const footerStart = mainEl.offsetTop + mainEl.offsetHeight;
 
 	// Is footerStart visible in the viewport?
 	if ( footerStart < scrollPosition + windowHeight ) {
-		container.style.setProperty( 'height', `${ footerStart - scrollPosition - container.offsetTop }px` );
+		containers.forEach( ( container ) => {
+			container.style.setProperty( 'height', `${ footerStart - scrollPosition - container.offsetTop }px` );
+		} );
 	} else {
-		container.style.removeProperty( 'height' );
+		containers.forEach( ( container ) => {
+			container.style.removeProperty( 'height' );
+		} );
 	}
 }
 
 function init() {
-	container = document.querySelector( '.wp-block-wporg-sidebar-container' );
+	containers = document.querySelectorAll( '.wp-block-wporg-sidebar-container' );
 	mainEl = document.getElementById( 'wp--skip-link--target' );
 
-	if ( mainEl && container ) {
+	if ( mainEl && containers.length ) {
 		onScroll(); // Run once to avoid footer collisions on load (ex, when linked to #reply-title).
 		window.addEventListener( 'scroll', onScroll );
 	}

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -30,9 +30,9 @@ function getCustomPropValue( name, element = document.body ) {
 }
 
 /**
- * Check the position of the sidebar vs the height of the viewport & page
- * container, and toggle the "bottom" class to position the sidebar without
- * overlapping the footer.
+ * Check the position of each sidebar relative to the scroll position,
+ * and toggle the "fixed" class at a certain point.
+ * Reduce the height of each sidebar to stop them overlapping the footer.
  */
 function onScroll() {
 	// Only run the scroll code if the sidebar is floating on a wide screen.
@@ -41,7 +41,6 @@ function onScroll() {
 	}
 
 	const { scrollY, innerHeight: windowHeight } = window;
-	// const footerTop = footer.getBoundingClientRect().top;
 	const scrollPosition = scrollY - ADMIN_BAR_HEIGHT;
 
 	// Toggle the fixed position based on whether the scrollPosition is greater than the initial gap from the top.
@@ -51,7 +50,7 @@ function onScroll() {
 
 	const footerStart = mainEl.offsetTop + mainEl.offsetHeight;
 
-	// Is footerStart visible in the viewport?
+	// Is the footer visible in the viewport?
 	if ( footerStart < scrollPosition + windowHeight ) {
 		containers.forEach( ( container ) => {
 			container.style.setProperty( 'height', `${ footerStart - scrollPosition - container.offsetTop }px` );

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -45,7 +45,10 @@ function onScroll() {
 
 	// Toggle the fixed position based on whether the scrollPosition is greater than the initial gap from the top.
 	containers.forEach( ( container ) => {
-		container.classList.toggle( 'is-fixed-sidebar', scrollPosition > SCROLL_POSITION_TO_FIX );
+		container.classList.toggle(
+			'is-fixed-sidebar',
+			scrollPosition > SCROLL_POSITION_TO_FIX - getCustomPropValue( '--local--padding-top', container )
+		);
 	} );
 
 	const footerStart = mainEl.offsetTop + mainEl.offsetHeight;

--- a/mu-plugins/blocks/sidebar-container/src/view.js
+++ b/mu-plugins/blocks/sidebar-container/src/view.js
@@ -72,7 +72,10 @@ function createScrollHandler( container ) {
  * Show hidden containers after layout.
  */
 function onResize() {
-	adminBarHeight = getCustomPropValue( '--wp-admin--admin-bar--height' ) || 32;
+	adminBarHeight = parseInt(
+		window.getComputedStyle( document.documentElement ).getPropertyValue( 'margin-top' ),
+		10
+	);
 	globalNavHeight = getCustomPropValue( '--wp-global-header-height' ) || 90;
 
 	containers.forEach( ( container ) => {

--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -56,11 +56,14 @@ function render( $attributes, $content, $block ) {
 	$title = apply_filters( 'wporg_table_of_contents_heading', __( 'In this article', 'wporg' ), $post->ID );
 
 	$content = '<div class="wporg-table-of-contents__header">';
-	$content .= do_blocks(
-		'<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"normal","fontFamily":"inter"} -->
-		<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="margin-top:0;margin-bottom:0;font-style:normal;font-weight:400">' . esc_html( $title ) . '</h2>
-		<!-- /wp:heading -->'
-	);
+	// If there is no content, don't render the heading.
+	$content .= empty( trim( wp_strip_all_tags( $post_content ) ) )
+		? '' 
+		: do_blocks(
+			'<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"normal","fontFamily":"inter"} -->
+			<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="margin-top:0;margin-bottom:0;font-style:normal;font-weight:400">' . esc_html( $title ) . '</h2>
+			<!-- /wp:heading -->'
+		);
 	$content .= '<button type="button" class="wporg-table-of-contents__toggle" aria-expanded="false">';
 	$content .= '<span class="screen-reader-text">' . esc_html__( 'Table of Contents', 'wporg' ) . '</span>';
 	$content .= '</button>';

--- a/mu-plugins/blocks/table-of-contents/index.php
+++ b/mu-plugins/blocks/table-of-contents/index.php
@@ -56,14 +56,11 @@ function render( $attributes, $content, $block ) {
 	$title = apply_filters( 'wporg_table_of_contents_heading', __( 'In this article', 'wporg' ), $post->ID );
 
 	$content = '<div class="wporg-table-of-contents__header">';
-	// If there is no content, don't render the heading.
-	$content .= empty( trim( wp_strip_all_tags( $post_content ) ) )
-		? '' 
-		: do_blocks(
-			'<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"normal","fontFamily":"inter"} -->
-			<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="margin-top:0;margin-bottom:0;font-style:normal;font-weight:400">' . esc_html( $title ) . '</h2>
-			<!-- /wp:heading -->'
-		);
+	$content .= do_blocks(
+		'<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"normal","fontFamily":"inter"} -->
+		<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="margin-top:0;margin-bottom:0;font-style:normal;font-weight:400">' . esc_html( $title ) . '</h2>
+		<!-- /wp:heading -->'
+	);
 	$content .= '<button type="button" class="wporg-table-of-contents__toggle" aria-expanded="false">';
 	$content .= '<span class="screen-reader-text">' . esc_html__( 'Table of Contents', 'wporg' ) . '</span>';
 	$content .= '</button>';

--- a/mu-plugins/blocks/table-of-contents/src/block.json
+++ b/mu-plugins/blocks/table-of-contents/src/block.json
@@ -26,5 +26,6 @@
 		}
 	},
 	"editorScript": "file:./index.js",
-	"style": "file:./style.css"
+	"style": "file:./style.css",
+	"viewScript": "file:./view.js"
 }

--- a/mu-plugins/blocks/table-of-contents/src/view.js
+++ b/mu-plugins/blocks/table-of-contents/src/view.js
@@ -1,0 +1,24 @@
+function init() {
+	const container = document.querySelector( '.wp-block-wporg-table-of-contents' );
+
+	if ( ! container ) {
+		return;
+	}
+
+	const toggleButton = container.querySelector( '.wporg-table-of-contents__toggle' );
+	const list = container.querySelector( '.wporg-table-of-contents__list' );
+
+	if ( toggleButton && list ) {
+		toggleButton.addEventListener( 'click', function () {
+			if ( toggleButton.getAttribute( 'aria-expanded' ) === 'true' ) {
+				toggleButton.setAttribute( 'aria-expanded', false );
+				list.removeAttribute( 'style' );
+			} else {
+				toggleButton.setAttribute( 'aria-expanded', true );
+				list.setAttribute( 'style', 'display:block;' );
+			}
+		} );
+	}
+}
+
+window.addEventListener( 'load', init );


### PR DESCRIPTION
See https://github.com/WordPress/wporg-developer/issues/453

This PR modifies the sidebar container so that once it becomes fixed, it also scrolls internally. When the footer collides with the bottom of the sidebar, the sidebar reduces in height rather than starting to scroll with the page.

It has been decoupled from the Table of Contents so that it can be used for the Developer Chapter List as well. JS changes are required to enable handling multiple sidebar containers on the page.

The scrolling areas have custom scrollbars so that they appear on hover. This has been inspired by the React docs ([example](https://react.dev/reference/react/legacy)), and should help users discover that these are scrollable more easily. With the typical Mac OS setting of hidden scrollbars, it is not immediately obvious. Note that this does not work in Firefox.

Overall this is a much simpler implementation, with no top positioning required, and no listener for `main` height changes.

### Testing

The Sidebar Container is currently used on [Developer Resources](https://developer.wordpress.org/wp-admin/) and [Documentation](https://wordpress.org/documentation).

#### Things to test

- Fixing and scrolling on pages with long and short ToCs and Chapter Lists
- Expand and collapse behaviour of ToC on small screens
- Scrollbars being shown on hover
- Show more/less Related items on Code Reference pages like http://localhost:8888/reference/functions/is_admin/

Use https://github.com/WordPress/wporg-developer/pull/447 to test Developer Resources

Documentation requires no changes, so you can use [that local environment](https://github.com/WordPress/wporg-documentation-2022) as is, and switch the mu-plugins install to this branch.