### PR TITLE
Fix alignment of dropdown caret in the Local Navigation Bar block.

### DIFF
--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -113,6 +113,15 @@
 		/* Needed for aligning the dropdown caret correctly. */
 		padding-right: 0;
 
+		/* Add right padding if the dropdown caret is not being displayed. */
+		&:not(.wporg-show-collapsed-nav) {
+			& .wp-block-navigation {
+				&:not(.wporg-is-mobile-nav) {
+					padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width));
+				}
+			}
+		}
+
 		& .global-header__wporg-logo-mark {
 			display: none;
 		}
@@ -184,11 +193,6 @@
 
 	/* Navigation. */
 	& .wp-block-navigation {
-
-		/* Add right padding if the dropdown caret is not being displayed. */
-		&:not(.wporg-is-mobile-nav):not(.wporg-is-collapsed-nav) {
-			padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width));
-		}
 
 		& .wp-block-navigation-submenu__toggle {
 			padding-block: calc(var(--wp--preset--spacing--10) / 2);

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -114,12 +114,8 @@
 		padding-right: 0;
 
 		/* Add right padding if the dropdown caret is not being displayed. */
-		&:not(.wporg-show-collapsed-nav) {
-			& .wp-block-navigation {
-				&:not(.wporg-is-mobile-nav) {
-					padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width));
-				}
-			}
+		& nav:not(.wporg-is-mobile-nav):not(.wporg-is-collapsed-nav) {
+			padding-right: var(--wp--preset--spacing--edge-space);
 		}
 
 		& .global-header__wporg-logo-mark {

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -110,8 +110,8 @@
 		position: relative !important;
 		top: 0 !important;
 
-		/* Matches the padding of the global header button. */
-		padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width)) !important;
+		/* Needed for aligning the dropdown caret correctly. */
+		padding-right: 0;
 
 		& .global-header__wporg-logo-mark {
 			display: none;
@@ -184,6 +184,12 @@
 
 	/* Navigation. */
 	& .wp-block-navigation {
+
+		/* Add right padding if the dropdown caret is not being displayed. */
+		&:not(.wporg-is-mobile-nav):not(.wporg-is-collapsed-nav) {
+			padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width));
+		}
+
 		& .wp-block-navigation-submenu__toggle {
 			padding-block: calc(var(--wp--preset--spacing--10) / 2);
 			padding-inline-start: calc(var(--wp--preset--spacing--10) / 2);
@@ -225,6 +231,9 @@
 		& .wp-block-navigation__responsive-container-close {
 			padding: 17px;
 
+			/* Add right padding to correctly align the dropdown caret. */
+			padding-right: calc(16px + var(--wp--custom--alignment--scroll-bar-width));
+
 			&:focus-visible {
 				outline: none;
 				border-radius: 2px;
@@ -234,10 +243,6 @@
 
 		&  .wp-block-navigation__responsive-container-close {
 			margin-block-start: calc(var(--wp--custom--local-navigation-bar--spacing--height) * -1) !important;
-
-			@media (max-width: 600px) {
-				margin-inline-end: calc(16px + var(--wp--custom--alignment--scroll-bar-width));
-			}
 		}
 
 		& .wp-block-navigation__responsive-close,

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -193,7 +193,6 @@
 
 	/* Navigation. */
 	& .wp-block-navigation {
-
 		& .wp-block-navigation-submenu__toggle {
 			padding-block: calc(var(--wp--preset--spacing--10) / 2);
 			padding-inline-start: calc(var(--wp--preset--spacing--10) / 2);

--- a/mu-plugins/blocks/local-navigation-bar/src/view.js
+++ b/mu-plugins/blocks/local-navigation-bar/src/view.js
@@ -83,7 +83,7 @@ function init() {
 				parseInt( paddingInlineStart, 10 ) -
 				parseInt( paddingInlineEnd, 10 ) -
 				parseInt( gap, 10 ) -
-				24; // 24px right padding is added when the collapsed nav is hidden.
+				20; // 20px right padding is added when the collapsed nav is hidden.
 
 			const titleElement = container.querySelector( '.wp-block-site-title, div.wp-block-group' );
 			if ( ! titleElement ) {

--- a/mu-plugins/blocks/local-navigation-bar/src/view.js
+++ b/mu-plugins/blocks/local-navigation-bar/src/view.js
@@ -82,7 +82,8 @@ function init() {
 				window.innerWidth -
 				parseInt( paddingInlineStart, 10 ) -
 				parseInt( paddingInlineEnd, 10 ) -
-				parseInt( gap, 10 );
+				parseInt( gap, 10 ) - 
+				24; // 24px right padding is added when the collapsed nav is hidden.
 
 			const titleElement = container.querySelector( '.wp-block-site-title, div.wp-block-group' );
 			if ( ! titleElement ) {

--- a/mu-plugins/blocks/local-navigation-bar/src/view.js
+++ b/mu-plugins/blocks/local-navigation-bar/src/view.js
@@ -82,7 +82,7 @@ function init() {
 				window.innerWidth -
 				parseInt( paddingInlineStart, 10 ) -
 				parseInt( paddingInlineEnd, 10 ) -
-				parseInt( gap, 10 ) - 
+				parseInt( gap, 10 ) -
 				24; // 24px right padding is added when the collapsed nav is hidden.
 
 			const titleElement = container.querySelector( '.wp-block-site-title, div.wp-block-group' );


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-mu-plugins/issues/604

The dropdown "caret" was misaligned in the Local Navigation Bar block on mobile. It should line up with the = icon in the global header. 

| Current | Proposed |
|-|-|
|<img width="680" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/7afa207e-5982-4b15-bbba-367814013900">|<img width="679" alt="image" src="https://github.com/WordPress/wporg-mu-plugins/assets/4832319/84f8e501-7b3c-4456-b131-82b05873fca5">|

And here's a video of the fix in action. 

https://github.com/WordPress/wporg-mu-plugins/assets/4832319/f6517c9f-e3da-4692-8ba7-2b206eac82f8

