### PR TITLE
Allow the language suggest to use an alternate API endpoint.

### DIFF
--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -5,7 +5,9 @@ const init = () => {
 		return;
 	}
 
-	const endpoint = container.dataset.endpoint || 'https://wordpress.org/lang-guess/lang-guess-ajax.php?uri=' + encodeURIComponent( window.location.pathname );
+	const endpoint =
+		container.dataset.endpoint ||
+		'https://wordpress.org/lang-guess/lang-guess-ajax.php?uri=' + encodeURIComponent( window.location.pathname );
 
 	fetch( endpoint )
 		.then( ( response ) => {

--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -7,7 +7,8 @@ const init = () => {
 
 	const endpoint =
 		container.dataset.endpoint ||
-		'https://wordpress.org/lang-guess/lang-guess-ajax.php?uri=' + encodeURIComponent( window.location.pathname );
+		'https://wordpress.org/lang-guess/lang-guess-ajax.php?uri=' +
+			encodeURIComponent( window.location.pathname );
 
 	fetch( endpoint )
 		.then( ( response ) => {

--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -5,9 +5,9 @@ const init = () => {
 		return;
 	}
 
-	const uri = encodeURIComponent( window.location.pathname );
+	const endpoint = container.dataset.endpoint || 'https://wordpress.org/lang-guess/lang-guess-ajax.php?uri=' + encodeURIComponent( window.location.pathname );
 
-	fetch( `https://wordpress.org/lang-guess/lang-guess-ajax.php?uri=${ uri }` )
+	fetch( endpoint )
 		.then( ( response ) => {
 			if ( ! response.ok ) {
 				throw Error( response.statusText );


### PR DESCRIPTION
This allows the language-suggest endpoint to be customised to allow the plugin directory to re-use this block.