### PR TITLE
New block: Query "Has results" to add extra content around query loops

### DIFF
--- a/mu-plugins/blocks/query-has-results/index.php
+++ b/mu-plugins/blocks/query-has-results/index.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Block Name: Has results
+ * Description: Contains the block elements to display when there are query results.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\MU_Plugins\Query_Has_Results_Block;
+
+use WP_Query;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Render the block content.
+ *
+ * Note: this mirrors the `query-no-results` block, and was initially copied from:
+ * https://github.com/WordPress/gutenberg/blob/7c25dc48244c8ff0b2585c075359ef6a5868464e/packages/block-library/src/query-no-results/index.php
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( empty( trim( $content ) ) ) {
+		return '';
+	}
+
+	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
+	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
+
+	// Override the custom query with the global query if needed.
+	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
+	if ( $use_global_query ) {
+		global $wp_query;
+		$query = $wp_query;
+	} else {
+		$query_args = build_query_vars_from_query_block( $block, $page );
+		$query      = new WP_Query( $query_args );
+	}
+
+	if ( $query->post_count <= 0 ) {
+		return '';
+	}
+
+	$classes            = ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) ? 'has-link-color' : '';
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$content
+	);
+}
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		__DIR__ . '/build',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}

--- a/mu-plugins/blocks/query-has-results/src/block.json
+++ b/mu-plugins/blocks/query-has-results/src/block.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wporg/query-has-results",
+	"title": "Has results",
+	"category": "theme",
+	"description": "Contains the block elements to display when there are query results.",
+	"parent": [ "core/query" ],
+	"textdomain": "wporg",
+	"usesContext": [ "queryId", "query" ],
+	"supports": {
+		"align": true,
+		"reusable": false,
+		"html": false,
+		"color": {
+			"link": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"editorScript": "file:./index.js"
+}

--- a/mu-plugins/blocks/query-has-results/src/index.js
+++ b/mu-plugins/blocks/query-has-results/src/index.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const TEMPLATE = [
+	[
+		'core/paragraph',
+		{
+			placeholder: __( 'Add text or blocks that will display only when a query has results.', 'wporg' ),
+		},
+	],
+];
+
+function Edit() {
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: TEMPLATE,
+	} );
+
+	return <div { ...innerBlocksProps } />;
+}
+
+function Save() {
+	return <InnerBlocks.Content />;
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: Save,
+} );

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -38,6 +38,7 @@ require_once __DIR__ . '/blocks/link-wrapper/index.php';
 require_once __DIR__ . '/blocks/navigation/index.php';
 require_once __DIR__ . '/blocks/notice/index.php';
 require_once __DIR__ . '/blocks/query-filter/index.php';
+require_once __DIR__ . '/blocks/query-has-results/index.php';
 require_once __DIR__ . '/blocks/query-total/index.php';
 require_once __DIR__ . '/blocks/sidebar-container/index.php';
 require_once __DIR__ . '/blocks/screenshot-preview/block.php';


### PR DESCRIPTION
See https://github.com/WordPress/pattern-directory/issues/636 – We have a query loop with a heading, but the heading does not make sense if there are no results in the query. This new block displays its contents conditionally, if the parent query loop has results.

**Screenshots**

In the editor, this behaves exactly like the "No results" block. You can add it to a Query Loop, and any content inside it will only show up if the query has results.

<img width="1045" alt="editor" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/006679d7-db99-45e3-862e-8b484cb49f40">

If there are posts, the heading and paragraph appear:

<img width="700" alt="has-results" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/251e9522-2084-4315-8bef-0fb4e9008c9b">

If there are no posts, the "no results" content appears:

<img width="623" alt="no-results" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/3b2a6be7-c07c-4703-a472-6ff7636b2c1b">

**To test**

- Add a Query Loop to a page
- Inside the query loop, add the "Has results" block
- Add content inside "Has results"
- The content should only show up on the frontend when there are posts in the query loop

Alternately, test with https://github.com/WordPress/pattern-directory/pull/657