### PR TITLE
Fonts: Add Noto Serif JP, faux `cjk` subset

### DIFF
--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -135,7 +135,7 @@ function get_font_url( $font, $subset ) {
 	$lower_font   = strtolower( trim( $font ) );
 	$lower_subset = strtolower( trim( $subset ) );
 
-	$valid_subsets = array( 'arrows', 'cyrillic-ext', 'cyrillic', 'greek-ext', 'greek', 'latin-ext', 'latin', 'vietnamese' );
+	$valid_subsets = array( 'arrows', 'cyrillic-ext', 'cyrillic', 'greek-ext', 'greek', 'latin-ext', 'latin', 'vietnamese', 'cjk' );
 	if ( ! in_array( $lower_subset, $valid_subsets ) ) {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			trigger_error( sprintf( 'Requested font subset %s does not exist.', esc_html( $lower_subset ) ), E_USER_WARNING );
@@ -211,6 +211,10 @@ function get_font_url( $font, $subset ) {
 		case 'ibm plex sans semibold':
 			$font_folder    = 'IBMPlexSans/';
 			$font_file_name = 'IBMPlexSans-SemiBold-';
+			break;
+		case 'noto serif':
+			$font_folder    = 'Noto Serif/';
+			$font_file_name = 'NotoSerifJP-';
 			break;
 	}
 

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -212,7 +212,7 @@ function get_font_url( $font, $subset ) {
 			$font_folder    = 'IBMPlexSans/';
 			$font_file_name = 'IBMPlexSans-SemiBold-';
 			break;
-		case 'noto serif':
+		case 'noto serif jp':
 			$font_folder    = 'Noto Serif/';
 			$font_file_name = 'NotoSerifJP-';
 			break;

--- a/mu-plugins/global-fonts/index.php
+++ b/mu-plugins/global-fonts/index.php
@@ -213,7 +213,7 @@ function get_font_url( $font, $subset ) {
 			$font_file_name = 'IBMPlexSans-SemiBold-';
 			break;
 		case 'noto serif jp':
-			$font_folder    = 'Noto Serif/';
+			$font_folder    = 'NotoSerif/';
 			$font_file_name = 'NotoSerifJP-';
 			break;
 	}

--- a/mu-plugins/global-fonts/style.css
+++ b/mu-plugins/global-fonts/style.css
@@ -1244,5 +1244,5 @@
 	font-weight: 200 900;
 	font-style: normal;
 	font-display: swap;
-	src: url(./Noto Serif/NotoSerifJP-cjk.woff2) format("woff2");
+	src: url(./NotoSerif/NotoSerifJP-cjk.woff2) format("woff2");
 }

--- a/mu-plugins/global-fonts/style.css
+++ b/mu-plugins/global-fonts/style.css
@@ -1233,3 +1233,16 @@
 	src: url(./IBMPlexSans/IBMPlexSans-SemiBold-arrows.woff2) format("woff2");
 	unicode-range: U+2190-2199;
 }
+
+/*------------------------------*
+ *  Noto Serif JP               *
+ *------------------------------*/
+
+/* cjk */
+@font-face {
+	font-family: "Noto Serif JP";
+	font-weight: 200 900;
+	font-style: normal;
+	font-display: swap;
+	src: url(./Noto Serif/NotoSerifJP-cjk.woff2) format("woff2");
+}


### PR DESCRIPTION
This PR adds the Noto Serif JP font from [noto-cjk](https://github.com/notofonts/noto-cjk/tree/main/Serif#downloading-noto-serif-cjk), using "Region Specific Subset OTFs Japanese (日本語)".

I've decided to use this version, instead of the subset version suggested in https://github.com/WordPress/wporg-main-2022/issues/427, because this is a variable font. This means we have access to all weights (just like EB Garamond) without having to load multiple font files. This version has also been updated since the subset versions were made.

The font file has been added to the global-fonts CSS, so that w.org sites can use this with `font-family: "Noto Serif JP";`. The font can also be marked for preloading with `global_fonts_preload( 'Noto Serif JP', 'cjk' );`.

Followup PRs to the parent theme and main theme are in progress to actually use the font.

Fixes https://github.com/WordPress/wporg-main-2022/issues/427
