### PR TITLE
Local navigation block: Hide page title before collapsing menu

### DIFF
--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -185,7 +185,7 @@
 		}
 	}
 
-	@media ( max-width: 550px ) {
+	@media ( max-width: 599px ) {
 		& .wp-block-group p:not(.wp-block-site-title) {
 			display: none;
 		}

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -341,6 +341,12 @@
 		display: none;
 	}
 
+	&.wporg-hide-page-title {
+		& .wp-block-group p:not(.wp-block-site-title) {
+			display: none;
+		}
+	}
+
 	&.wporg-show-collapsed-nav {
 		& .wp-block-navigation {
 			display: none;

--- a/mu-plugins/blocks/local-navigation-bar/src/view.js
+++ b/mu-plugins/blocks/local-navigation-bar/src/view.js
@@ -114,7 +114,6 @@ function init() {
 
 			const usedFullWidth = Math.ceil( fullTitleWidth ) + Math.ceil( navWidth );
 			const usedShortWidth = Math.ceil( soloTitleWidth ) + Math.ceil( navWidth );
-			console.log( { availableWidth, usedFullWidth, usedShortWidth } );
 
 			if ( availableWidth > usedFullWidth ) {
 				// Screen is large enough for everything, show all.


### PR DESCRIPTION
Fixes #640, see See https://github.com/WordPress/Learn/issues/2622. When elements (site title, page title, navigation) are too long, they can overlap or cause wrapping issues. In https://github.com/WordPress/wporg-mu-plugins/pull/573, the navigation menu collapsed when they would wrap, but in some cases this can cause the navigation to be hidden on more screen-sizes than is ideal. Instead, the navigation menu should be prioritized, and the page title can be hidden first.

This PR updates the logic, so that the page title is hidden first, extending the screen sizes that will see the correct desktop version of the nav bar. If the menu will still collide with the site title, it does collapse down into the chevron dropdown, but this is only at some screen sizes, since most site titles are short.

**Screenshots**

Screen recording of shrinking the screen from 1440px, with an exaggerated page title and menu length. The page title disappears around 1300px, and while the menu stays inline until around 970px (where it would otherwise run into the site title). Previously, the menu would collapse at that 1300 width. (Note that these breakpoints are relative to the page content, not universal)

https://github.com/user-attachments/assets/e5c47d7c-b332-45fd-842b-f415e2ce444f

| | Before | After |
|---|---|---|
| 1310px | ![Screen Shot 2024-07-18 at 17 14 13](https://github.com/user-attachments/assets/e9aac4ff-5dbe-4192-b94e-a48b17135592) | same |
| 1300px | ![Screen Shot 2024-07-18 at 17 19 44](https://github.com/user-attachments/assets/943b4546-9b43-4534-b939-33b3b5353dc4) | ![Screen Shot 2024-07-18 at 17 14 17](https://github.com/user-attachments/assets/90db40cd-36f1-4b8f-8627-e0a867e50749) |

On a real page, the Learn menu is now visible here, where previously it collapsed on a larger screen size.

![Screen Shot 2024-07-18 at 17 42 50](https://github.com/user-attachments/assets/cd6dfdee-8bf4-4f0b-b579-cbdf970d4c59)

**To test:**

- View a site with a "L2B" page header — has the site title and a page title.
- Scroll down so you can see the page title (easier to test)
- Shrink your screen down, the page title should disappear before the menu collapses into a chevron
- Nothing should wrap to a second line
- The mobile menu kicks in at 600px, and there should be no change there
