### PR TITLE
Table of Contents: Update inline breakpoint to 1300px

### DIFF
--- a/mu-plugins/blocks/sidebar-container/src/block.json
+++ b/mu-plugins/blocks/sidebar-container/src/block.json
@@ -14,7 +14,7 @@
 		},
 		"inlineBreakpoint": {
 			"type": "string",
-			"default": "1200px"
+			"default": "1300px"
 		}
 	},
 	"supports": {

--- a/mu-plugins/blocks/table-of-contents/postcss/style.pcss
+++ b/mu-plugins/blocks/table-of-contents/postcss/style.pcss
@@ -4,7 +4,7 @@
 
 	font-size: var(--wp--preset--font-size--small);
 
-	@media (max-width: 1199px) {
+	@media (max-width: 1299px) {
 		border: 1px solid var(--wp--preset--color--light-grey-1);
 		border-radius: 2px;
 	}
@@ -13,7 +13,7 @@
 .wporg-table-of-contents__header {
 	position: relative;
 
-	@media (max-width: 1199px) {
+	@media (max-width: 1299px) {
 		padding: 15px var(--wp--preset--spacing--20);
 	}
 
@@ -34,7 +34,7 @@
 		border: none;
 		padding: 0 var(--wp--preset--spacing--20) 0 0;
 
-		@media (min-width: 1200px) {
+		@media (min-width: 1300px) {
 			display: none;
 		}
 
@@ -69,7 +69,7 @@
 	line-height: 1.6;
 	list-style: none;
 
-	@media (max-width: 1199px) {
+	@media (max-width: 1299px) {
 		display: none;
 		margin-bottom: 0;
 		margin-top: 0;


### PR DESCRIPTION
Closes #566 

Changes the breakpoint where the Table of Content becomes inline and collapsed from 1200px to 1300px, see discussion on issue.

Sites affected: [Developer Resources](https://developer.wordpress.org) and [Documentation](https://wordpress.org/documentation).

This has the greatest effect on the Developer Resources 3 column layout used for handbooks, eg. https://developer.wordpress.org/block-editor/ where making the ToC inline earlier allows the content column to be wider on screens > 1200px and < 1300px.

## Screenshots

https://github.com/WordPress/wporg-mu-plugins/assets/1017872/7271ff9c-3776-4fd9-935c-8cd806f2bc59

## Testing

### Dev Resources
Easiest to test using Dev Resources local env, see https://github.com/WordPress/wporg-developer/pull/491 for testing instructions

### Docs
There are no code changes required in this repo, simply ensure your mu-plugins is on this branch and check the breakpoint works as expected on an article page like http://localhost:8888/article/faq-working-with-wordpress/
