### PR TITLE
REST API: Add locale suggestion endpoint & helpers for plugins and themes

### DIFF
--- a/mu-plugins/helpers/helpers.php
+++ b/mu-plugins/helpers/helpers.php
@@ -1,7 +1,10 @@
 <?php
 
 namespace WordPressdotorg\MU_Plugins\Helpers;
+
 defined( 'WPINC' ) || die();
+
+require_once __DIR__ . '/locale.php';
 
 /**
  * Join a string with a natural language conjunction at the end.

--- a/mu-plugins/helpers/locale.php
+++ b/mu-plugins/helpers/locale.php
@@ -147,7 +147,7 @@ function map_locale( $lang, $region, $available_locales ) {
  *
  * @return array
  */
-function get_transalated_locales( $type, $slug ) {
+function get_translated_locales( $type, $slug ) {
 	global $wpdb;
 
 	$language_packs = $wpdb->get_results(

--- a/mu-plugins/helpers/locale.php
+++ b/mu-plugins/helpers/locale.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Set up some helper functions for fetching locale data.
+ */
+
+namespace WordPressdotorg\MU_Plugins\Helpers\Locale;
+
+/**
+ * Get all locales with subdomain mapping.
+ */
+function get_all_locales_with_subdomain() {
+	global $wpdb;
+	return $wpdb->get_results(
+		"SELECT locale, subdomain FROM wporg_locales WHERE locale NOT LIKE '%\_%\_%'",
+		OBJECT_K
+	);
+}
+
+/**
+ * Get all available locales with valid WordPress locale values.
+ *
+ * Not all locales have valid WordPress sites, this filters out those that
+ * don't exist.
+ */
+function get_all_valid_locales() {
+	$all_locales = get_all_locales_with_subdomain();
+	// Retrieve all the WordPress locales.
+	$all_locales = wp_list_pluck( $all_locales, 'locale' );
+
+	return array_filter(
+		$all_locales,
+		function( $locale ) {
+			return \GP_Locales::by_field( 'wp_locale', $locale );
+		}
+	);
+}
+
+/**
+ * Get locales matching the HTTP accept language header.
+ *
+ * @return array List of locales.
+ */
+function get_locale_from_header() {
+	$res = array();
+
+	$available_locales = get_all_valid_locales();
+	if ( ! $available_locales ) {
+		return $res;
+	}
+
+	if ( ! isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
+		return $res;
+	}
+
+	$http_locales = get_http_locales( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ); // phpcs:ignore
+
+	if ( is_array( $http_locales ) ) {
+		foreach ( $http_locales as $http_locale ) {
+			$lang   = $http_locale;
+			$region = $http_locale;
+			if ( str_contains( $http_locale, '-' ) ) {
+				list( $lang, $region ) = explode( '-', $http_locale );
+			}
+
+			/*
+			 * Discard English -- it's the default for all browsers,
+			 * ergo not very reliable information
+			 */
+			if ( 'en' === $lang ) {
+				continue;
+			}
+
+			// Region should be uppercase.
+			$region = strtoupper( $region );
+
+			$mapped = map_locale( $lang, $region, $available_locales );
+			if ( $mapped ) {
+				$res[] = $mapped;
+			}
+		}
+
+		$res = array_unique( $res );
+	}
+
+	return $res;
+}
+
+/**
+ * Given a HTTP Accept-Language header $header
+ * returns all the locales in it.
+ *
+ * @param string $header HTTP acccept header.
+ * @return array Matched locales.
+ */
+function get_http_locales( $header ) {
+	$locale_part_re = '[a-z]{2,}';
+	$locale_re      = "($locale_part_re(\-$locale_part_re)?)";
+
+	if ( preg_match_all( "/$locale_re/i", $header, $matches ) ) {
+		return $matches[0];
+	} else {
+		return [];
+	}
+}
+
+/**
+ * Tries to map a lang/region pair to one of our locales.
+ *
+ * @param string $lang              Lang part of the HTTP accept header.
+ * @param string $region            Region part of the HTTP accept header.
+ * @param array  $available_locales List of available locales.
+ * @return string|false Our locale matching $lang and $region, false otherwise.
+ */
+function map_locale( $lang, $region, $available_locales ) {
+	$uregion  = strtoupper( $region );
+	$ulang    = strtoupper( $lang );
+	$variants = array(
+		"$lang-$region",
+		"{$lang}_$region",
+		"$lang-$uregion",
+		"{$lang}_$uregion",
+		"{$lang}_$ulang",
+		$lang,
+	);
+
+	foreach ( $variants as $variant ) {
+		if ( in_array( $variant, $available_locales ) ) {
+			return $variant;
+		}
+	}
+
+	foreach ( $available_locales as $locale ) {
+		list( $locale_lang, ) = preg_split( '/[_-]/', $locale );
+		if ( $lang === $locale_lang ) {
+			return $locale;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Get the active language packs for a package.
+ *
+ * @param string $type Package type. One of "theme", "plugin".
+ * @param string $slug Slug of the requested item (e.g., `jetpack`, `twentynineteen`).
+ *
+ * @return array
+ */
+function get_transalated_locales( $type, $slug ) {
+	global $wpdb;
+
+	$language_packs = $wpdb->get_results(
+		$wpdb->prepare(
+			'SELECT *
+			FROM language_packs
+			WHERE
+				type = %s AND
+				domain = %s AND
+				active = 1
+			GROUP BY language',
+			$type,
+			$slug
+		)
+	);
+
+	// Retrieve all the WordPress locales in which the theme is translated.
+	$translated_locales = wp_list_pluck( $language_packs, 'language' );
+
+	require_once GLOTPRESS_LOCALES_PATH;
+
+	// Validate the list of locales can be found by `wp_locale`.
+	return array_filter(
+		$translated_locales,
+		function( $locale ) {
+			return \GP_Locales::by_field( 'wp_locale', $locale );
+		}
+	);
+}

--- a/mu-plugins/rest-api/endpoints/class-wporg-base-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-base-locale-banner-controller.php
@@ -20,9 +20,7 @@ abstract class Base_Locale_Banner_Controller extends \WP_REST_Controller {
 				'callback' => array( $this, 'get_response' ),
 				'args' => array(
 					'debug' => array(
-						'sanitize_callback' => function( $param ) {
-							return (bool) $param;
-						},
+						'type' => 'boolean',
 					),
 				),
 				'permission_callback' => '__return_true',
@@ -36,9 +34,7 @@ abstract class Base_Locale_Banner_Controller extends \WP_REST_Controller {
 				'callback' => array( $this, 'get_response_for_item' ),
 				'args' => array(
 					'debug' => array(
-						'sanitize_callback' => function( $param ) {
-							return (bool) $param;
-						},
+						'type' => 'boolean',
 					),
 					'slug' => array(
 						'validate_callback' => array( $this, 'check_slug' ),

--- a/mu-plugins/rest-api/endpoints/class-wporg-base-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-base-locale-banner-controller.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace WordPressdotorg\MU_Plugins\REST_API;
+
+/**
+ * Base_Locale_Banner_Controller
+ */
+class Base_Locale_Banner_Controller extends \WP_REST_Controller {
+	/**
+	 * Register the endpoint routes used across both themes and plugins.
+	 *
+	 * @see register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods' => \WP_REST_Server::READABLE,
+				'callback' => array( $this, 'get_response' ),
+				'args' => array(
+					'debug' => array(
+						'sanitize_callback' => function( $param ) {
+							return (bool) $param;
+						},
+					),
+				),
+				'permission_callback' => '__return_true',
+			)
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<slug>[^/]+)/',
+			array(
+				'methods' => \WP_REST_Server::READABLE,
+				'callback' => array( $this, 'get_response_for_item' ),
+				'args' => array(
+					'debug' => array(
+						'sanitize_callback' => function( $param ) {
+							return (bool) $param;
+						},
+					),
+					'slug' => array(
+						'validate_callback' => array( $this, 'check_slug' ),
+					),
+				),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Check if the given slug is a valid item.
+	 *
+	 * Must be defined in the child class.
+	 */
+	public function check_slug( $param ) {
+		_doing_it_wrong(
+			'Base_Locale_Banner_Controller::check_slug',
+			/* translators: %s: register_routes() */
+			sprintf( "Method '%s' must be overridden.", __METHOD__ ),
+			'4.7.0'
+		);
+		return false;
+	}
+
+	/**
+	 * Send the response as plain text so it can be used as-is.
+	 */
+	public function send_plain_text( $result ) {
+		header( 'Content-Type: text/text' );
+		if ( $result ) {
+			echo '<div>' . $result . '</div>'; // phpcs:ignore
+		}
+
+		return null;
+	}
+}

--- a/mu-plugins/rest-api/endpoints/class-wporg-base-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-base-locale-banner-controller.php
@@ -5,7 +5,7 @@ namespace WordPressdotorg\MU_Plugins\REST_API;
 /**
  * Base_Locale_Banner_Controller
  */
-class Base_Locale_Banner_Controller extends \WP_REST_Controller {
+abstract class Base_Locale_Banner_Controller extends \WP_REST_Controller {
 	/**
 	 * Register the endpoint routes used across both themes and plugins.
 	 *
@@ -54,15 +54,7 @@ class Base_Locale_Banner_Controller extends \WP_REST_Controller {
 	 *
 	 * Must be defined in the child class.
 	 */
-	public function check_slug( $param ) {
-		_doing_it_wrong(
-			'Base_Locale_Banner_Controller::check_slug',
-			/* translators: %s: register_routes() */
-			sprintf( "Method '%s' must be overridden.", __METHOD__ ),
-			'4.7.0'
-		);
-		return false;
-	}
+	abstract public function check_slug( $param );
 
 	/**
 	 * Send the response as plain text so it can be used as-is.

--- a/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
@@ -122,22 +122,21 @@ class Plugins_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 		if ( 'en_US' !== $current_locale && $current_gp_locale && ! in_array( $current_locale, $translated_locales ) ) {
 			$output_locale = $current_locale;
 			switch_to_locale( $output_locale );
-			$suggest_string = sprintf(
-				// translators: %s: Locale name.
-				__( 'This plugin is not translated into %s yet.', 'wporg' ),
-				$current_gp_locale->native_name
-			);
 
-			// Append some other suggestions if they exist.
 			if ( ! empty( $suggestion_links ) ) {
-				$suggest_string .= ' ' . sprintf(
-					// translators: %s: List of links to plugin in other locales.
-					__( 'This plugin is available in %s.', 'wporg' ),
+				$suggest_string = sprintf(
+					// translators: %1$s: Locale name, %2$s: List of links to plugin in other locales.
+					__( 'This plugin is not translated into %1$s yet, but it is available in %2$s.', 'wporg' ),
+					$current_gp_locale->native_name,
 					wp_sprintf_l( '%l', $suggestion_links )
 				);
+			} else {
+				$suggest_string = sprintf(
+					// translators: %s: Locale name.
+					__( 'This plugin is not translated into %s yet.', 'wporg' ),
+					$current_gp_locale->native_name
+				);
 			}
-
-			// Lastly, add the call for help.
 			$suggest_string .= ' ' . sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( 'https://translate.wordpress.org/projects/wp-plugins/' . $plugin_slug ),

--- a/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace WordPressdotorg\MU_Plugins\REST_API;
+
+use WordPressdotorg\Plugin_Directory\Plugin_Directory;
+use function WordPressdotorg\MU_Plugins\Helpers\Locale\{ get_all_locales_with_subdomain, get_all_valid_locales, get_locale_from_header, get_transalated_locales };
+
+/**
+ * Plugins_Locale_Banner_Controller
+ */
+class Plugins_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wporg-plugins/v1';
+		$this->rest_base = 'locale-banner';
+	}
+
+	/**
+	 * Validate the plugin slug.
+	 */
+	public function check_slug( $param ) {
+		return is_string( $param ) && $param && Plugin_Directory::get_plugin_post( $param );
+	}
+
+	/**
+	 * Get banner for general plugin directory
+	 */
+	public function get_response( $request ) {
+		if ( ! defined( 'GLOTPRESS_LOCALES_PATH' ) ) {
+			return;
+		}
+
+		require_once GLOTPRESS_LOCALES_PATH;
+
+		$locale_subdomain_assoc = get_all_locales_with_subdomain();
+		$current_locale = get_locale();
+		$current_gp_locale = \GP_Locales::by_field( 'wp_locale', $current_locale );
+
+		// Build a list of WordPress locales which we'll suggest to the user.
+		$suggest_locales = array_values( array_intersect( get_locale_from_header(), get_all_valid_locales() ) );
+
+		$suggestion_links = [];
+		foreach ( $suggest_locales as $locale ) {
+			$language = \GP_Locales::by_field( 'wp_locale', $locale )->native_name;
+			$suggestion_links[ $locale ] = sprintf(
+				'<a href="https://%s.wordpress.org%s">%s</a>',
+				$locale_subdomain_assoc[ $locale ]->subdomain,
+				esc_url( get_site()->path ),
+				$language
+			);
+		}
+
+		$suggest_string = '';
+
+		unset( $suggestion_links[ $current_locale ] );
+
+		if ( ! empty( $suggestion_links ) ) {
+			$output_locale = key( $suggestion_links );
+			switch_to_locale( $output_locale );
+			$suggest_string = sprintf(
+				// translators: %s: List of links to plugin directory in other locales.
+				__( 'The plugin directory is also available in %s.', 'wporg' ),
+				wp_sprintf_l( '%l', $suggestion_links )
+			);
+		}
+
+		// Return more information if this is a debug request.
+		if ( ! empty( $request['debug'] ) ) {
+			return new \WP_REST_Response(
+				array(
+					'currentLocale' => $current_locale,
+					'suggestions' => $suggest_locales,
+					'message' => $suggest_string,
+				)
+			);
+		}
+
+		// The result should be a raw text response.
+		add_filter( 'rest_pre_echo_response', array( $this, 'send_plain_text' ) );
+		return new \WP_REST_Response( $suggest_string );
+	}
+
+	/**
+	 * Get banner for single plugins.
+	 */
+	public function get_response_for_item( $request ) {
+		// This has already been validated by `validate_callback`.
+		$plugin_slug = $request['slug'];
+
+		if ( ! defined( 'GLOTPRESS_LOCALES_PATH' ) ) {
+			return;
+		}
+
+		require_once GLOTPRESS_LOCALES_PATH;
+
+		$locale_subdomain_assoc = get_all_locales_with_subdomain();
+		$current_locale = get_locale();
+		$current_gp_locale = \GP_Locales::by_field( 'wp_locale', $current_locale );
+		$translated_locales = get_transalated_locales( 'plugin', $plugin_slug );
+
+		// Build a list of WordPress locales which we'll suggest to the user.
+		$suggest_locales = array_values( array_intersect( get_locale_from_header(), $translated_locales ) );
+
+		$suggestion_links = [];
+		foreach ( $suggest_locales as $locale ) {
+			$language = \GP_Locales::by_field( 'wp_locale', $locale )->native_name;
+			$suggestion_links[ $locale ] = sprintf(
+				'<a href="https://%s.wordpress.org%s">%s</a>',
+				$locale_subdomain_assoc[ $locale ]->subdomain,
+				esc_url( get_site()->path . $plugin_slug . '/' ),
+				$language
+			);
+		}
+
+		$suggest_string = '';
+
+		unset( $suggestion_links[ $current_locale ] );
+
+		// If we're on a rosetta site, and the plugin is not translated, the message should ask for help.
+		if ( 'en_US' !== $current_locale && $current_gp_locale && ! in_array( $current_locale, $translated_locales ) ) {
+			$output_locale = $current_locale;
+			switch_to_locale( $output_locale );
+			$suggest_string = sprintf(
+				// translators: %s: Locale name.
+				__( 'This plugin is not translated into %s yet.', 'wporg' ),
+				$current_gp_locale->native_name
+			);
+
+			// Append some other suggestions if they exist.
+			if ( ! empty( $suggestion_links ) ) {
+				$suggest_string .= ' ' . sprintf(
+					// translators: %s: List of links to plugin in other locales.
+					__( 'This plugin is available in %s.', 'wporg' ),
+					wp_sprintf_l( '%l', $suggestion_links )
+				);
+			}
+
+			// Lastly, add the call for help.
+			$suggest_string .= ' ' . sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( 'https://translate.wordpress.org/projects/wp-plugins/' . $plugin_slug ),
+				__( 'Help translate it!', 'wporg' )
+			);
+
+		} else if ( ! empty( $suggestion_links ) ) {
+			$output_locale = key( $suggestion_links );
+			switch_to_locale( $output_locale );
+			$suggest_string = sprintf(
+				// translators: %s: List of links to plugin in other locales.
+				__( 'This plugin is also available in %s.', 'wporg' ),
+				wp_sprintf_l( '%l', $suggestion_links )
+			);
+			$suggest_string .= ' ' . sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( 'https://translate.wordpress.org/projects/wp-plugins/' . $plugin_slug ),
+				__( 'Help improve the translation!', 'wporg' )
+			);
+
+		} else if ( ! empty( $locales_from_header ) ) {
+			$output_locale = reset( $locales_from_header );
+			switch_to_locale( $output_locale );
+
+			$suggest_string = sprintf(
+				// translators: %s: Locale name.
+				__( 'This plugin is not translated into %s yet.', 'wporg' ),
+				\GP_Locales::by_field( 'wp_locale', $output_locale )->native_name
+			);
+			$suggest_string .= ' ' . sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( 'https://translate.wordpress.org/projects/wp-plugins/' . $plugin_slug ),
+				__( 'Help translate it!', 'wporg' )
+			);
+		}
+
+		// Return more information if this is a debug request.
+		if ( ! empty( $request['debug'] ) ) {
+			return new \WP_REST_Response(
+				array(
+					'currentLocale' => $current_locale,
+					'suggestions' => $suggest_locales,
+					'message' => $suggest_string,
+				)
+			);
+		}
+
+		// The result should be a raw text response.
+		add_filter( 'rest_pre_echo_response', array( $this, 'send_plain_text' ) );
+		return new \WP_REST_Response( $suggest_string );
+	}
+}

--- a/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
@@ -3,7 +3,7 @@
 namespace WordPressdotorg\MU_Plugins\REST_API;
 
 use WordPressdotorg\Plugin_Directory\Plugin_Directory;
-use function WordPressdotorg\MU_Plugins\Helpers\Locale\{ get_all_locales_with_subdomain, get_all_valid_locales, get_locale_from_header, get_transalated_locales };
+use function WordPressdotorg\MU_Plugins\Helpers\Locale\{ get_all_locales_with_subdomain, get_all_valid_locales, get_locale_from_header, get_translated_locales };
 
 /**
  * Plugins_Locale_Banner_Controller
@@ -98,7 +98,7 @@ class Plugins_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 		$locale_subdomain_assoc = get_all_locales_with_subdomain();
 		$current_locale = get_locale();
 		$current_gp_locale = \GP_Locales::by_field( 'wp_locale', $current_locale );
-		$translated_locales = get_transalated_locales( 'plugin', $plugin_slug );
+		$translated_locales = get_translated_locales( 'plugin', $plugin_slug );
 
 		// Build a list of WordPress locales which we'll suggest to the user.
 		$suggest_locales = array_values( array_intersect( get_locale_from_header(), $translated_locales ) );

--- a/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
@@ -21,7 +21,7 @@ class Plugins_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 	 * Validate the plugin slug.
 	 */
 	public function check_slug( $param ) {
-		return is_string( $param ) && $param && Plugin_Directory::get_plugin_post( $param );
+		return Plugin_Directory::get_plugin_post( $param );
 	}
 
 	/**

--- a/mu-plugins/rest-api/endpoints/class-wporg-themes-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-themes-locale-banner-controller.php
@@ -122,22 +122,20 @@ class Themes_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 		if ( 'en_US' !== $current_locale && $current_gp_locale && ! in_array( $current_locale, $translated_locales ) ) {
 			$output_locale = $current_locale;
 			switch_to_locale( $output_locale );
-			$suggest_string = sprintf(
-				// translators: %s: Locale name.
-				__( 'This theme is not translated into %s yet.', 'wporg' ),
-				$current_gp_locale->native_name
-			);
-
-			// Append some other suggestions if they exist.
 			if ( ! empty( $suggestion_links ) ) {
-				$suggest_string .= ' ' . sprintf(
-					// translators: %s: List of links to theme in other locales.
-					__( 'This theme is available in %s.', 'wporg' ),
+				$suggest_string = sprintf(
+					// translators: %1$s: Locale name, %2$s: List of links to theme in other locales.
+					__( 'This theme is not translated into %1$s yet, but it is available in %2$s.', 'wporg' ),
+					$current_gp_locale->native_name,
 					wp_sprintf_l( '%l', $suggestion_links )
 				);
+			} else {
+				$suggest_string = sprintf(
+					// translators: %s: Locale name.
+					__( 'This theme is not translated into %s yet.', 'wporg' ),
+					$current_gp_locale->native_name
+				);
 			}
-
-			// Lastly, add the call for help.
 			$suggest_string .= ' ' . sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_url( 'https://translate.wordpress.org/projects/wp-themes/' . $theme_slug ),

--- a/mu-plugins/rest-api/endpoints/class-wporg-themes-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-themes-locale-banner-controller.php
@@ -2,7 +2,7 @@
 
 namespace WordPressdotorg\MU_Plugins\REST_API;
 
-use function WordPressdotorg\MU_Plugins\Helpers\Locale\{ get_all_locales_with_subdomain, get_all_valid_locales, get_locale_from_header, get_transalated_locales };
+use function WordPressdotorg\MU_Plugins\Helpers\Locale\{ get_all_locales_with_subdomain, get_all_valid_locales, get_locale_from_header, get_translated_locales };
 
 /**
  * Themes_Locale_Banner_Controller
@@ -98,7 +98,7 @@ class Themes_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 		$locale_subdomain_assoc = get_all_locales_with_subdomain();
 		$current_locale = get_locale();
 		$current_gp_locale = \GP_Locales::by_field( 'wp_locale', $current_locale );
-		$translated_locales = get_transalated_locales( 'theme', $theme_slug );
+		$translated_locales = get_translated_locales( 'theme', $theme_slug );
 
 		// Build a list of WordPress locales which we'll suggest to the user.
 		$suggest_locales = array_values( array_intersect( get_locale_from_header(), $translated_locales ) );

--- a/mu-plugins/rest-api/endpoints/class-wporg-themes-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-themes-locale-banner-controller.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace WordPressdotorg\MU_Plugins\REST_API;
+
+use function WordPressdotorg\MU_Plugins\Helpers\Locale\{ get_all_locales_with_subdomain, get_all_valid_locales, get_locale_from_header, get_transalated_locales };
+
+/**
+ * Themes_Locale_Banner_Controller
+ */
+class Themes_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wporg-themes/v1';
+		$this->rest_base = 'locale-banner';
+	}
+
+	/**
+	 * Validate the theme slug.
+	 */
+	public function check_slug( $param ) {
+		$theme = wporg_themes_theme_information( $param );
+		return ! isset( $theme->error );
+	}
+
+	/**
+	 * Get banner for general theme directory
+	 */
+	public function get_response( $request ) {
+		if ( ! defined( 'GLOTPRESS_LOCALES_PATH' ) ) {
+			return;
+		}
+
+		require_once GLOTPRESS_LOCALES_PATH;
+
+		$locale_subdomain_assoc = get_all_locales_with_subdomain();
+		$current_locale = get_locale();
+		$current_gp_locale = \GP_Locales::by_field( 'wp_locale', $current_locale );
+
+		// Build a list of WordPress locales which we'll suggest to the user.
+		$suggest_locales = array_values( array_intersect( get_locale_from_header(), get_all_valid_locales() ) );
+
+		$suggestion_links = [];
+		foreach ( $suggest_locales as $locale ) {
+			$language = \GP_Locales::by_field( 'wp_locale', $locale )->native_name;
+			$suggestion_links[ $locale ] = sprintf(
+				'<a href="https://%s.wordpress.org%s">%s</a>',
+				$locale_subdomain_assoc[ $locale ]->subdomain,
+				esc_url( get_site()->path ),
+				$language
+			);
+		}
+
+		$suggest_string = '';
+
+		unset( $suggestion_links[ $current_locale ] );
+
+		if ( ! empty( $suggestion_links ) ) {
+			$output_locale = key( $suggestion_links );
+			switch_to_locale( $output_locale );
+			$suggest_string = sprintf(
+				// translators: %s: List of links to theme directory in other locales.
+				__( 'The theme directory is also available in %s.', 'wporg' ),
+				wp_sprintf_l( '%l', $suggestion_links )
+			);
+		}
+
+		// Return more information if this is a debug request.
+		if ( ! empty( $request['debug'] ) ) {
+			return new \WP_REST_Response(
+				array(
+					'currentLocale' => $current_locale,
+					'suggestions' => $suggest_locales,
+					'message' => $suggest_string,
+				)
+			);
+		}
+
+		// The result should be a raw text response.
+		add_filter( 'rest_pre_echo_response', array( $this, 'send_plain_text' ) );
+		return new \WP_REST_Response( $suggest_string );
+	}
+
+	/**
+	 * Get banner for single themes.
+	 */
+	public function get_response_for_item( $request ) {
+		// This has already been validated by `validate_callback`.
+		$theme_slug = $request['slug'];
+
+		if ( ! defined( 'GLOTPRESS_LOCALES_PATH' ) ) {
+			return;
+		}
+
+		require_once GLOTPRESS_LOCALES_PATH;
+
+		$locale_subdomain_assoc = get_all_locales_with_subdomain();
+		$current_locale = get_locale();
+		$current_gp_locale = \GP_Locales::by_field( 'wp_locale', $current_locale );
+		$translated_locales = get_transalated_locales( 'theme', $theme_slug );
+
+		// Build a list of WordPress locales which we'll suggest to the user.
+		$suggest_locales = array_values( array_intersect( get_locale_from_header(), $translated_locales ) );
+
+		$suggestion_links = [];
+		foreach ( $suggest_locales as $locale ) {
+			$language = \GP_Locales::by_field( 'wp_locale', $locale )->native_name;
+			$suggestion_links[ $locale ] = sprintf(
+				'<a href="https://%s.wordpress.org%s">%s</a>',
+				$locale_subdomain_assoc[ $locale ]->subdomain,
+				esc_url( get_site()->path . $theme_slug . '/' ),
+				$language
+			);
+		}
+
+		$suggest_string = '';
+
+		unset( $suggestion_links[ $current_locale ] );
+
+		// If we're on a rosetta site, and the theme is not translated, the message should ask for help.
+		if ( 'en_US' !== $current_locale && $current_gp_locale && ! in_array( $current_locale, $translated_locales ) ) {
+			$output_locale = $current_locale;
+			switch_to_locale( $output_locale );
+			$suggest_string = sprintf(
+				// translators: %s: Locale name.
+				__( 'This theme is not translated into %s yet.', 'wporg' ),
+				$current_gp_locale->native_name
+			);
+
+			// Append some other suggestions if they exist.
+			if ( ! empty( $suggestion_links ) ) {
+				$suggest_string .= ' ' . sprintf(
+					// translators: %s: List of links to theme in other locales.
+					__( 'This theme is available in %s.', 'wporg' ),
+					wp_sprintf_l( '%l', $suggestion_links )
+				);
+			}
+
+			// Lastly, add the call for help.
+			$suggest_string .= ' ' . sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( 'https://translate.wordpress.org/projects/wp-themes/' . $theme_slug ),
+				__( 'Help translate it!', 'wporg' )
+			);
+
+		} else if ( ! empty( $suggestion_links ) ) {
+			$output_locale = key( $suggestion_links );
+			switch_to_locale( $output_locale );
+			$suggest_string = sprintf(
+				// translators: %s: List of links to theme in other locales.
+				__( 'This theme is also available in %s.', 'wporg' ),
+				wp_sprintf_l( '%l', $suggestion_links )
+			);
+			$suggest_string .= ' ' . sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( 'https://translate.wordpress.org/projects/wp-themes/' . $theme_slug ),
+				__( 'Help improve the translation!', 'wporg' )
+			);
+
+		} else if ( ! empty( $locales_from_header ) ) {
+			$output_locale = reset( $locales_from_header );
+			switch_to_locale( $output_locale );
+
+			$suggest_string = sprintf(
+				// translators: %s: Locale name.
+				__( 'This theme is not translated into %s yet.', 'wporg' ),
+				\GP_Locales::by_field( 'wp_locale', $output_locale )->native_name
+			);
+			$suggest_string .= ' ' . sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( 'https://translate.wordpress.org/projects/wp-themes/' . $theme_slug ),
+				__( 'Help translate it!', 'wporg' )
+			);
+		}
+
+		// Return more information if this is a debug request.
+		if ( ! empty( $request['debug'] ) ) {
+			return new \WP_REST_Response(
+				array(
+					'currentLocale' => $current_locale,
+					'suggestions' => $suggest_locales,
+					'message' => $suggest_string,
+				)
+			);
+		}
+
+		// The result should be a raw text response.
+		add_filter( 'rest_pre_echo_response', array( $this, 'send_plain_text' ) );
+		return new \WP_REST_Response( $suggest_string );
+	}
+}

--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -20,6 +20,19 @@ function initialize_rest_endpoints() {
 
 	$users_controller = new Users_Controller();
 	$users_controller->register_routes();
+
+	if ( defined( 'WPORG_THEME_DIRECTORY_BLOGID' ) && WPORG_THEME_DIRECTORY_BLOGID === get_current_blog_id() ) {
+		require_once __DIR__ . '/endpoints/class-wporg-base-locale-banner-controller.php';
+		require_once __DIR__ . '/endpoints/class-wporg-themes-locale-banner-controller.php';
+		$locale_banner_controller = new Themes_Locale_Banner_Controller();
+		$locale_banner_controller->register_routes();
+	}
+	if ( class_exists( 'WordPressdotorg\Plugin_Directory\Plugin_Directory' ) ) {
+		require_once __DIR__ . '/endpoints/class-wporg-base-locale-banner-controller.php';
+		require_once __DIR__ . '/endpoints/class-wporg-plugins-locale-banner-controller.php';
+		$locale_banner_controller = new Plugins_Locale_Banner_Controller();
+		$locale_banner_controller->register_routes();
+	}
 }
 
 /**


### PR DESCRIPTION
See https://github.com/WordPress/wporg-theme-directory/pull/52 — I've moved `rest-api-locale.php` to `mu-plugins/helpers/locale.php`, and the endpoint to `rest-api/endpoints/`. In fact, I've updated the code to handle both theme and plugin requests, so that all this locale-banner-related code can stay in one place (this isn't exactly what was requested on the other PR, but once I started building it out as two similar endpoints, it made sense to share a base class & live here).

The endpoints:

- https://wordpress.org/themes/wp-json/wporg-themes/v1/locale-banner/ — Main theme directory banner
- https://wordpress.org/themes/wp-json/wporg-themes/v1/locale-banner/pulitzer — A specific theme request
- https://wordpress.org/plugins/wp-json/wporg-plugins/v1/locale-banner/ — Main plugin directory banner
- https://wordpress.org/plugins/wp-json/wporg-plugins/v1/locale-banner/recipe-block/ — A specific plugin request

These can also be used from Rosetta URLs

- https://eo.wordpress.org/themes/wp-json/wporg-themes/v1/locale-banner/
- https://eo.wordpress.org/plugins/wp-json/wporg-plugins/v1/locale-banner/recipe-block/

The routes should only appear on the relevant sites, so you can't request `wordpress.org/themes/wp-json/wporg-plugins/v1/locale-banner/`.

This leaves open the possibility to add a `patterns` variation later, if we wanted to.

**To test**

Same instructions as https://github.com/WordPress/wporg-theme-directory/pull/52

> Try out various combinations of header locale (Accept-Language header), theme, rosetta origin site, etc. This needs a sandbox to test for the locale database.

You can also try with the `try/mu-plugins-locale-api` branch on [wporg-theme-directory](https://github.com/WordPress/wporg-theme-directory/compare/try/mu-plugins-locale-api), which should show the banner if your browser is set up to send alternate language suggestions.

There is also a `debug` parameter you can add to the endpoints to show more information about the request. For example,

```sh
$ curl 'https://es.wordpress.org/themes/wp-json/wporg-themes/v1/locale-banner/?debug=1' -H 'Accept-Language: en,ko-KR,es-ES,fr,eo,it,ru'

{
	"currentLocale": "es_ES",
	"suggestions": [
		"ko_KR",
		"es_ES",
		"fr_FR",
		"eo",
		"it_IT",
		"ru_RU"
	],
	"message": "The theme directory is also available in <a href=\"https:\/\/ko.wordpress.org\/themes\/\">한국어<\/a>, <a href=\"https:\/\/fr.wordpress.org\/themes\/\">Français<\/a>, <a href=\"https:\/\/eo.wordpress.org\/themes\/\">Esperanto<\/a>, <a href=\"https:\/\/it.wordpress.org\/themes\/\">Italiano<\/a>, 그리고 <a href=\"https:\/\/ru.wordpress.org\/themes\/\">Русский<\/a>."
}
```