### PR TITLE
Fixed missing quotes on the code is poetry src

### DIFF
--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -158,7 +158,7 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 		<!-- wp:image {"width":188,"height":13,"className":"global-footer__code_is_poetry"} -->
 		<figure class="wp-block-image is-resized global-footer__code_is_poetry">
 			<img
-				src=<?php echo esc_url( $code_is_poetry_src ); ?>
+				src="<?php echo esc_url( $code_is_poetry_src ); ?>"
 				alt="<?php echo esc_html_x( 'Code is Poetry', 'Image alt text', 'wporg' ); ?>"
 				width="188"
 				height="13"


### PR DESCRIPTION
This PR fixes the missing quotes on the "Code is Poetry" image src attribute in the footer. This was identified when running https://wordpress.org/ through the Equalize Digital Accessibility Checker plugin. The missing quotes cause false positives in this plugin.

![Screenshot 2024-06-04 at 12 43 05 PM](https://github.com/WordPress/wporg-mu-plugins/assets/2895788/44228fa1-1c43-4325-9f4d-86f9d4ddb26a)
