### PR TITLE
Add a prominent style variation for the language suggestion.

### DIFF
--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -17,5 +17,14 @@ namespace WordPressdotorg\MU_Plugins\Language_Suggest;
  */
 function language_suggest_block_init() {
 	register_block_type( __DIR__ . '/build' );
+
+
+	register_block_style(
+		'wporg/language-suggest',
+		array(
+			'name'         => 'prominent',
+			'label'        => _x( 'Prominent', 'wporg' ),
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\language_suggest_block_init' );

--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -18,7 +18,6 @@ namespace WordPressdotorg\MU_Plugins\Language_Suggest;
 function language_suggest_block_init() {
 	register_block_type( __DIR__ . '/build' );
 
-
 	register_block_style(
 		'wporg/language-suggest',
 		array(

--- a/mu-plugins/blocks/language-suggest/postcss/style.pcss
+++ b/mu-plugins/blocks/language-suggest/postcss/style.pcss
@@ -6,28 +6,25 @@
  */
 
 .wp-block-wporg-language-suggest {
-	--wp--custom--wporg-language-suggest--background: var(--wp--preset--color--blueberry-4, #eff2ff);
-	--wp--custom--wporg-language-suggest--color--text: var(--wp--preset--color--charcoal-1, #1e1e1e);
-	--wp--custom--wporg-language-suggest--font-size: var(--wp--preset--font-size--extra-small, 12px);
-	--wp--custom--wporg-language-suggest--spacing: var(--wp--preset--spacing--10, 10px);
+	--wporg-language-suggest--background: var(--wp--custom--wporg-language-suggest--background, var(--wp--preset--color--blueberry-4, #eff2ff));
+	--wporg-language-suggest--text: var(--wp--custom--wporg-language-suggest--text, var(--wp--preset--color--charcoal-1, #1e1e1e));
+	--wporg-language-suggest--font-size: var(--wp--custom--wporg-language-suggest--font-size, var(--wp--preset--font-size--extra-small, 12px));
+	--wporg-language-suggest--spacing: var(--wp--custom--wporg-language-suggest--spacing, var(--wp--preset--spacing--10, 10px));
 
-	background-color: var(--wp--custom--wporg-language-suggest--background);
-	color: var(--wp--custom--wporg-language-suggest--color--text);
-	font-size: var(--wp--custom--wporg-language-suggest--font-size);
+	background-color: var(--wporg-language-suggest--background);
+	color: var(--wporg-language-suggest--text);
+	font-size: var(--wporg-language-suggest--font-size);
 	line-height: 1;
 	text-align: center;
 }
 
 /* The api returns a div element but that isn't guaranteed. */
 .wp-block-wporg-language-suggest > * {
-	padding: var(--wp--custom--wporg-language-suggest--spacing) 4px;
+	padding: var(--wporg-language-suggest--spacing) 4px;
 }
 
 .wp-block-wporg-language-suggest.is-style-prominent {
-	--wp--custom--wporg-language-suggest--background: var(--wp--preset--color--lemon-3, #fffdd6);
-	--wp--custom--wporg-language-suggest--font-size: var(--wp--preset--font-size--small, 14px);
-}
-
-.wp-block-wporg-language-suggest.is-style-prominent > * {
-	--wp--custom--wporg-language-suggest--spacing: var(--wp--preset--spacing--20);
+	--wporg-language-suggest--background: var(--wp--preset--color--lemon-3, #fffdd6);
+	--wporg-language-suggest--font-size: var(--wp--preset--font-size--small, 14px);
+	--wporg-language-suggest--spacing: var(--wp--preset--spacing--20, 20px);
 }

--- a/mu-plugins/blocks/language-suggest/postcss/style.pcss
+++ b/mu-plugins/blocks/language-suggest/postcss/style.pcss
@@ -8,23 +8,26 @@
 .wp-block-wporg-language-suggest {
 	--wp--custom--wporg-language-suggest--background: var(--wp--preset--color--blueberry-4, #eff2ff);
 	--wp--custom--wporg-language-suggest--color--text: var(--wp--preset--color--charcoal-1, #1e1e1e);
+	--wp--custom--wporg-language-suggest--font-size: var(--wp--preset--font-size--extra-small, 12px);
+	--wp--custom--wporg-language-suggest--spacing: var(--wp--preset--spacing--10, 10px);
 
 	background-color: var(--wp--custom--wporg-language-suggest--background);
 	color: var(--wp--custom--wporg-language-suggest--color--text);
-	font-size: 12px;
+	font-size: var(--wp--custom--wporg-language-suggest--font-size);
 	line-height: 1;
 	text-align: center;
 }
 
 /* The api returns a div element but that isn't guaranteed. */
 .wp-block-wporg-language-suggest > * {
-	padding: 10px 4px;
+	padding: var(--wp--custom--wporg-language-suggest--spacing) 4px;
 }
 
 .wp-block-wporg-language-suggest.is-style-prominent {
 	--wp--custom--wporg-language-suggest--background: var(--wp--preset--color--lemon-3, #fffdd6);
+	--wp--custom--wporg-language-suggest--font-size: var(--wp--preset--font-size--small, 14px);
+}
 
-	font-size: var(--wp--preset--font-size--small);
-	padding-top: var(--wp--preset--spacing--10);
-	padding-bottom: var(--wp--preset--spacing--10);
+.wp-block-wporg-language-suggest.is-style-prominent > * {
+	--wp--custom--wporg-language-suggest--spacing: var(--wp--preset--spacing--20);
 }

--- a/mu-plugins/blocks/language-suggest/postcss/style.pcss
+++ b/mu-plugins/blocks/language-suggest/postcss/style.pcss
@@ -6,10 +6,10 @@
  */
 
 .wp-block-wporg-language-suggest {
-	--wporg-language-suggest--background: var(--wp--custom--wporg-language-suggest--background, var(--wp--preset--color--blueberry-4, #eff2ff));
-	--wporg-language-suggest--text: var(--wp--custom--wporg-language-suggest--text, var(--wp--preset--color--charcoal-1, #1e1e1e));
-	--wporg-language-suggest--font-size: var(--wp--custom--wporg-language-suggest--font-size, var(--wp--preset--font-size--extra-small, 12px));
-	--wporg-language-suggest--spacing: var(--wp--custom--wporg-language-suggest--spacing, var(--wp--preset--spacing--10, 10px));
+	--wporg-language-suggest--background: var(--wp--preset--color--blueberry-4, #eff2ff);
+	--wporg-language-suggest--text: var(--wp--preset--color--charcoal-1, #1e1e1e);
+	--wporg-language-suggest--font-size: var(--wp--preset--font-size--extra-small, 12px);
+	--wporg-language-suggest--spacing: var(--wp--preset--spacing--10, 10px);
 
 	background-color: var(--wporg-language-suggest--background);
 	color: var(--wporg-language-suggest--text);

--- a/mu-plugins/blocks/language-suggest/postcss/style.pcss
+++ b/mu-plugins/blocks/language-suggest/postcss/style.pcss
@@ -6,8 +6,11 @@
  */
 
 .wp-block-wporg-language-suggest {
-	background-color: #eff2ff;
-	color: #1e1e1e;
+	--wp--custom--wporg-language-suggest--background: var(--wp--preset--color--blueberry-4, #eff2ff);
+	--wp--custom--wporg-language-suggest--color--text: var(--wp--preset--color--charcoal-1, #1e1e1e);
+
+	background-color: var(--wp--custom--wporg-language-suggest--background);
+	color: var(--wp--custom--wporg-language-suggest--color--text);
 	font-size: 12px;
 	line-height: 1;
 	text-align: center;
@@ -16,4 +19,12 @@
 /* The api returns a div element but that isn't guaranteed. */
 .wp-block-wporg-language-suggest > * {
 	padding: 10px 4px;
+}
+
+.wp-block-wporg-language-suggest.is-style-prominent {
+	--wp--custom--wporg-language-suggest--background: var(--wp--preset--color--lemon-3, #fffdd6);
+
+	font-size: var(--wp--preset--font-size--small);
+	padding-top: var(--wp--preset--spacing--10);
+	padding-bottom: var(--wp--preset--spacing--10);
 }


### PR DESCRIPTION
Relating to https://github.com/WordPress/wordpress.org/issues/301, this PR adds a new style variation to the language suggest block. This will allow us to set it in a theme template.

For the case of the plugin directory where it can be conditional based on the page, I assume we can just filter it as follows:

```php
function filter_language_suggest( $block_content ) {
	$html = new \WP_HTML_Tag_Processor( $block_content );
	$html->next_tag();
	$html->add_class('is-style-prominent');
	return $html->get_updated_html();
}

add_filter( 'render_block_wporg/language-suggest', __NAMESPACE__ . '\filter_language_suggest' );
```

## Screenshots
| Variation | Display |
|--------|--------|
| Default | <img width="682" alt="Screenshot 2024-05-08 at 9 56 39 AM" src="https://github.com/WordPress/wporg-mu-plugins/assets/1657336/2cdc46fa-71da-49ec-b215-515291ad4a56"> |
| `is-prominent` | <img width="682" alt="Screenshot 2024-05-08 at 9 56 57 AM" src="https://github.com/WordPress/wporg-mu-plugins/assets/1657336/1b9b7b6d-9d82-4885-95ef-03459b3ddb63"> | 




