### PR TITLE
Header: Shrink inline padding to match top-level text alignment

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -218,7 +218,7 @@
 			padding: calc(var(--wp--style--block-gap) / 4);
 
 			@media (--tablet) {
-				padding: calc(var(--wp--style--block-gap) / 2) var(--wp--style--block-gap);
+				padding: calc(var(--wp--style--block-gap) / 2);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #559. This updates the padding to be the same on the header items as in the submenus, so that the text alignment is the same.

| Before | After |
|---|---|
| <img width="412" alt="" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/a575eedd-bd93-4835-bd60-f107a2e58c2d"> | <img width="419" alt="" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/cd97e56d-7416-4e80-908c-5de38bf07c03"> |
| <img width="375" alt="" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/41e04329-23f2-42c9-9ef3-fabc62b43cbf"> | <img width="395" alt="" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/b6baf926-eefe-41df-b4d9-8274aa3be384"> |



