### PR TITLE
Local Navigation Bar: Update scroll offset to prevent local nav bar overlapping content

### DIFF
--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -1,5 +1,5 @@
 /* Set up the custom properties. These can be overridden by settings in theme.json. */
-:where(body) {
+:where(html) {
 	--wp--custom--local-navigation-bar--spacing--height: 60px;
 }
 
@@ -318,8 +318,7 @@
 }
 
 @media (min-width: 890px) {
-	/* stylelint-disable selector-id-pattern */
-	#wp--skip-link--target {
-		scroll-margin-top: var(--wp--custom--local-navigation-bar--spacing--height, 0);
+	html {
+		scroll-padding-top: calc(var(--wp--custom--local-navigation-bar--spacing--height, 0px) + var(--wp-admin--admin-bar--height, 0px));
 	}
 }

--- a/mu-plugins/blocks/table-of-contents/postcss/style.pcss
+++ b/mu-plugins/blocks/table-of-contents/postcss/style.pcss
@@ -148,6 +148,6 @@
 
 @media (min-width: 890px) {
 	.is-toc-heading {
-		scroll-margin-top: calc(var(--wp--custom--local-navigation-bar--spacing--height) + var(--wp--preset--spacing--20));
+		scroll-margin-top: var(--wp--preset--spacing--20);
 	}
 }


### PR DESCRIPTION
Fixes #586. The local nav bar overlaps content when using anchor links. There is [some code in the parent theme](https://github.com/WordPress/wporg-parent-2021/blob/624ac76935bb9c072e72ecde9b465218852c92e5/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss#L524-L529) that used to work for the sticky header, but since we unstuck the header in favor of the local nav bar, this doesn't apply anymore.

I've taken the same approach here, but put it in the Local Navigation Bar's CSS, so that it will load whenever that block is used. This adds `scroll-padding-top` to `html`, to account for the local nav bar + admin bar (if it exists).

Some child themes have added `scroll-margin-top` to individual elements, this will add extra space until it's removed, but I don't think that needs to block rolling this fix out.

**Screenshots**

Developer

| With `scroll-margin-top` on TOC headings | Without `scroll-margin-top` |
|---|---|
| ![Screen Shot 2024-04-04 at 13 00 34](https://github.com/WordPress/wporg-mu-plugins/assets/541093/e0608a90-dcab-4576-aaad-e1ef2444f0d3) | ![Screen Shot 2024-04-04 at 13 00 49](https://github.com/WordPress/wporg-mu-plugins/assets/541093/6cdd3f49-700c-4f58-be05-a86043143fc2) |

Forums, with the local `scroll-margin-top` disabled:

![forum](https://github.com/WordPress/wporg-mu-plugins/assets/541093/de060fc7-c90e-48e1-8d38-32cf5a83e16b)

Plugin FAQs

![plugins](https://github.com/WordPress/wporg-mu-plugins/assets/541093/f93683ae-73ea-4d32-a83a-e62874b1d6be)