### PR TITLE
Global header, local nav: Make the logo bigger

### DIFF
--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -31,11 +31,6 @@ html {
 		padding-left: var(--wp--style--block-gap);
 		padding-right: var(--wp--style--block-gap);
 		margin: 0;
-
-		@media (--tablet) {
-			padding-top: 33px;
-			padding-bottom: 33px;
-		}
 	}
 
 	& .global-header__search,
@@ -43,14 +38,10 @@ html {
 		padding: 0;
 
 		& .wp-block-navigation__responsive-container-open {
-
-			/* Magic numbers to center the 24px icon in 60px height. */
-			padding: 18px 16px 18px;
-
-			@media (--tablet) {
-				padding-top: 37px;
-				padding-bottom: 37px;
-			}
+			padding-top: calc((var(--wp-global-header-height) - 24px) / 2);
+			padding-right: 16px;
+			padding-bottom: calc((var(--wp-global-header-height) - 24px) / 2);
+			padding-left: 16px;
 		}
 	}
 

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -26,19 +26,9 @@
 	& .wp-block-image > a {
 		display: inline-flex;
 		box-sizing: content-box;
-		height: 27px;
-		padding: 16px var(--wp--style--block-gap);
+		height: 30px;
+		padding: calc((var(--wp-global-header-height) - 30px) / 2) var(--wp--style--block-gap);
 		color: var(--wp-global-header--text-color);
-
-		@media (--tablet) {
-			padding-top: 31px;
-			padding-bottom: 32px;
-		}
-
-		@media (--short-screen) {
-			padding-bottom: 16px;
-			padding-top: 16px;
-		}
 
 		&:hover {
 			background-color: var(--wp-global-header--background-color--hover);

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -147,10 +147,10 @@
 			}
 
 			@media (--tablet) {
-				padding-bottom: calc(33px - var(--active-menu-item-border-height, 0px));
-				padding-top: 33px;
-				padding-left: calc(var(--wp--style--block-gap) / 2);
+				padding-top: calc((var(--wp-global-header-height) - 24px) / 2);
 				padding-right: calc(var(--wp--style--block-gap) / 2);
+				padding-bottom: calc((var(--wp-global-header-height) - 24px) / 2 - var(--active-menu-item-border-height, 0px));
+				padding-left: calc(var(--wp--style--block-gap) / 2);
 			}
 
 			@media (--short-screen) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/search.pcss
@@ -13,17 +13,8 @@
 
 	& .wp-block-navigation__responsive-container-open,
 	& .wp-block-navigation__responsive-container-close {
-
-		@media (--tablet) {
-			padding-top: 33px;
-			padding-bottom: 33px;
-		}
-
-		@media (--short-screen) {
-			padding-bottom: 20px;
-			padding-top: 16px;
-			background-position: center;
-		}
+		padding-top: calc((var(--wp-global-header-height) - 24px) / 2);
+		padding-bottom: calc((var(--wp-global-header-height) - 24px) / 2);
 
 		&:focus-visible {
 			outline: none;

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -69,9 +69,12 @@
 			top: -5px;
 			left: 0;
 			opacity: 0;
-			padding: 16px var(--wp--style--block-gap);
+			padding: calc(var(--wp--custom--local-navigation-bar--spacing--height) / 2 - 15px) var(--wp--style--block-gap);
+			padding-left: calc(var(--wp--style--block-gap) + 5px);
 			transition: all 0.2s ease-in-out;
 			visibility: hidden;
+			box-sizing: content-box;
+			width: 30px;
 
 			& a {
 				display: block;
@@ -81,6 +84,9 @@
 
 			& svg {
 				fill: currentcolor;
+				display: block;
+				height: auto;
+				width: 100%;
 			}
 		}
 


### PR DESCRIPTION
Fixes #646. Adjust the spacing around the logo and other elements to use a calculated value from the nav bar height, so the extra media queries can be removed. This also adjusts the size of the logo from ~27px to 30px, [making the logo bigger](https://images.app.goo.gl/Hz8tyJR5omQZPQCL7).

**Screenshots**

| Before | After |
|---|---|
| ![logo-before-top](https://github.com/user-attachments/assets/dcb6b71e-5293-40a7-906e-b921d8069f19) | ![logo-after-top](https://github.com/user-attachments/assets/28860eae-a483-4bb8-a02c-76c523ee2849) |
| ![logo-before-scroll](https://github.com/user-attachments/assets/7ef9a1b1-cec6-4f61-81b3-baf806d51c36) | ![logo-after-scroll](https://github.com/user-attachments/assets/d6407907-fe59-4646-9a30-a22a2ec16285) |
| ![logo-before-mobile](https://github.com/user-attachments/assets/35709766-98d5-4f2f-9a30-dded71fff696) | ![logo-after-mobile](https://github.com/user-attachments/assets/6e403c00-9ea0-4839-a349-a43c2895029b) |
| ![logo-before-download](https://github.com/user-attachments/assets/1355864f-409b-40d1-9207-efb44b1b08ff) | ![logo-after-download](https://github.com/user-attachments/assets/87baa3be-c61a-4f65-ab8a-200427337422) |
