### PR TITLE
Query Filter: Update style and behavior of single-select filters

### DIFF
--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -57,6 +57,15 @@ $button_classes = array_keys(
 	)
 );
 
+$modal_classes = array_keys(
+	array_filter(
+		array(
+			'wporg-query-filter__modal' => true,
+			'is-single-select' => ! $has_multiple,
+		)
+	)
+);
+
 if ( $selected_count && $has_multiple ) {
 	/* translators: %s is count of currently selected filters. */
 	$apply_label = sprintf( __( 'Apply (%s)', 'wporg' ), $selected_count );
@@ -87,7 +96,7 @@ if ( $selected_count && $has_multiple ) {
 	></div>
 
 	<div
-		class="wporg-query-filter__modal"
+		class="<?php echo esc_attr( implode( ' ', $modal_classes ) ); ?>"
 		id="<?php echo esc_attr( $html_id ); ?>"
 		data-wp-bind--hidden="!context.isOpen"
 		data-wp-effect--focus="effects.focusFirstElement"
@@ -146,6 +155,7 @@ if ( $selected_count && $has_multiple ) {
 			?>
 
 			<div class="wporg-query-filter__modal-actions">
+				<?php if ( $has_multiple ) : ?>
 				<input
 					type="button"
 					class="wporg-query-filter__modal-action-clear"
@@ -153,8 +163,10 @@ if ( $selected_count && $has_multiple ) {
 					data-wp-on--click="actions.clearSelection"
 					aria-disabled="<?php echo $selected_count ? 'false' : 'true'; ?>"
 				/>
+				<?php endif; ?>
 				<input
 					type="submit"
+					class="wporg-query-filter__modal-action-submit"
 					data-label-with-count="<?php echo esc_attr( $label_count ); ?>"
 					data-label=<?php esc_attr_e( 'Apply', 'wporg' ); ?>
 					value="<?php echo esc_html( $apply_label ); ?>"

--- a/mu-plugins/blocks/query-filter/src/style.pcss
+++ b/mu-plugins/blocks/query-filter/src/style.pcss
@@ -112,8 +112,25 @@
 	color: var(--wp--custom--wporg-query-filters--color--text);
 	display: none;
 
-	& .wporg-query-filter__modal-header {
+	&:where(:not(.is-single-select)) .wporg-query-filter__modal-header {
 		display: none;
+	}
+
+	& .wporg-query-filter__modal-header {
+		padding-block-start: var(--wp--preset--spacing--10);
+		padding-inline-start: calc(var(--wp--preset--spacing--10) + var(--wp--custom--wporg-query-filters--spacing--padding--inline-start));
+		padding-inline-end: var(--wp--preset--spacing--10);
+
+		& h2 {
+			margin: 0 !important;
+			font-family: var(--wp--preset--font-family--inter);
+			font-size: var(--wp--preset--font-size--small);
+			line-height: var(--wp--custom--body--small--typography--line-height);
+		}
+
+		& .wporg-query-filter__modal-close {
+			display: none;
+		}
 	}
 }
 
@@ -148,8 +165,8 @@
 		display: block;
 		margin: 0;
 		padding-block: var(--wp--custom--wporg-query-filters--spacing--padding--block);
-		padding-left: var(--wp--custom--wporg-query-filters--spacing--padding--inline-start);
-		padding-right: calc(var(--wp--custom--wporg-query-filters--spacing--padding--inline-end) * 2 + var(--wporg-query-filter--icon-size));
+		padding-left: calc(var(--wp--custom--wporg-query-filters--spacing--padding--inline-end) * 2 + var(--wporg-query-filter--icon-size));
+		padding-right: var(--wp--custom--wporg-query-filters--spacing--padding--inline-start);
 		font-size: var(--wp--preset--font-size--small);
 		line-height: var(--wp--custom--body--small--typography--line-height);
 		border-radius: 2px;
@@ -172,14 +189,10 @@
 	&:checked + label {
 		background-color: var(--wp--custom--wporg-query-filters--option--active--color--background);
 		color: var(--wp--custom--wporg-query-filters--option--active--color--text);
-	}
-
-	/* Only checkboxes can be cleared with a second click. */
-	&[type="checkbox"]:checked + label {
 		/* stylelint-disable-next-line function-url-quotes */
-		background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 13.0607L15.7123 16.773L16.773 15.7123L13.0607 12L16.773 8.28772L15.7123 7.22706L12 10.9394L8.28771 7.22705L7.22705 8.28771L10.9394 12L7.22706 15.7123L8.28772 16.773L12 13.0607Z' fill='%231E1E1E'/%3E%3C/svg%3E%0A");
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3E%3Cpath fill='%231E1E1E' fill-rule='evenodd' d='m17.93 7.978-7.2 9.681-4.516-3.358.896-1.204 3.312 2.463 6.303-8.477 1.204.895Z' clip-rule='evenodd'/%3E%3C/svg%3E%0A");
 		background-repeat: no-repeat;
-		background-position: right var(--wp--custom--wporg-query-filters--spacing--padding--inline-end) center;
+		background-position: left var(--wp--custom--wporg-query-filters--spacing--padding--inline-end) center;
 	}
 }
 
@@ -241,6 +254,10 @@
 			}
 		}
 	}
