### PR TITLE
Screenshot Preview block: Enable block to be "hidden" initially, prevent image fetch

### DIFF
--- a/mu-plugins/blocks/screenshot-preview-block/README.md
+++ b/mu-plugins/blocks/screenshot-preview-block/README.md
@@ -24,14 +24,29 @@ The same as above, but instead of adding the block to `block-templates/*.html` f
 echo do_blocks( '<!-- wp:wporg/screenshot-preview {"src":"https://wordpress.org/"} /-->' );
 ```
 
+## Showing/hiding an image
+
+If you pass through `"isHidden":true` as a block attribute, this will trigger a CSS class to hide the block, and prevent any network requests loading the image. To show the image, currently this requires manually dispatching a custom event.
+
+For example, in another block on a button click event, the `wporg-show` event can be triggered. This will call `actions.makeVisible` within the correct element context, flipping off the `isHidden` value. The context update then triggers the `watch` action, which fetches the image if it's not already loaded.
+
+```js
+// container is a wrapper around multiple screenshot preview blocks.
+container.querySelectorAll( '.wp-block-wporg-screenshot-preview' ).forEach( ( element ) => {
+    const event = new Event( 'wporg-show' );
+    element.dispatchEvent( event );
+} );
+```
+
 ## Attributes
 
-| Name          | Type    | Description                                | Default |
-|---------------|---------|--------------------------------------------|---------|
-| alt            | string  | Alt text for image.                         | ""      |
-| fullPage       | boolean | If true, image only captures page content, up to viewportHeight. If false, image is fixed height (viewportHeight), with whitespace surrounding. | "" |
-| href           | string  | Destination for link wrapper, if provided.  | ""      |
-| src            | string  | Source (website) to capture for display     | ""      |
-| viewportHeight | integer | Viewport height (or max-height if fullPage) | 0       |
-| viewportWidth  | integer | Viewport width                              | 1200    |
-| width          | integer | Image width                                 | 800     |
+| Name           | Type    | Description                                | Default |
+|----------------|---------|--------------------------------------------|---------|
+| alt            | string  | Alt text for image.                         | ""     |
+| fullPage       | boolean | If true, image only captures page content, up to viewportHeight. If false, image is fixed height (viewportHeight), with whitespace surrounding. | true |
+| href           | string  | Destination for link wrapper, if provided.  | ""     |
+| isHidden       | boolean | If true, hide the block with CSS, prevent network requests. | false |
+| src            | string  | Source (website) to capture for display     | ""     |
+| viewportHeight | integer | Viewport height (or max-height if fullPage) | 0      |
+| viewportWidth  | integer | Viewport width                              | 1200   |
+| width          | integer | Image width                                 | 800    |

--- a/mu-plugins/blocks/screenshot-preview-block/render.php
+++ b/mu-plugins/blocks/screenshot-preview-block/render.php
@@ -10,6 +10,7 @@ if ( ! $view_url ) {
 
 $alt_text = $attributes['alt'] ?? '';
 $has_link = isset( $attributes['href'] ) && $attributes['href'];
+$is_hidden = (bool) $attributes['isHidden'];
 
 // Set up the viewport sizes.
 $viewport_width = $attributes['viewportWidth'] ?? 1200;
@@ -44,6 +45,7 @@ $init_state = [
 	'attempts' => 0,
 	'shouldRetry' => true,
 	'hasError' => false,
+	'isHidden' => $is_hidden,
 ];
 $encoded_state = wp_json_encode( $init_state );
 
@@ -57,9 +59,11 @@ if ( $has_link ) {
 	<?php echo get_block_wrapper_attributes( array( 'class' => $classname ) ); // phpcs:ignore ?>
 	data-wp-interactive="wporg/screenshot-preview"
 	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
-	data-wp-init="callbacks.init"
+	data-wp-watch="callbacks.init"
 	data-wp-class--has-loaded="state.hasLoaded"
 	data-wp-class--has-error="state.hasError"
+	data-wp-class--is-hidden="context.isHidden"
+	data-wp-on--wporg-show="actions.makeVisible"
 	tabIndex="-1"
 >
 	<?php if ( $has_link ) : ?>

--- a/mu-plugins/blocks/screenshot-preview-block/src/block.json
+++ b/mu-plugins/blocks/screenshot-preview-block/src/block.json
@@ -20,6 +20,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"isHidden": {
+			"type": "boolean",
+			"default": false
+		},
 		"src": {
 			"type": "string",
 			"default": ""

--- a/mu-plugins/blocks/screenshot-preview-block/src/style.scss
+++ b/mu-plugins/blocks/screenshot-preview-block/src/style.scss
@@ -22,6 +22,10 @@
 		box-shadow: none;
 	}
 
+	&:where(.is-hidden) {
+		display: none;
+	}
+
 	.wporg-screenshot-preview__container {
 		aspect-ratio: 4 / 3;
 		display: flex;

--- a/mu-plugins/blocks/screenshot-preview-block/src/view.js
+++ b/mu-plugins/blocks/screenshot-preview-block/src/view.js
@@ -44,6 +44,11 @@ const { actions, state } = store( 'wporg/screenshot-preview', {
 			context.base64Image = value;
 		},
 
+		makeVisible() {
+			const context = getContext();
+			context.isHidden = false;
+		},
+
 		*fetchImage( fullUrl ) {
 			try {
 				const context = getContext();
@@ -72,9 +77,12 @@ const { actions, state } = store( 'wporg/screenshot-preview', {
 	},
 
 	callbacks: {
-		// Run on init, starts the image fetch process.
+		// Run on any changes, trigger the image fetch process.
 		*init() {
-			const { src } = getContext();
+			const { isHidden, src } = getContext();
+			if ( isHidden ) {
+				return;
+			}
 
 			if ( ! state.base64Image ) {
 				// Initial fetch.


### PR DESCRIPTION
This adds a new attribute to the Screenshot Preview block, which renders the block on the page but hides it and does not fetch the image. Previously, having the block on the page (even hidden with CSS) would cause the `fetchImage` process to run, triggering queries for every block on the page even if they're not visible. Now, the image is hidden until a custom `show` event is fired. Eventually this could work in conjunction with something like the `useInView` hook of the React component, but for now it's manually triggered.

See https://github.com/WordPress/wporg-theme-directory/issues/42

To test

- Create a page with screenshot blocks, for example
    ```
    <!-- wp:wporg/screenshot-preview {"fullPage":false,"src":"https://wordpress.org/"} /-->

    <!-- wp:wporg/screenshot-preview {"fullPage":false,"src":"https://wordpress.org/about/","isHidden":true} /-->
    ```
- Load the page
- Only the first screenshot (wporg homepage) should be visible
- There should only be network requests for that one image
- Trigger the load event in console
    ```js
    document.querySelector( '.wp-block-wporg-screenshot-preview.is-hidden' ).dispatchEvent( new Event( 'show' ) );
    ```
- The second image will trigger network requests, then should appear

Or test with the [try/screenshot-preview-hidden branch](https://github.com/WordPress/wporg-theme-directory/compare/try%2Fscreenshot-preview-hidden) of the theme directory.