### PR TITLE
Screenshot Preview Block: Split React code and block, use Interactivty API for block

### DIFF
--- a/mu-plugins/blocks/screenshot-preview-block/README.md
+++ b/mu-plugins/blocks/screenshot-preview-block/README.md
@@ -28,8 +28,10 @@ echo do_blocks( '<!-- wp:wporg/screenshot-preview {"src":"https://wordpress.org/
 
 | Name          | Type    | Description                                | Default |
 |---------------|---------|--------------------------------------------|---------|
-| alt           | string  | Alt text for image.                        | ""      |
-| href          | string  | Destination for link wrapper, if provided. | ""      |
-| src           | string  | Source (website) to capture for display    | ""      |
-| width         | integer | Image width                                | 800     |
-| viewportWidth | integer | Viewport width                             | 1200    |
+| alt            | string  | Alt text for image.                         | ""      |
+| fullPage       | boolean | If true, image only captures page content, up to viewportHeight. If false, image is fixed height (viewportHeight), with whitespace surrounding. | "" |
+| href           | string  | Destination for link wrapper, if provided.  | ""      |
+| src            | string  | Source (website) to capture for display     | ""      |
+| viewportHeight | integer | Viewport height (or max-height if fullPage) | 0       |
+| viewportWidth  | integer | Viewport width                              | 1200    |
+| width          | integer | Image width                                 | 800     |

--- a/mu-plugins/blocks/screenshot-preview-block/README.md
+++ b/mu-plugins/blocks/screenshot-preview-block/README.md
@@ -1,0 +1,35 @@
+# Screenshot Preview
+
+This block uses [mShots](https://github.com/Automattic/mShots) to screenshot a site and show a thumbnail preview.
+
+## Full Site Editing themes
+
+1. Add the block with the required attributes to the theme's `block-templates/*.html` files. For example
+
+```html
+<!-- wp:wporg/screenshot-preview {"src":"https://wordpress.org/"} /-->
+```
+
+Or for a linked image:
+
+```html
+<!-- wp:wporg/screenshot-preview {"src":"https://developer.wordpress.org/","href":"https://developer.wordpress.org/","alt":"WordPress Developer Resources"} /-->
+```
+
+## Classic themes in the w.org network
+
+The same as above, but instead of adding the block to `block-templates/*.html` files, you'd add it to `themes/{template}`:
+
+```php
+echo do_blocks( '<!-- wp:wporg/screenshot-preview {"src":"https://wordpress.org/"} /-->' );
+```
+
+## Attributes
+
+| Name          | Type    | Description                                | Default |
+|---------------|---------|--------------------------------------------|---------|
+| alt           | string  | Alt text for image.                        | ""      |
+| href          | string  | Destination for link wrapper, if provided. | ""      |
+| src           | string  | Source (website) to capture for display    | ""      |
+| width         | integer | Image width                                | 800     |
+| viewportWidth | integer | Viewport width                             | 1200    |

--- a/mu-plugins/blocks/screenshot-preview-block/block.php
+++ b/mu-plugins/blocks/screenshot-preview-block/block.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Block Name: Screenshot Preview
+ * Description: Show a preview of a website.
+ */
+
+namespace WordPressdotorg\MU_Plugins\ScreenshotPreview_Block;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Registers the `wporg/screenshot-preview` block on the server.
+ */
+function init() {
+	register_block_type( __DIR__ . '/build/' );
+}

--- a/mu-plugins/blocks/screenshot-preview-block/render.php
+++ b/mu-plugins/blocks/screenshot-preview-block/render.php
@@ -3,7 +3,11 @@ if ( ! isset( $attributes['src'] ) ) {
 	return '';
 }
 
-$view_url = $attributes['src'];
+$view_url = wp_http_validate_url( $attributes['src'] );
+if ( ! $view_url ) {
+	return '';
+}
+
 $alt_text = $attributes['alt'] ?? '';
 $has_link = isset( $attributes['href'] ) && $attributes['href'];
 $width = isset( $attributes['width'] ) ? $attributes['width'] * 2 : 800;

--- a/mu-plugins/blocks/screenshot-preview-block/render.php
+++ b/mu-plugins/blocks/screenshot-preview-block/render.php
@@ -10,21 +10,31 @@ if ( ! $view_url ) {
 
 $alt_text = $attributes['alt'] ?? '';
 $has_link = isset( $attributes['href'] ) && $attributes['href'];
-$width = isset( $attributes['width'] ) ? $attributes['width'] * 2 : 800;
+
+// Set up the viewport sizes.
 $viewport_width = $attributes['viewportWidth'] ?? 1200;
+$viewport_height = $attributes['viewportHeight'] ?? 0;
+$fullpage = isset( $attributes['fullPage'] ) && $attributes['fullPage'];
+
+// Multiply by 2 for hiDPI-ready sizes.
+$width = isset( $attributes['width'] ) ? $attributes['width'] * 2 : 800;
+
+$mshots_args = array(
+	'w' => $width,
+	'vpw' => $viewport_width,
+);
+if ( $fullpage ) {
+	// `screen_height` is the max height of a screenshot, image can be smaller.
+	$mshots_args['screen_height'] = $viewport_height ? $viewport_height : 3600;
+	$mshots_args['vph'] = 300; // Smaller than the vast majority of patterns to avoid whitespace.
+} else {
+	// `vph` is the fixed height of the screenshot (image size will be scaled by w/vpw).
+	$mshots_args['vph'] = $viewport_height ? $viewport_height : 900;
+}
 
 $cache_key = '20240423'; // To break out of cached image.
-
 $view_url = add_query_arg( 'v', $cache_key, $view_url );
-$url = add_query_arg(
-	array(
-		'w' => $width,
-		'vpw' => $viewport_width,
-		'vph' => 300, // Smaller than the vast majority of patterns to avoid whitespace.
-		'screen_height' => 3600, // Max height of a screenshot.
-	),
-	'https://s0.wp.com/mshots/v1/' . urlencode( $view_url ),
-);
+$url = add_query_arg( $mshots_args, 'https://s0.wp.com/mshots/v1/' . urlencode( $view_url ) );
 
 // Initial state to pass to Interactivity API.
 $init_state = [

--- a/mu-plugins/blocks/screenshot-preview-block/render.php
+++ b/mu-plugins/blocks/screenshot-preview-block/render.php
@@ -1,0 +1,75 @@
+<?php
+if ( ! isset( $attributes['src'] ) ) {
+	return '';
+}
+
+$view_url = $attributes['src'];
+$alt_text = $attributes['alt'] ?? '';
+$has_link = isset( $attributes['href'] ) && $attributes['href'];
+$width = isset( $attributes['width'] ) ? $attributes['width'] * 2 : 800;
+$viewport_width = $attributes['viewportWidth'] ?? 1200;
+
+$cache_key = '20240423'; // To break out of cached image.
+
+$view_url = add_query_arg( 'v', $cache_key, $view_url );
+$url = add_query_arg(
+	array(
+		'w' => $width,
+		'vpw' => $viewport_width,
+		'vph' => 300, // Smaller than the vast majority of patterns to avoid whitespace.
+		'screen_height' => 3600, // Max height of a screenshot.
+	),
+	'https://s0.wp.com/mshots/v1/' . urlencode( $view_url ),
+);
+
+// Initial state to pass to Interactivity API.
+$init_state = [
+	'base64Image' => '',
+	'src' => esc_url( $url ),
+	'alt' => $alt_text,
+	'attempts' => 0,
+	'shouldRetry' => true,
+	'hasError' => false,
+];
+$encoded_state = wp_json_encode( $init_state );
+
+$classname = '';
+if ( $has_link ) {
+	$classname .= ' is-linked-image';
+}
+
+?>
+<div
+	<?php echo get_block_wrapper_attributes( array( 'class' => $classname ) ); // phpcs:ignore ?>
+	data-wp-interactive="wporg/screenshot-preview"
+	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
+	data-wp-init="callbacks.init"
+	data-wp-class--has-loaded="state.hasLoaded"
+	data-wp-class--has-error="state.hasError"
+	tabIndex="-1"
+>
+	<?php if ( $has_link ) : ?>
+	<a href="<?php echo esc_url( $attributes['href'] ); ?>">
+	<?php endif; ?>
+
+	<div
+		class="wporg-screenshot-preview__container"
+		data-wp-class--wporg-screenshot-preview__loader="!state.hasLoaded"
+		data-wp-class--wporg-screenshot-preview__error="state.hasError"
+	>
+		<img
+			data-wp-bind--hidden="!state.base64Image"
+			data-wp-bind--alt="context.alt"
+			data-wp-bind--src="state.base64Image"
+		/>
+		<span
+			data-wp-bind--hidden="state.base64Image"
+			class="screen-reader-text"
+			data-wp-text="context.alt"
+		></span>
+	</div>
+
+	<?php if ( $has_link ) : ?>
+	</a>
+	<?php endif; ?>
+</div>

--- a/mu-plugins/blocks/screenshot-preview-block/src/block.json
+++ b/mu-plugins/blocks/screenshot-preview-block/src/block.json
@@ -1,0 +1,58 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/screenshot-preview",
+	"title": "Screenshot Preview",
+	"category": "widgets",
+	"icon": "plugin",
+	"description": "Show a preview of a website.",
+	"textdomain": "wporg",
+	"attributes": {
+		"alt": {
+			"type": "string",
+			"default": ""
+		},
+		"href": {
+			"type": "string",
+			"default": ""
+		},
+		"src": {
+			"type": "string",
+			"default": ""
+		},
+		"width": {
+			"type": "integer",
+			"default": 800
+		},
+		"viewportWidth": {
+			"type": "integer",
+			"default": 1200
+		}
+	},
+	"supports": {
+		"align": true,
+		"color": {
+			"text": false,
+			"background": true,
+			"link": false
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		}
+	},
+	"editorScript": "file:./index.js",
+	"viewScriptModule": "file:./view.js",
+	"style": "file:./style-index.css",
+	"render": "file:../render.php"
+}

--- a/mu-plugins/blocks/screenshot-preview-block/src/block.json
+++ b/mu-plugins/blocks/screenshot-preview-block/src/block.json
@@ -12,6 +12,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"fullPage": {
+			"type": "boolean",
+			"default": true
+		},
 		"href": {
 			"type": "string",
 			"default": ""
@@ -20,13 +24,17 @@
 			"type": "string",
 			"default": ""
 		},
-		"width": {
+		"viewportHeight": {
 			"type": "integer",
-			"default": 800
+			"default": 0
 		},
 		"viewportWidth": {
 			"type": "integer",
 			"default": 1200
+		},
+		"width": {
+			"type": "integer",
+			"default": 800
 		}
 	},
 	"supports": {

--- a/mu-plugins/blocks/screenshot-preview-block/src/edit.js
+++ b/mu-plugins/blocks/screenshot-preview-block/src/edit.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @return {Element} Element to render.
+ */
+export default function Edit() {
+	return <div { ...useBlockProps() }>Thumbnail</div>;
+}

--- a/mu-plugins/blocks/screenshot-preview-block/src/index.js
+++ b/mu-plugins/blocks/screenshot-preview-block/src/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/mu-plugins/blocks/screenshot-preview-block/src/style.scss
+++ b/mu-plugins/blocks/screenshot-preview-block/src/style.scss
@@ -1,0 +1,89 @@
+.wp-block-wporg-screenshot-preview {
+	position: relative;
+	margin: 0;
+	border: 1px solid var(--wp--preset--color--light-grey-2);
+	border-radius: 4px;
+	overflow: hidden;
+
+	&:where(.is-linked-image) a {
+		display: block;
+	}
+
+	&:where(.is-linked-image):hover {
+		border-color: var(--wp--preset--color--charcoal-5);
+	}
+
+	&:where(.is-linked-image):focus-within {
+		outline: 1.5px solid var(--wp--custom--link--color--text);
+		outline-offset: -1.5px;
+	}
+
+	&:where(.is-linked-image) a:focus {
+		box-shadow: none;
+	}
+
+	.wporg-screenshot-preview__container {
+		aspect-ratio: 4 / 3;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 100%;
+	}
+
+	img {
+		display: none;
+		margin: auto;
+		max-width: 100%;
+		max-height: 100%;
+		flex-basis: 0;
+	}
+
+	&.has-loaded:not(.has-error) {
+		img {
+			display: block;
+		}
+	}
+
+	.wporg-screenshot-preview__loader {
+		&::after {
+			content: "";
+			display: inline-block;
+			box-sizing: border-box;
+			height: 16px;
+			width: 16px;
+			border: 1.5px solid;
+			border-color:
+				var(--wp--preset--color--light-grey-2)
+				var(--wp--preset--color--light-grey-2)
+				var(--wp--custom--link--color--text);
+			border-radius: 50%;
+			animation: rotate-360 1.4s linear infinite;
+		}
+	}
+
+	.wporg-screenshot-preview__error {
+		flex-direction: column;
+
+		&::before {
+			content: "";
+			display: inline-block;
+			box-sizing: border-box;
+			height: 24px;
+			width: 24px;
+			/* stylelint-disable-next-line function-url-quotes */
+			background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h5l-.121-.121 1.379-1.379H5a.5.5 0 0 1-.5-.5v-2.436l4.096-2.987 2.996 1.941a.75.75 0 0 0 .93-.091L16 12.046l1.375 1.337 1.06-1.06-1.912-1.86a.75.75 0 0 0-1.046 0l-3.571 3.471-2.927-1.897a.75.75 0 0 0-.85.024L4.5 14.707V5a.5.5 0 0 1 .5-.5h14a.5.5 0 0 1 .5.5v6.258l1.5-1.5V5a2 2 0 0 0-2-2H5Zm16 11-1.5 1.5V19a.5.5 0 0 1-.5.5h-3.5L14 21h5a2 2 0 0 0 2-2v-5Z' fill='%231E1E1E'/%3E%3C/svg%3E");
+			background-position: center;
+			background-repeat: no-repeat;
+		}
+	}
+}
+
+@keyframes rotate-360 {
+	0% {
+		transform: rotate(0deg);
+	}
+
+	100% {
+		transform: rotate(360deg);
+	}
+}

--- a/mu-plugins/blocks/screenshot-preview-block/src/view.js
+++ b/mu-plugins/blocks/screenshot-preview-block/src/view.js
@@ -1,0 +1,97 @@
+/* global FileReader */
+/**
+ * WordPress dependencies
+ */
+import { getContext, store } from '@wordpress/interactivity';
+
+/**
+ * Module constants
+ */
+const MAX_ATTEMPTS = 10;
+const RETRY_DELAY = 2000;
+
+const { actions, state } = store( 'wporg/screenshot-preview', {
+	state: {
+		get attempts() {
+			return getContext().attempts;
+		},
+		get shouldRetry() {
+			return getContext().shouldRetry;
+		},
+		get hasError() {
+			return getContext().hasError;
+		},
+		get base64Image() {
+			return getContext().base64Image;
+		},
+		get hasLoaded() {
+			return state.base64Image || state.hasError;
+		},
+	},
+	actions: {
+		setShouldRetry( value ) {
+			const context = getContext();
+			context.shouldRetry = value;
+		},
+
+		setHasError( value ) {
+			const context = getContext();
+			context.hasError = value;
+		},
+
+		setBase64Image( value ) {
+			const context = getContext();
+			context.base64Image = value;
+		},
+
+		*fetchImage( fullUrl ) {
+			try {
+				const context = getContext();
+				const res = yield fetch( fullUrl );
+				context.attempts++;
+
+				if ( res.redirected ) {
+					actions.setShouldRetry( true );
+				} else if ( res.status === 200 && ! res.redirected ) {
+					const blob = yield res.blob();
+
+					const value = yield new Promise( ( resolve ) => {
+						const reader = new FileReader();
+						reader.onloadend = () => resolve( reader.result );
+						reader.readAsDataURL( blob );
+					} );
+
+					actions.setBase64Image( value );
+					actions.setShouldRetry( false );
+				}
+			} catch ( error ) {
+				actions.setHasError( true );
+				actions.setShouldRetry( false );
+			}
+		},
+	},
+
+	callbacks: {
+		// Run on init, starts the image fetch process.
+		*init() {
+			const { src } = getContext();
+
+			if ( ! state.base64Image ) {
+				// Initial fetch.
+				yield actions.fetchImage( src );
+
+				while ( state.shouldRetry ) {
+					yield new Promise( ( resolve ) => {
+						setTimeout( () => resolve(), RETRY_DELAY );
+					} );
+					yield actions.fetchImage( src );
+
+					if ( state.attempts >= MAX_ATTEMPTS ) {
+						actions.setHasError( true );
+						actions.setShouldRetry( false );
+					}
+				}
+			}
+		},
+	},
+} );

--- a/mu-plugins/blocks/screenshot-preview/block.php
+++ b/mu-plugins/blocks/screenshot-preview/block.php
@@ -15,36 +15,11 @@ defined( 'WPINC' ) || die();
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_assets', 20 );
 
 /**
- * Renders the `wporg/screenshot-preview` block on the server.
- *
- * @param array    $attributes Block attributes.
- * @param string   $content    Block default content.
- * @param WP_Block $block      Block instance.
- *
- * @return string Returns the event year for the current post.
- */
-function render_block( $attributes, $content ) {
-	if( ! isset( $attributes['link'] ) || ! isset( $attributes['preview-link'] ) ) {
-		return '';
-	}
-
-	return sprintf(
-		'<div 
-			class="wporg-screenshot-preview-js"
-			data-link="%1$s" 
-			data-preview-link="%2$s" 
-		></div>',
-		esc_attr( $attributes['link'] ),		
-		esc_attr( $attributes['preview-link'] )
-	);
-}
-
-/**
  * Register scripts, styles, and block.
  */
 function register_assets() {
 	$deps_path = __DIR__ . '/build/index.asset.php';
-	
+
 	if ( ! file_exists( $deps_path ) ) {
 		return;
 	}
@@ -67,20 +42,6 @@ function register_assets() {
 			filemtime( __DIR__ . '/build/style.css' )
 		);
 
-		wp_style_add_data( 'wporg-screenshot-preview-style', 'rtl', 'replace' ); 
+		wp_style_add_data( 'wporg-screenshot-preview-style', 'rtl', 'replace' );
 	}
-
-	register_block();
-}
-
-/**
- * Registers the `wporg/screenshot-preview` block on the server.
- */
-function register_block() {
-	register_block_type(
-		__DIR__ . '/block.json',
-		array(
-			'render_callback' => __NAMESPACE__ . '\render_block',
-		)
-	);
 }

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -42,6 +42,7 @@ require_once __DIR__ . '/blocks/query-has-results/index.php';
 require_once __DIR__ . '/blocks/query-total/index.php';
 require_once __DIR__ . '/blocks/sidebar-container/index.php';
 require_once __DIR__ . '/blocks/screenshot-preview/block.php';
+require_once __DIR__ . '/blocks/screenshot-preview-block/block.php';
 require_once __DIR__ . '/blocks/site-breadcrumbs/index.php';
 require_once __DIR__ . '/blocks/table-of-contents/index.php';
 require_once __DIR__ . '/blocks/time/index.php';


### PR DESCRIPTION
This PR pulls out the block code from the existing `blocks/screenshot-preview` folder, and brings in the screenshot block from the pattern directory (using the Interactivity API). The new block lives in `blocks/screenshot-preview-block`. Spitting the folder like this lets us keep the current React code & `__wporg_screenshot_preview_render` in place, while using the newer block for the new themes (to avoid changes to the current Theme Directory).

The new block is used like this. See [the readme for all attributes](https://github.com/WordPress/wporg-mu-plugins/blob/51e1c2129843bdd2bca77ab875e0f89f4c7c2c4e/mu-plugins/blocks/screenshot-preview-block/README.md#attributes)

<table role="table">
<thead><tr><th>Code</th><th>Screenshot</th></tr></thead>
<tbody><tr>
<td width="50%"><code>&lt;!-- wp:wporg/screenshot-preview {"src":"https://developer.wordpress.org/","href":"https://developer.wordpress.org/","alt":"WordPress Developer Resources","align":"wide"} /--&gt;</code></td>
<td width="50%"><img width="720" alt="Screenshot 2024-04-23 at 4 14 11 PM" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/827131ac-1a86-43a0-8931-b94fe55aba3b"></td>
</tr>
</tbody>
</table>

After the Theme Directory refresh is launched, we can remove `blocks/screenshot-preview`. That should be the only place this is used.

We could also simplify the pattern-thumbnail block by using this one, but that still needs to be a separate block as it uses a dynamic URL from the current pattern.

**Screenshots**

This is in use on the in-progress theme directory (See https://github.com/WordPress/wordpress.org/pull/279 about the overly tall images)

<img width="801" alt="Screenshot 2024-04-23 at 3 28 16 PM" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/e2538850-c446-485a-92d2-f2120309fef1">

<img width="822" alt="Screenshot 2024-04-23 at 3 28 05 PM" src="https://github.com/WordPress/wporg-mu-plugins/assets/541093/98693b38-eb76-489b-9445-e300eada0f04">

**To test**

1. Manually add the block to a page or template (there is no UI yet, maybe in the future)
2. Try using different attributes when loading the image
3. It should show a loading indicator, then show the screenshot
4. If the src URL is missing or invalid (ex, `localhost`), it should not output anything