+
+	&.wporg-query-filter__modal-action-submit {
+		margin-inline-start: auto;
+	}
 }
 
 /* Update layout to floating modal on smaller screens. */
@@ -266,25 +283,20 @@
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
-			padding:
-				var(--wp--preset--spacing--10)
-				var(--wp--preset--spacing--10)
-				var(--wp--preset--spacing--10)
-				calc(var(--wp--preset--spacing--10) + var(--wp--custom--wporg-query-filters--spacing--padding--inline-start));
+			padding-block-end: var(--wp--preset--spacing--10);
 			border-bottom:
 				var(--wp--custom--wporg-query-filters--border--width)
 				var(--wp--custom--wporg-query-filters--border--style)
 				var(--wp--custom--wporg-query-filters--border--color);
 
 			& h2 {
-				margin: 0 !important;
-				font-family: var(--wp--preset--font-family--inter);
 				font-size: var(--wp--custom--button--typography--font-size);
 				line-height: var(--wp--custom--button--typography--line-height);
 				font-weight: 700;
 			}
 
 			& .wporg-query-filter__modal-close {
+				display: initial;
 				height: 40px;
 				width: 40px;
 				border: none;

--- a/mu-plugins/blocks/query-filter/src/style.pcss
+++ b/mu-plugins/blocks/query-filter/src/style.pcss
@@ -117,7 +117,7 @@
 	}
 
 	& .wporg-query-filter__modal-header {
-		padding-block-start: var(--wp--preset--spacing--10);
+		padding-block-start: calc(var(--wp--preset--spacing--10) + 8px);
 		padding-inline-start: calc(var(--wp--preset--spacing--10) + var(--wp--custom--wporg-query-filters--spacing--padding--inline-start));
 		padding-inline-end: var(--wp--preset--spacing--10);
 
@@ -283,7 +283,7 @@
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
-			padding-block-end: var(--wp--preset--spacing--10);
+			padding-block: var(--wp--preset--spacing--10);
 			border-bottom:
 				var(--wp--custom--wporg-query-filters--border--width)
 				var(--wp--custom--wporg-query-filters--border--style)

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -70,7 +70,9 @@ const { actions } = store( 'wporg/query-filter', {
 				}
 			}
 
-			clearButton.setAttribute( 'aria-disabled', count ? 'false' : 'true' );
+			if ( clearButton ) {
+				clearButton.setAttribute( 'aria-disabled', count ? 'false' : 'true' );
+			}
 		},
 
 		toggle: () => {


### PR DESCRIPTION
Fixes #594 — This implements the new design for single-select filters, which removes "Clear" and shows a heading in the dropdown at all screen sizes. This also changes the selected style from an ✖️  to a ✔️  on multiple-choice filters, since the same applies to single.

This has a corresponding patterns PR which updates the labels: https://github.com/WordPress/pattern-directory/pull/656

**Screenshots**

|  | Screenshot | 
|---|---|
| Home | ![home-default](https://github.com/WordPress/wporg-mu-plugins/assets/541093/26cd0c83-1174-41a1-84d5-046539f27a9c) |
| "Filter" open | ![home-filter-open](https://github.com/WordPress/wporg-mu-plugins/assets/541093/dfc7af5d-a22b-4ed1-9684-11a2f14dacf5) |
| "Sort" open | ![home-sort-open](https://github.com/WordPress/wporg-mu-plugins/assets/541093/d697ca26-ffe4-4743-93a0-a1cc8d9add9a) |
| All patterns | ![all-patterns-default](https://github.com/WordPress/wporg-mu-plugins/assets/541093/aaae25be-bcf5-41a2-b87a-370eff3330ff) |
| All patterns, with filters applied | ![all-patterns-filtered](https://github.com/WordPress/wporg-mu-plugins/assets/541093/e3cdeb3f-7c03-4d31-b7ce-00ae1342556f) |
| Multiple select, with some selected | ![multiple-open](https://github.com/WordPress/wporg-mu-plugins/assets/541093/9bba1284-1b3c-40a5-bc78-be1969c0839e) |
| Multiple select, none selected | ![multiple-open-empty](https://github.com/WordPress/wporg-mu-plugins/assets/541093/9187b40c-a12d-404d-b1f8-c8a18a3eb693) |
| Mobile (modal view) | ![modal-view](https://github.com/WordPress/wporg-mu-plugins/assets/541093/33c52edc-1802-4c7a-ae95-4c67558b8d75) |

Part of the design had "Apply" disabled until new items were checked, but we can't really do that. There's no way to differentiate between a 3 items already selected, vs 2 already selected + 1 new — they're all just selected or not.

**To test**

- Apply this PR in a project that uses query filters— showcase, patterns, events
- Open a single-select filter
- There should be no clear button
- The selected item should have a ✔️ 
- Open a multiple-select filter
- There should be a clear button
- The selected items should have a ✔️ 

The functionality should not change, applying (and clearing multi-select) filters should work.

