### PR TITLE
Add tag name configurability to global footer block

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -847,8 +847,10 @@ function render_global_footer( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array( 'class' => 'global-footer wp-block-group' )
 	);
+	$tag_name = $attributes['tagName'] ?? 'footer';
 	return sprintf(
-		'<footer %1$s>%2$s</footer>%3$s',
+		'<%1$s %2$s>%3$s</%1$s>%4$s',
+		$tag_name,
 		$wrapper_attributes,
 		$markup,
 		$footer_markup,

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -847,7 +847,13 @@ function render_global_footer( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array( 'class' => 'global-footer wp-block-group' )
 	);
-	$tag_name = $attributes['tagName'] ?? 'footer';
+
+	$tag_name = $attributes['tagName'];
+	$allowed_tag_names = array( 'footer', 'div', 'section' );
+	if ( ! $tag_name || ! in_array( $tag_name, $allowed_tag_names, true ) ) {
+		$tag_name = 'footer';
+	}
+
 	return sprintf(
 		'<%1$s %2$s>%3$s</%1$s>%4$s',
 		$tag_name,

--- a/mu-plugins/blocks/global-header-footer/src/footer/block.json
+++ b/mu-plugins/blocks/global-header-footer/src/footer/block.json
@@ -26,7 +26,12 @@
 			"width": true
 		}
 	},
-	"attributes": {},
+	"attributes": {
+		"tagName": {
+			"type": "string",
+			"default": "footer"
+		}
+	},
 	"textdomain": "wporg",
 	"style": "wporg-global-header-footer",
 	"editorStyle": "wporg-global-header-footer",


### PR DESCRIPTION
See https://github.com/WordPress/Learn/issues/2501 and https://wordpress.slack.com/archives/C01KC5VDQBC/p1717552327365119?thread_ts=1717455021.461299&cid=C01KC5VDQBC

On Learn there is a site footer above the global footer. This is currently between the `main` and the `footer` landmark provided by the global footer block. For accessibility reasons there shouldn't be content between these landmarks.

This PR adds the ability for the tagName to be configured so that the global footer can be nested within a footer element and maintain valid HTML.

Can be tested using https://github.com/WordPress/Learn/pull/2502

There should be no effect in other themes as the default value for the `tagName` attribute is set to `footer`.

### Before

![Screenshot 2024-06-05 at 2 38 30 PM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/72d44b89-846c-48d0-87cd-6891dde56aa4)

### After 

![Screenshot 2024-06-05 at 2 52 30 PM](https://github.com/WordPress/wporg-mu-plugins/assets/1017872/19f35e7b-1fba-4db5-ab80-0a9dd66967dc)