### PR TITLE
Don't overwrite position 0 plugins when running in a switched context

### DIFF
--- a/mu-plugins/plugin-tweaks/incompatible-plugins.php
+++ b/mu-plugins/plugin-tweaks/incompatible-plugins.php
@@ -61,39 +61,35 @@ function filter_the_filters() {
 			continue;
 		}
 
-		if ( in_array( $from, $active_plugins, true ) ) {
-			add_filter(
-				'option_active_plugins',
-				function( $plugins ) use ( $from, $to ) {
-					$pos = array_search( $from, $plugins, true );
-					if ( false !== $pos ) {
-						// Splice to retain load order, if it's important.
-						array_splice(
-							$plugins,
-							$pos,
-							1,
-							$to
-						);
-					}
-
-					return $plugins;
+		add_filter(
+			'option_active_plugins',
+			function( $plugins ) use ( $from, $to ) {
+				$pos = array_search( $from, $plugins, true );
+				if ( false !== $pos ) {
+					// Splice to retain load order, if it's important.
+					array_splice(
+						$plugins,
+						$pos,
+						1,
+						$to
+					);
 				}
-			);
-		}
 
-		if ( isset( $active_sitewide_plugins[ $from ] ) ) {
-			add_filter(
-				'site_option_active_sitewide_plugins',
-				function( $plugins ) use ( $from, $to ) {
-					if ( isset( $plugins[ $from ] ) ) {
-						$plugins[ $to ] = $plugins[ $from ];
-						unset( $plugins[ $from ] );
-					}
+				return $plugins;
+			}
+		);
 
-					return $plugins;
+		add_filter(
+			'site_option_active_sitewide_plugins',
+			function( $plugins ) use ( $from, $to ) {
+				if ( isset( $plugins[ $from ] ) ) {
+					$plugins[ $to ] = $plugins[ $from ];
+					unset( $plugins[ $from ] );
 				}
-			);
-		}
+
+				return $plugins;
+			}
+		);
 	}
 }
 


### PR DESCRIPTION
As a followup to #561 some fatal were encountered in a cron task.

It turns out that the flow is something like this:
1. Cron Load Pattern Directory
2. This kicks in, realises that it should load Gutenberg-16.8
3. The Pattern Directory code switches to the Translate.wordpress.org site, and includes the translate plugins
4. Translate.wordpress.org doesn't have the Gutenberg plugin active
   - `active_plugins[ array_search() = false ]` translates to `active_plugins[0] = gutenberg-16.8/...`, which was previously glotpress, not gutenberg.
   - It then loads the other GlotPress plugins that require GlotPress to be active first, and fatals.

Supporting loading plugins for a switched site is not something that WordPress really allows for; but is something that can be done "good enough" if the two sites are running an almost different set of plugins. For example; the Pattern Directory does it like this:
https://github.com/WordPress/pattern-directory/blob/43e0eedfba131cd1fdfc24ac2939a48629acff2e/public_html/wp-content/plugins/pattern-translations/includes/makepot.php#L166-L189

This PR just verifies that the `$from` plugin is actually in the array before mangling it.

I considered using `blog_id` checks or checking that `$check` exists in the array at filter time; but this isn't enough.
Consider the following, SiteA should be filtered to `gutenberg-16.8` and if the plugins for SiteB get loaded, it should also load that same version of Gutenberg to avoid conflicts.
 - SiteA: `gutenberg`, `plugin-that-causes-gutenberg-16.8-to-load`.
 - SiteB: `gutenberg`, `translation-plugin`