### PR TITLE
Output message when no ratings exist.

### DIFF
--- a/mu-plugins/blocks/ratings-bars/render.php
+++ b/mu-plugins/blocks/ratings-bars/render.php
@@ -34,7 +34,7 @@ $defaults = array(
 $data = wp_parse_args( $data, $defaults );
 
 if ( empty( $data['ratings'] ) || empty( $data['ratingsCount'] ) ) {
-	echo '<p>' . esc_html__( 'No ratings have been submitted yet.', 'wporg' ) . '</p>';
+	echo '<p>' . esc_html__( 'No reviews have been submitted yet.', 'wporg' ) . '</p>';
 	return;
 }
 

--- a/mu-plugins/blocks/ratings-bars/render.php
+++ b/mu-plugins/blocks/ratings-bars/render.php
@@ -34,6 +34,7 @@ $defaults = array(
 $data = wp_parse_args( $data, $defaults );
 
 if ( empty( $data['ratings'] ) || empty( $data['ratingsCount'] ) ) {
+	echo '<p>' . esc_html__( 'No ratings have been submitted yet.', 'wporg' ) . '</p>';
 	return;
 }
 


### PR DESCRIPTION
See: https://github.com/WordPress/wordpress.org/pull/380

This block doesn't have any view when no ratings exist.

| Before | After |
|--------|--------|
| <img width="375" alt="Screenshot 2024-10-07 at 10 38 53 AM" src="https://github.com/user-attachments/assets/6fef105e-c03e-48c3-8577-1497985ac9c9"> | <img width="370" alt="Screenshot 2024-10-07 at 10 38 43 AM" src="https://github.com/user-attachments/assets/a63a11a8-585e-468e-8eea-02bc95c43f0a"> | 
