### PR TITLE
Remove links to Swag store

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -574,11 +574,6 @@ function get_global_menu_items() {
 					'url'   => 'https://wordpress.org/gutenberg/',
 					'type'  => 'custom',
 				),
-				array(
-					'title' => esc_html_x( 'Swag Store ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://mercantile.wordpress.org/',
-					'type'  => 'custom',
-				),
 			),
 		),
 	);

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -91,9 +91,6 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 		<!-- wp:list-item -->
 		<li><a href="https://wordpressfoundation.org/donate/"><?php echo esc_html_x( 'Donate ↗', 'Menu item title', 'wporg' ); ?></a></li>
 		<!-- /wp:list-item -->
-		<!-- wp:list-item -->
-		<li><a href="https://mercantile.wordpress.org/"><?php echo esc_html_x( 'Swag Store ↗', 'Menu item title', 'wporg' ); ?></a></li>
-		<!-- /wp:list-item -->
 	</ul>
 	<!-- /wp:list -->
 


### PR DESCRIPTION
Removes links to swag store from global header and footer. Does not replace theme, a follow up PR will do that.

See #614 