### PR TITLE
Add a shortcode for nocookie youtube embeds

### DIFF
--- a/mu-plugins/plugin-tweaks/index.php
+++ b/mu-plugins/plugin-tweaks/index.php
@@ -13,3 +13,4 @@ require_once __DIR__ . '/wporg-internal-notes.php';
 require_once __DIR__ . '/stream.php';
 require_once __DIR__ . '/incompatible-plugins.php';
 require_once __DIR__ . '/gutenberg.php';
+require_once __DIR__ . '/youtube-shortcode.php';

--- a/mu-plugins/plugin-tweaks/youtube-shortcode.php
+++ b/mu-plugins/plugin-tweaks/youtube-shortcode.php
@@ -19,11 +19,10 @@ add_shortcode( 'youtube-nocookie', __NAMESPACE__ . '\render' );
  *
  * @param array  $attr    Shortcode attributes array, can be empty if the original arguments string cannot be parsed.
  * @param string $content Content inside shortcode tags.
- * @param string $tag     Shortcode name.
  *
  * @return string HTML code for iframe embed.
  */
-function render( $attr, $content, $tag ) {
+function render( $attr, $content ) {
 	// Short out early if the content is not a valid URL.
 	// Returns null if content is not a URL at all.
 	$host = wp_parse_url( $content, PHP_URL_HOST );

--- a/mu-plugins/plugin-tweaks/youtube-shortcode.php
+++ b/mu-plugins/plugin-tweaks/youtube-shortcode.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Add a shortcode for nocookie youtube embeds.
+ *
+ * These are not supported in the core embed block or shortcode.
+ * See https://core.trac.wordpress.org/ticket/44610
+ */
+
+namespace WordPressdotorg\MU_Plugins\Plugin_Tweaks\Youtube_Shortcode;
+
+add_shortcode( 'youtube-nocookie', __NAMESPACE__ . '\render' );
+
+/**
+ * Render the youtube iframe.
+ *
+ * The shortcode content is the URL, checked against a safelist of
+ * `youtube-nocookie` domains. Attributes can be `width`, `height`,
+ * and `title.
+ *
+ * @param array  $attr    Shortcode attributes array, can be empty if the original arguments string cannot be parsed.
+ * @param string $content Content inside shortcode tags.
+ * @param string $tag     Shortcode name.
+ *
+ * @return string HTML code for iframe embed.
+ */
+function render( $attr, $content, $tag ) {
+	// Short out early if the content is not a valid URL.
+	// Returns null if content is not a URL at all.
+	$host = wp_parse_url( $content, PHP_URL_HOST );
+	$valid_hosts = [ 'www.youtube-nocookie.com', 'youtube-nocookie.com' ];
+	if ( ! in_array( $host, $valid_hosts, true ) ) {
+		return '';
+	}
+
+	$defaults = array(
+		'width' => '100%',
+		'height' => false,
+		'title' => 'YouTube video player',
+	);
+	$args = shortcode_atts( $defaults, $attr );
+
+	$html_attrs = '';
+	foreach ( $args as $name => $value ) {
+		if ( $value ) {
+			$html_attrs .= $name . '="' . esc_attr( $value ) . '" ';
+		}
+	}
+
+	return sprintf(
+		// `allow` settings copied from youtube-provided embed code.
+		'<iframe style="aspect-ratio: 16/9;" src="%s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen %s></iframe>',
+		esc_url( $content ),
+		$html_attrs
+	);
+}


### PR DESCRIPTION
See https://github.com/WordPress/wporg-main-2022/issues/493#issuecomment-2316230298 — We'd like to use the "privacy-enhanced" youtube embeds, but the domain used is not supported by the core embeds. I've put this code in wporg-mu-plugins because I'll also want to use it on WCUS's livestream pages; and I can see needing it on other pages.

Hopefully [the core ticket](https://core.trac.wordpress.org/ticket/44610) will be fixed at some point, and we can phase this out.

```
[youtube-nocookie title="Showcase Day video player"]https://www.youtube-nocookie.com/embed/PM2Ov8atqBw?si=4YwCx25TQfdWPcW_[/youtube-nocookie]
```

<img width="768" alt="Screenshot 2024-09-10 at 6 34 43 PM" src="https://github.com/user-attachments/assets/1beca746-07c2-4527-9bbd-0191cabb5d55">

**To test**

- Find a youtube video
- Click share, embed to get to the iframe code
- Select "Enable privacy-enhanced mode."

<img width="417" alt="Screenshot 2024-09-10 at 6 32 06 PM" src="https://github.com/user-attachments/assets/8145f131-c9b0-4408-9d31-b8f93aacd061">

- From there, copy out the `src` URL
- Create or edit a post, add the shortcode block
- Add the shortcode: `[youtube-nocookie]COPIED URL[/youtube-nocookie]`
- Optionally set height, width, and title attributes

Try other URLs, it should only create the iframe for youtube-nocookie.com domains.

