### PR TITLE
Language suggestion: Prevent loading script when not needed

### DIFF
--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -28,19 +28,14 @@ function language_suggest_block_init() {
 }
 add_action( 'init', __NAMESPACE__ . '\language_suggest_block_init' );
 
-function language_suggest_enqueue_scripts() {
-    wp_enqueue_script(
-        'language-suggest-front',
-        plugins_url( 'src/front.js', __FILE__ ),
-        array(),
-        null,
-        true
-    );
-
-    wp_add_inline_script(
-        'language-suggest-front',
-        'var languageSuggestData = ' . wp_json_encode( array( 'locale' => get_locale() ) ) . ';',
-        'before'
-    );
+/**
+ * Inject the locale data for use in viewScript.
+ */
+function add_locale_data() {
+	wp_add_inline_script(
+		'wporg-language-suggest-view-script',
+		'var languageSuggestData = ' . wp_json_encode( array( 'locale' => get_locale() ) ) . ';',
+		'before'
+	);
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\language_suggest_enqueue_scripts' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\add_locale_data' );

--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -22,7 +22,7 @@ function language_suggest_block_init() {
 		'wporg/language-suggest',
 		array(
 			'name'         => 'prominent',
-			'label'        => _x( 'Prominent', 'wporg' ),
+			'label'        => _x( 'Prominent', 'block style name', 'wporg' ),
 		)
 	);
 }


### PR DESCRIPTION
See #626. That PR registered and enqueued the viewScript so that it appeared on every single page, regardless of whether the block was used. Instead, this attaches the data to the viewScript itself, so that it is rendered when the block loads the viewScript.

This also fixes the notice I mentioned in https://github.com/WordPress/wporg-mu-plugins/pull/626#issuecomment-2174428957; and fixes a missing translation context value in the block style.

To test

- Load a page with the language suggest banner
- You should see `language-suggest/build/front.js` in the network tab
- View source, and `languageSuggestData` should be defined
- No JS errors or warnings
- Load a page without the language suggest banner
- No `language-suggest/build/front.js` in the network tab or page source