### PR TITLE
Meetup Client: Handle Errors better

### DIFF
--- a/mu-plugins/utilities/class-meetup-client.php
+++ b/mu-plugins/utilities/class-meetup-client.php
@@ -508,8 +508,10 @@ class Meetup_Client extends API_Client {
 
 		$result = $this->send_paginated_request( $query, $variables );
 
-		if ( is_wp_error( $result ) || ! array_key_exists( 'groupsSearch', $result['proNetworkByUrlname'] ) ) {
+		if ( is_wp_error( $result ) ) {
 			return $result;
+		} elseif ( empty( $result['proNetworkByUrlname'] ) ) {
+			return new WP_Error( 'not_found', 'Invalid API response.' );
 		}
 
 		$groups = array_column(
@@ -588,15 +590,13 @@ class Meetup_Client extends API_Client {
 
 		$result = $this->send_paginated_request( $query, $variables );
 
-		if ( is_wp_error( $result ) || ! array_key_exists( 'event', $result ) ) {
+		if ( is_wp_error( $result ) ) {
 			return $result;
+		} elseif ( empty( $result['event'] ) ) {
+			return false;
 		}
 
-		$event = $result['event'] ?: false;
-
-		if ( $event ) {
-			$event = $this->apply_backcompat_fields( 'event',  $event );
-		}
+		$event = $this->apply_backcompat_fields( 'event',  $result['event'] );
 
 		return $event;
 	}
@@ -693,8 +693,10 @@ class Meetup_Client extends API_Client {
 
 		$result = $this->send_paginated_request( $query, $variables );
 
-		if ( is_wp_error( $result ) || ! isset( $result['groupByUrlname'] ) ) {
+		if ( is_wp_error( $result ) ) {
 			return $result;
+		} elseif ( empty( $result['groupByUrlname'] ) ) {
+			return new WP_Error( 'not_found', 'Invalid API response.' );
 		}
 
 		// Format it similar to previous response payload.
@@ -755,8 +757,10 @@ class Meetup_Client extends API_Client {
 		);
 
 		$results = $this->send_paginated_request( $query, $variables );
-		if ( is_wp_error( $results ) || ! isset( $results['groupByUrlname'] ) ) {
+		if ( is_wp_error( $results ) ) {
 			return $results;
+		} elseif ( empty( $results['groupByUrlname'] ) ) {
+			return new WP_Error( 'not_found', 'Invalid API response.' );
 		}
 
 		// Select memberships.edges[*].node.
@@ -830,11 +834,9 @@ class Meetup_Client extends API_Client {
 
 		$results = $this->send_paginated_request( $query, $variables );
 
-		if ( is_wp_error( $results ) || ! array_key_exists( 'eventsSearch', $results['proNetworkByUrlname'] ) ) {
+		if ( is_wp_error( $results ) ) {
 			return $results;
-		}
-
-		if ( empty( $results['proNetworkByUrlname']['eventsSearch'] ) ) {
+		} elseif ( empty( $results['proNetworkByUrlname']['eventsSearch'] ) ) {
 			return array();
 		}
 
@@ -953,8 +955,10 @@ class Meetup_Client extends API_Client {
 		);
 
 		$results = $this->send_paginated_request( $query, $variables );
-		if ( is_wp_error( $results ) || ! isset( $results['groupByUrlname'] ) ) {
+		if ( is_wp_error( $results ) ) {
 			return $results;
+		} elseif ( empty( $results['groupByUrlname'] ) ) {
+			return new WP_Error( 'not_found', 'Invalid API response.' );
 		}
 
 		// Select {$event_field}.edges[*].node.
@@ -1029,7 +1033,7 @@ class Meetup_Client extends API_Client {
 			return $results;
 		}
 
-		return (int) $results['proNetworkByUrlname']['groupsSearch']['count'];
+		return (int) $results['proNetworkByUrlname']['groupsSearch']['count'] ?? 0;
 	}
 
 	/**


### PR DESCRIPTION
The Meetup GraphQL API can return a `NULL` response, when we'd usually expect an error to be returned.

An example of this is when a query is made to a non-existent group:
```
$client->get_group_details( 'A-Group-That-No-Exist' );
```

This has a flow-on effect to uses of this client, as a non-false/non-error result is returned, that's often just `[ 'groupByUrlname' => NULL ]`