### PR TITLE
Table of Contents: Make whole header clickable on small and medium screens

### DIFF
--- a/mu-plugins/blocks/table-of-contents/postcss/style.pcss
+++ b/mu-plugins/blocks/table-of-contents/postcss/style.pcss
@@ -7,32 +7,38 @@
 	@media (max-width: 1199px) {
 		border: 1px solid var(--wp--preset--color--light-grey-1);
 		border-radius: 2px;
-		padding: 15px var(--wp--preset--spacing--20);
 	}
 }
 
 .wporg-table-of-contents__header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+	position: relative;
+
+	@media (max-width: 1199px) {
+		padding: 15px var(--wp--preset--spacing--20);
+	}
 
 	.wp-block-heading {
 		margin-bottom: 0;
 	}
 
 	.wporg-table-of-contents__toggle {
-		font-size: inherit;
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
 		background-color: transparent;
 		border: none;
-		padding: 0;
-		cursor: pointer;
-		height: var(--local--icon-size);
+		padding: 0 var(--wp--preset--spacing--20) 0 0;
 
 		@media (min-width: 1200px) {
 			display: none;
 		}
 
-		&::before {
+		&::after {
 			content: "";
 			display: inline-block;
 			height: var(--local--icon-size);
@@ -44,7 +50,7 @@
 			background-color: var(--wp--preset--color--charcoal-4);
 		}
 
-		&[aria-expanded="true"]::before {
+		&[aria-expanded="true"]::after {
 			transform: revert;
 			background-color: var(--wp--preset--color--charcoal-1);
 		}
@@ -66,6 +72,8 @@
 	@media (max-width: 1199px) {
 		display: none;
 		margin-bottom: 0;
+		margin-top: 0;
+		padding: 0 var(--wp--preset--spacing--20) 15px;
 	}
 
 	& li {


### PR DESCRIPTION
Fixes #547 

I've decided to use absolute positioning to make the toggle button fill the header, so that the H2 doesn't need to be hidden and removed from the markup, thus maintaining the page structure. No visual changes.

If this approach is acceptable I'll follow on with the same for the Chapter List, in the Developer Resources repo. For now that remains a separate UI component, as there is further discussed functionality for it, like the ability to collapse left.

### Testing

The ToC block is used on Documentation and Developer Resources. Using one of those local environments, or sandbox, switch mu-plugins to this branch.

1. Open pages using the ToC, eg. [Code Reference](https://developer.wordpress.org/reference/classes/wp_query/), [Block Editor ](https://developer.wordpress.org/block-editor/) or [Optimization](https://wordpress.org/documentation/article/optimization/)
2. On screens < 1200px wide with the ToC inline, the toggle button should fill the header.
3. Expand and contract the ToC
4. Check for regressions on large screens