### PR TITLE
Add Five for the Future link to global footer

### DIFF
--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -91,6 +91,9 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 		<!-- wp:list-item -->
 		<li><a href="https://wordpressfoundation.org/donate/"><?php echo esc_html_x( 'Donate ↗', 'Menu item title', 'wporg' ); ?></a></li>
 		<!-- /wp:list-item -->
+		<!-- wp:list-item -->
+		<li><a href="https://wordpress.org/five-for-the-future/"><?php echo esc_html_x( 'Five for the Future', 'Menu item title', 'wporg' ); ?></a></li>
+		<!-- /wp:list-item -->
 	</ul>
 	<!-- /wp:list -->
 


### PR DESCRIPTION
See #614 

Replaces the Swag store links which have been removed while the store is closed.

![Screenshot 2024-06-05 at 10 21 26 AM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/9bc66e72-b54c-4df9-92a3-6bc6bad30619)
