### PR TITLE
Site Breadcrumbs: Return empty string when breadcrumbs is an empty array

### DIFF
--- a/mu-plugins/blocks/site-breadcrumbs/index.php
+++ b/mu-plugins/blocks/site-breadcrumbs/index.php
@@ -69,6 +69,10 @@ function render_block( $attributes, $content, $block ) {
 	 */
 	$breadcrumbs = apply_filters( 'wporg_block_site_breadcrumbs', $breadcrumbs, $attributes, $block );
 
+	if ( empty( $breadcrumbs ) ) {
+		return '';
+	}
+
 	$content = '';
 	foreach ( $breadcrumbs as $i => $crumb ) {
 		// We can assume that the item without a URL is the current page.


### PR DESCRIPTION
In the design of most wporg sites, breadcrumbs are not needed when the level is less than 3. Therefore, a filter is usually applied to the breadcrumbs block to make the breadcrumbs an empty array. If this early return is not implemented, it would still return a div that occupies space.

See https://github.com/WordPress/Learn/pull/2598/commits/6fa130a1dd222cf020da700f0afb9b65cef33643