### PR TITLE
Get the locale of current site and send it to lang-guess

### DIFF
--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -27,3 +27,20 @@ function language_suggest_block_init() {
 	);
 }
 add_action( 'init', __NAMESPACE__ . '\language_suggest_block_init' );
+
+function language_suggest_enqueue_scripts() {
+    wp_enqueue_script(
+        'language-suggest-front',
+        plugins_url( 'src/front.js', __FILE__ ),
+        array(),
+        null,
+        true
+    );
+
+    wp_add_inline_script(
+        'language-suggest-front',
+        'var LanguageSuggestData = ' . json_encode( array( 'locale' => get_locale() ) ) . ';',
+        'before'
+    );
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\language_suggest_enqueue_scripts' );

--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -39,7 +39,7 @@ function language_suggest_enqueue_scripts() {
 
     wp_add_inline_script(
         'language-suggest-front',
-        'var languageSuggestData = ' . json_encode( array( 'locale' => get_locale() ) ) . ';',
+        'var languageSuggestData = ' . wp_json_encode( array( 'locale' => get_locale() ) ) . ';',
         'before'
     );
 }

--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -39,7 +39,7 @@ function language_suggest_enqueue_scripts() {
 
     wp_add_inline_script(
         'language-suggest-front',
-        'var LanguageSuggestData = ' . json_encode( array( 'locale' => get_locale() ) ) . ';',
+        'var languageSuggestData = ' . json_encode( array( 'locale' => get_locale() ) ) . ';',
         'before'
     );
 }

--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -11,7 +11,7 @@ const init = () => {
 		container.dataset.endpoint || 'https://wordpress.org/lang-guess/lang-guess-ajax.php'
 	);
 	endpoint.searchParams.set( 'uri', encodeURIComponent( window.location.pathname ) );
-	endpoint.searchParams.set( 'locale', encodeURIComponent( languageSuggestData.locale ) );
+	endpoint.searchParams.set( 'locale', languageSuggestData.locale );
 
 	fetch( endpoint )
 		.then( ( response ) => {

--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -1,3 +1,5 @@
+/* global LanguageSuggestData */
+
 const init = () => {
 	const container = document.querySelector( '.wp-block-wporg-language-suggest' );
 
@@ -5,10 +7,11 @@ const init = () => {
 		return;
 	}
 
-	const endpoint =
-		container.dataset.endpoint ||
-		'https://wordpress.org/lang-guess/lang-guess-ajax.php?uri=' +
-			encodeURIComponent( window.location.pathname );
+	const endpoint = new URL(
+		container.dataset.endpoint || 'https://wordpress.org/lang-guess/lang-guess-ajax.php'
+	);
+	endpoint.searchParams.set( 'uri', encodeURIComponent( window.location.pathname ) );
+	endpoint.searchParams.set( 'locale', encodeURIComponent( LanguageSuggestData.locale ) );
 
 	fetch( endpoint )
 		.then( ( response ) => {

--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -1,4 +1,4 @@
-/* global LanguageSuggestData */
+/* global languageSuggestData */
 
 const init = () => {
 	const container = document.querySelector( '.wp-block-wporg-language-suggest' );
@@ -11,7 +11,7 @@ const init = () => {
 		container.dataset.endpoint || 'https://wordpress.org/lang-guess/lang-guess-ajax.php'
 	);
 	endpoint.searchParams.set( 'uri', encodeURIComponent( window.location.pathname ) );
-	endpoint.searchParams.set( 'locale', encodeURIComponent( LanguageSuggestData.locale ) );
+	endpoint.searchParams.set( 'locale', encodeURIComponent( languageSuggestData.locale ) );
 
 	fetch( endpoint )
 		.then( ( response ) => {


### PR DESCRIPTION
Closes https://github.com/WordPress/Learn/issues/2428

The locale information for Learn comes from the query parameter "locale" rather than the URL subdomain, so this PR retrieves the locale and sends it to lang guess for processing.

lang-guess corresponding tweaks: [meta.trac.wordpress.org/ticket/7675](https://meta.trac.wordpress.org/ticket/7675)