### PR TITLE
Query Filter: Don't display by default in mobile viewports

### DIFF
--- a/mu-plugins/blocks/query-filter/src/style.pcss
+++ b/mu-plugins/blocks/query-filter/src/style.pcss
@@ -245,10 +245,12 @@
 	}
 
 	.wporg-query-filter__modal-backdrop {
+		display: none;
 		background-color: rgba(0, 0, 0, 0.15);
 	}
 
 	.wporg-query-filter__modal {
+		display: none;
 		position: fixed;
 		top: 20vh;
 		bottom: 20vh;
@@ -300,6 +302,10 @@
 
 
 	.is-modal-open {
+		& .wporg-query-filter__modal {
+			display: block;
+		}
+
 		& .wporg-query-filter__modal-backdrop {
 			display: block;
 		}


### PR DESCRIPTION
The Query Filter block should be hidden by default for mobile viewports, unless the modal is open.

The modal is hidden on load with Javascript, causing a white flash of the modal before being hidden.

This was easiest tested with Javascript disabled.

H/T @StevenDufresne for the report.