### PR TITLE
Navigation: Add support for submenu items in the hardcoded menus

### DIFF
--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -114,6 +114,7 @@
 	/* Navigation. */
 
 	/* Remove padding from menu items with background color, which is used to color the modal background. */
+	& .wp-block-navigation ul.has-background,
 	& .wp-block-navigation:where(.has-background) .wp-block-navigation-item a:not(.wp-element-button),
 	& .wp-block-navigation:where(.has-background) .wp-block-navigation-submenu a:not(.wp-element-button) {
 		padding: 0;
@@ -130,6 +131,13 @@
 			padding-left: var(--wp--preset--spacing--edge-space) !important;
 			padding-top: 21px !important;
 			padding-bottom: 18px !important;
+
+			& .wp-block-navigation__submenu-container {
+				padding: 0 !important;
+				padding-inline-start: var(--wp--preset--spacing--20, 20px) !important;
+				margin-top: var(--wp--preset--spacing--20, 20px) !important;
+				gap: var(--wp--preset--spacing--20, 20px) !important;
+			}
 		}
 	}
 

--- a/mu-plugins/blocks/navigation/index.php
+++ b/mu-plugins/blocks/navigation/index.php
@@ -94,6 +94,34 @@ function get_menu_content( $menu_slug ) {
 
 	$menu_content = '';
 	foreach ( $menu_items as $item ) {
+		$menu_content .= render_menu_item( $item );
+	}
+
+	return $menu_content;
+}
+
+/**
+ * Render an individual navigation item, to support recursively building submenus.
+ *
+ * @param array $item
+ *
+ * @return string Menu item in block syntax.
+ */
+function render_menu_item( $item ) {
+	$output = '';
+
+	if ( isset( $item['submenu'] ) ) {
+		$output = sprintf(
+			'<!-- wp:navigation-submenu {"label":"%1$s","url":"#","kind":"custom"} -->',
+			$item['label']
+		);
+
+		foreach ( $item['submenu'] as $submenu_item ) {
+			$output .= render_menu_item( $submenu_item, false );
+		}
+
+		$output .= '<!-- /wp:navigation-submenu -->';
+	} else {
 		$block_code = '<!-- wp:navigation-link {"label":"%1$s","url":"%2$s","kind":"custom"} /-->';
 
 		// If this is a relative link, convert it to absolute and try to find
@@ -108,7 +136,7 @@ function get_menu_content( $menu_slug ) {
 			}
 		}
 
-		$menu_content .= sprintf(
+		$output .= sprintf(
 			$block_code,
 			esc_html( $item['label'] ),
 			esc_url( $item['url'], ),
@@ -116,7 +144,7 @@ function get_menu_content( $menu_slug ) {
 		);
 	}
 
-	return $menu_content;
+	return $output;
 }
 
 /**


### PR DESCRIPTION
This updates the Navigation block filter to enable a `submenu` config to allow nested navigation, and adds style to the Local Navigation Bar to better style nested menus on small screens.

Currently, this only supports submenus that open on click (matching the behavior of the global nav). If we need linked parent elements, we can add `url` support in the future.

See #535.

**To test**

Try with the About PR https://github.com/WordPress/wporg-main-2022/pull/387, or add a menu with a `submenu` to the config for any site:

```php
add_filter(
	'wporg_block_navigation_menus',
	function( $menus ) {
		return array(
			'test' => array(
				array(
					'label' => 'News',
					'url' => '#',
				),
				array(
					'label' => 'About',
					'submenu' => array(
						array(
							'label' => 'Item A',
							'url' => '#',
						),
						array(
							'label' => 'Item B',
							'url' => '#',
						),
					),
				),
			),
		);
	}
);
```

Use this menu with the following code:

```html
<!-- wp:navigation {"menuSlug":"test","textColor":"blueberry-1","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","openSubmenusOnClick":true} /-->
```

The navigation should render correctly - using the hierarchy - and there should be no PHP errors.