### PR TITLE
Link Wrapper: Default to the permalink if the url isn't defined

### DIFF
--- a/mu-plugins/blocks/link-wrapper/index.php
+++ b/mu-plugins/blocks/link-wrapper/index.php
@@ -35,9 +35,12 @@ function init() {
  * @param string $content    Block content.
  * @return string Rendered block HTML.
  */
-function render( $attributes, $content ) {
+function render( $attributes, $content, $block ) {
+	$post_id   = $block->context['postId'];
+	$post_slug = get_post_field( 'post_name', $post_id );
+	$link  = isset( $attributes['url'] ) ? ' ' . $attributes['url'] : site_url( $post_slug );
+
 	$wrapper_attributes = get_block_wrapper_attributes();
-	$link  = isset( $attributes['url'] ) ? ' ' . $attributes['url'] : get_permalink();
 
 	return sprintf(
 		'<a href="%1$s" %2$s>%3$s</a>',

--- a/mu-plugins/blocks/link-wrapper/index.php
+++ b/mu-plugins/blocks/link-wrapper/index.php
@@ -20,5 +20,29 @@ add_action( 'init', __NAMESPACE__ . '\init' );
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function init() {
-	register_block_type( __DIR__ . '/build' );
+	register_block_type(
+		__DIR__ . '/build',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Renders the Link Wrapper block.
+ *
+ * @param array  $attributes Block attributes.
+ * @param string $content    Block content.
+ * @return string Rendered block HTML.
+ */
+function render( $attributes, $content ) {
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$link  = isset( $attributes['url'] ) ? ' ' . $attributes['url'] : get_permalink();
+
+	return sprintf(
+		'<a href="%1$s" %2$s>%3$s</a>',
+		esc_url( $link ),
+		$wrapper_attributes,
+		do_blocks( $content )
+	);
 }

--- a/mu-plugins/blocks/link-wrapper/src/block.json
+++ b/mu-plugins/blocks/link-wrapper/src/block.json
@@ -30,6 +30,9 @@
 				"padding": true
 			}
 		},
+		"dimensions": {
+			"minHeight": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true

--- a/mu-plugins/blocks/link-wrapper/src/block.json
+++ b/mu-plugins/blocks/link-wrapper/src/block.json
@@ -6,6 +6,7 @@
 	"icon": "admin-links",
 	"category": "layout",
 	"description": "Link a set of blocks to a given page.",
+	"usesContext": [ "postId" ],
 	"textdomain": "wporg",
 	"attributes": {
 		"url": {

--- a/mu-plugins/blocks/link-wrapper/src/index.js
+++ b/mu-plugins/blocks/link-wrapper/src/index.js
@@ -24,6 +24,7 @@ function Edit( { attributes, setAttributes } ) {
 		<>
 			<InspectorControls key="setting">
 				<PanelBody title={ __( 'Link destination', 'wporg' ) }>
+					<p>{ __( 'Defaults to the permalink if not set.', 'wporg' ) }</p>
 					<TextControl
 						label={ __( 'Link destination', 'wporg' ) }
 						hideLabelFromVision
@@ -55,12 +56,7 @@ function Edit( { attributes, setAttributes } ) {
 
 registerBlockType( metadata.name, {
 	edit: Edit,
-	save: ( { attributes } ) => {
-		const blockProps = useBlockProps.save();
-		return (
-			<a { ...blockProps } href={ attributes.url }>
-				<InnerBlocks.Content />
-			</a>
-		);
+	save: () => {
+		return <InnerBlocks.Content />;
 	},
 } );


### PR DESCRIPTION
This enables the block to be used in query loops, for example the Make homepage team grid.

Uses server side rendering so that the permalink can be easily looked up.