### PR TITLE
Override the visited link color for affected blocks

### DIFF
--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -53,6 +53,10 @@
 			border-radius: 2px;
 			box-shadow: inset 0 0 0 1.5px var(--wp--custom--local-navigation-bar--focus--color);
 		}
+
+		&:visited {
+			color: var(--wp--preset--color--white);
+		}
 	}
 
 	&:not(.is-sticking) {

--- a/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
+++ b/mu-plugins/blocks/site-breadcrumbs/postcss/style.pcss
@@ -30,6 +30,10 @@
 		&:hover {
 			text-decoration-line: underline;
 		}
+
+		&:visited {
+			color: var(--wp--preset--color--charcoal-4);
+		}
 	}
 
 	& span {


### PR DESCRIPTION
See https://github.com/WordPress/wporg-parent-2021/issues/128

Visited link color is being added to the parent theme. This PR overrides that color for blocks which have specific styles.