### PR TITLE
Global header, Local navigation: Add aria label to the main, search, and local nav blocks

### DIFF
--- a/mu-plugins/blocks/global-header-footer/header.php
+++ b/mu-plugins/blocks/global-header-footer/header.php
@@ -81,7 +81,7 @@ function recursive_menu( $menu_item, $top_level = true ) {
 <!-- /wp:paragraph -->
 <?php endif; ?>
 
-<!-- wp:navigation {"openSubmenusOnClick":true,"className":"global-header__navigation","layout":{"type":"flex","orientation":"horizontal"}} -->
+<!-- wp:navigation {"openSubmenusOnClick":true,"className":"global-header__navigation","ariaLabel":"<?php echo esc_attr_x( 'Main', 'main navigation label', 'wporg' ); ?>","layout":{"type":"flex","orientation":"horizontal"}} -->
 	<?php
 	/*
 	* Loop though menu items and create navigation item blocks. Recurses through any submenu items to output dropdowns.
@@ -99,7 +99,7 @@ function recursive_menu( $menu_item, $top_level = true ) {
 	calls for. It also provides a consistent experience with the primary navigation menu, with respect to
 	keyboard navigation, ARIA states, etc. It also saves having to write custom code for all the interactions.
 -->
-<!-- wp:navigation {"className":"global-header__search","layout":{"type":"flex","orientation":"vertical"},"overlayMenu":"always"} -->
+<!-- wp:navigation {"className":"global-header__search","ariaLabel":"<?php echo esc_attr_x( 'Search', 'search toggle navigation label', 'wporg' ); ?>","layout":{"type":"flex","orientation":"vertical"},"overlayMenu":"always"} -->
 	<!-- wp:search <?php echo wp_json_encode( $search_args ); ?> /-->
 <!-- /wp:navigation -->
 <?php endif; ?>

--- a/mu-plugins/blocks/local-navigation-bar/index.php
+++ b/mu-plugins/blocks/local-navigation-bar/index.php
@@ -98,6 +98,7 @@ function update_child_block_attributes( $parsed_block, $source_block, $parent_bl
 			'type' => 'flex',
 			'orientation' => 'horizontal',
 		);
+		$parsed_block['attrs']['ariaLabel'] = _x( 'Section', 'local navigation label', 'wporg' );
 
 		// Add an extra navigation block which is always collapsed, so that it
 		// can be swapped out when the section title + nav menu collide.


### PR DESCRIPTION
Fixes #622 — This PR adds aria-labels to the 3 header `nav` elements. There are two in the global header, the main navigation element and the search toggle; and one in the local navigation bar just below the global header. This PR adds aria labels to each, so they are now "Main", "Search", and "Section", respectively.

```
<nav class="is-responsive global-header__navigation …" aria-label="Main" data-wp-interactive…
```

```
<nav class="is-responsive  is-vertical global-header__search …" aria-label="Search" data-wp-interactive…
```

```
<nav class="has-small-font-size is-responsive …" aria-label="Section" data-wp-interactive…
```

Note: There is a separate issue to merge the search toggle into the main navigation landmark #311, but that would require more refactoring of the header. For now, I've just added the aria label to clarify that nav too.

**To test**

- View a page with the global header (should be any page)
- The first two navigation elements have `aria-label`s
- View a page with a local navigation bar (About, a download subpage, one of the directories)
- The local navigation menu should also have an aria-label.

CC @bbertucc, @alexstine 