### PR TITLE
Set overflow scroll behaviour to auto

### DIFF
--- a/mu-plugins/blocks/query-filter/src/style.pcss
+++ b/mu-plugins/blocks/query-filter/src/style.pcss
@@ -121,7 +121,7 @@
 	margin: 0;
 	padding: var(--wp--preset--spacing--10);
 	max-height: 18rem;
-	overflow: scroll;
+	overflow-y: auto;
 	border: none;
 }
 

--- a/mu-plugins/blocks/sidebar-container/postcss/style.pcss
+++ b/mu-plugins/blocks/sidebar-container/postcss/style.pcss
@@ -30,7 +30,7 @@
 
 		width: var(--local--block-end-sidebar--width);
 		padding-bottom: var(--local--padding);
-		overflow-y: scroll;
+		overflow-y: auto;
 		overscroll-behavior: contain;
 		scrollbar-color: var(--wp--preset--color--charcoal-5) transparent;
 

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -11,7 +11,7 @@
 	}
 
 	& .wporg-site-breadcrumbs__wrapper {
-		overflow: scroll;
+		overflow-x: auto;
 		text-overflow: clip;
 		white-space: nowrap;
 


### PR DESCRIPTION
Fixes #575 

This stops the scrollbar controls always being shown when device preferences are set to show scrollbars.

Changes are made to Breadcrumbs and Sidebar Container blocks.

### Screenshots

| Before | After | After scrolled |
|-|-|-|
| ![Screenshot 2024-02-15 at 4 26 08 PM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/3c04841f-0611-4a2a-85fe-bb528a167925) | ![Screenshot 2024-02-15 at 4 32 27 PM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/bc6d5e91-1a6f-4556-9b7c-9b9280539309) | ![Screenshot 2024-02-15 at 4 32 47 PM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/fac9b754-45c6-4e1e-a61a-b9c662a6b5fd) |

### Testing

1. Use a theme like Developer Resources or Documentation and load this branch.
2. Set your preferences to always show scrollbars. Seems to be the default behaviour on Windows. Needs to be set in MacOS Appearance settings.
3. Check that when the breadcrumb wrapper and sidebar container are not overflowing, no scrollbar controls are displayed.
4. Check that when the breadcrumb wrapper and sidebar container ore overflowing they are still scrollable and scrollbar controls appear.
