### PR TITLE
Global header: Implement design updates

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/view.js
+++ b/mu-plugins/blocks/global-header-footer/js/view.js
@@ -193,29 +193,16 @@
 			closeSearchButton.setAttribute( 'aria-label', labels.closeSearchLabel || 'Close Search' );
 		}
 
-		// Watch for the `has-modal-open` class to be removed, and remove the global class too.
-		// This works as a callback to be fired when the global header modals are closed, as
-		// they're attached when each modal opens.
-		const modalCloseObserver = new window.MutationObserver( ( mutationList, observer ) => {
-			for ( const mutation of mutationList ) {
-				const { attributeName, type, target } = mutation;
-				if ( type === 'attributes' && attributeName === 'class' ) {
-					if ( ! target.classList.contains( 'has-modal-open' ) ) {
-						target.classList.remove( 'has-global-modal-open' );
-					}
-				}
-			}
-			// Remove the observer to prevent recursion. This will be re-attached when the modal is opened.
-			observer.disconnect();
-		} );
-
-		const openButtons = document.querySelectorAll( '[data-micromodal-trigger]' );
+		const openButtons = document.querySelectorAll(
+			'.global-header__navigation [data-wp-on-async--click="actions.openMenuOnClick"],' +
+			'.global-header__search [data-wp-on-async--click="actions.openMenuOnClick"]'
+		);
 		openButtons.forEach( function ( button ) {
 			// When any open menu button is clicked, find any existing close buttons and click them.
 			button.addEventListener( 'click', function ( event ) {
-				const thisModal = event.target.getAttribute( 'data-micromodal-trigger' );
+				const thisModal = event.target.parentNode.querySelector( '[data-wp-class--has-modal-open]' ).id;
 				const closeButtons = Array.from(
-					document.querySelectorAll( 'button[data-micromodal-close]' )
+					document.querySelectorAll( '[data-wp-on-async--click="actions.closeMenuOnClick"]' )
 				).filter(
 					// Filter to find visible close buttons that are not for this modal.
 					( _button ) => _button.offsetWidth > 0 && null === _button.closest( `#${ thisModal }` )
@@ -223,14 +210,19 @@
 
 				closeButtons.forEach( ( _button ) => _button.click() );
 
-				// If this button opened the global search, add a class and trigger the close observer.
-				if (
-					button.parentNode.classList.contains( 'global-header__navigation' ) ||
-					button.parentNode.classList.contains( 'global-header__search' )
-				) {
-					document.documentElement.classList.add( 'has-global-modal-open' );
-					modalCloseObserver.observe( document.documentElement, { attributes: true } );
-				}
+				// Add a helper class when one of the global modals are open.
+				document.documentElement.classList.add( 'has-global-modal-open' );
+			} );
+		} );
+
+		const closeButtons = document.querySelectorAll(
+			'.global-header__navigation [data-wp-on-async--click="actions.closeMenuOnClick"],' +
+			'.global-header__search [data-wp-on-async--click="actions.closeMenuOnClick"]'
+		);
+		// When the global menus are closed (close button is clicked), remove the helper class.
+		closeButtons.forEach( function ( button ) {
+			button.addEventListener( 'click', function () {
+				document.documentElement.classList.remove( 'has-global-modal-open' );
 			} );
 		} );
 	} );

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -137,7 +137,7 @@ html {
 .wp-block-group.global-header,
 .global-header__alert-banner,
 .wp-block-group.global-footer {
-	--active-menu-item-border-height: 4px;
+	--active-menu-item-border-height: 1px;
 
 	background-color: var(--wp-global-header--background-color);
 	color: var(--wp-global-header--text-color);

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -71,6 +71,7 @@ html {
 	--wp--preset--color--charcoal-2: #23282d;
 	--wp--preset--color--charcoal-3: #40464d; /* Used only in the admin bar. */
 	--wp--preset--color--charcoal-4: #656a71;
+	--wp--preset--color--charcoal-5: #979aa1;
 	--wp--preset--color--nero: #1c2024; /* Only used in the header (hovers), not in the parent/child themes. */
 	--wp--preset--color--white: #fff;
 	--wp--preset--color--deep-blueberry: #213fd4;
@@ -85,6 +86,7 @@ html {
 
 	--wp-global-header--link-color--active: var(--wp--preset--color--blueberry-2);
 	--wp-global-header--text-color: var(--wp--preset--color--white);
+	--wp-global-header--text-color--light: var(--wp--preset--color--charcoal-5);
 }
 
 .has-charcoal-0-color,
@@ -93,6 +95,7 @@ html {
 	--wp-global-header--link-color: var(--wp--preset--color--charcoal-2);
 	--wp-global-header--link-color--active: var(--wp--preset--color--deep-blueberry);
 	--wp-global-header--text-color: var(--wp--preset--color--charcoal-2);
+	--wp-global-header--text-color--light: var(--wp--preset--color--charcoal-4);
 
 	&.has-background[style*="background-color:"] {
 		--wp-global-header--background-color--hover: var(--wp--preset--color--light-grey-2);
@@ -103,6 +106,7 @@ html {
 	--wp-global-header--background-color: var(--wp--preset--color--blueberry-1);
 	--wp-global-header--background-color--hover: var(--wp--preset--color--deep-blueberry);
 	--wp-global-header--link-color--active: var(--wp--preset--color--white);
+	--wp-global-header--text-color--light: var(--wp--preset--color--white);
 }
 
 .has-charcoal-1-background-color {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/get-wordpress.pcss
@@ -37,17 +37,10 @@
 	/* Desktop - `div` containing `a` */
 	& .global-header__desktop-get-wordpress-container {
 		display: none;
-		padding-top: 27px;
-		padding-bottom: 27px;
-		padding-left: var(--wp--style--block-gap);
+		padding: calc((var(--wp-global-header-height) - 36px) / 2) var(--wp--style--block-gap);
 
 		@media (--tablet) {
 			display: inline;
-		}
-
-		@media (--short-screen) {
-			padding-top: 12px;
-			padding-bottom: 12px;
 		}
 
 		& a:hover,

--- a/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/header.pcss
@@ -2,7 +2,7 @@ html {
 	--wp-global-header-height: 60px;
 
 	@media (--tablet) {
-		--wp-global-header-height: 90px;
+		--wp-global-header-height: 70px;
 	}
 
 	@media (--short-screen) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/logos.pcss
@@ -48,9 +48,11 @@
 	}
 
 	& .global-header__wporg-locale-title {
+
+		/* 1.35em = line height of element. */
+		padding-top: calc((var(--wp-global-header-height) - 1.35em) / 2);
+		padding-bottom: calc((var(--wp-global-header-height) - 1.35em) / 2);
 		padding-left: 0;
-		padding-bottom: 16px;
-		padding-top: 16px;
 		flex-basis: max-content;
 		flex-grow: 1;
 		flex-shrink: 1;
@@ -71,13 +73,6 @@
 			max-width: 15em;
 			flex-basis: min-content;
 			flex-shrink: 0;
-			padding-top: 31px;
-			padding-bottom: 32px;
-		}
-
-		@media (--short-screen) {
-			padding-bottom: 16px;
-			padding-top: 16px;
 		}
 
 		@media (--desktop-wide) {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -75,7 +75,7 @@
 
 	& .wp-block-navigation__container {
 		padding: 0 0 var(--wp--custom--margin--vertical) 0;
-		row-gap: 0;
+		row-gap: calc(var(--wp--style--block-gap) / 4);
 		column-gap: 0;
 		font-size: inherit;
 		line-height: 24px;
@@ -95,20 +95,15 @@
 			}
 
 			&.current-menu-item:not(.global-header__get-wordpress) {
-				border-left: var(--active-menu-item-border-height) solid var(--wp-global-header--link-color--active);
-				margin-left: calc((var(--wp--style--block-gap) / 2) * -1);
-				padding-left: calc(var(--wp--style--block-gap) / 2 - var(--active-menu-item-border-height));
 
 				@media (--tablet) {
-					margin-left: 0;
-					padding-left: 0;
 					border-bottom: var(--active-menu-item-border-height) solid var(--wp-global-header--link-color--active);
 					border-left: none;
 				}
 
 				& > a {
 					color: var(--wp-global-header--link-color--active);
-					font-weight: 700;
+					font-weight: 400;
 				}
 
 				& > button svg {
@@ -160,6 +155,7 @@
 		}
 
 		& .wp-block-navigation-submenu__toggle {
+			margin-bottom: calc(var(--wp--style--block-gap) / 4);
 
 			@media (--tablet) {
 				margin: 0;
@@ -195,29 +191,24 @@
 	}
 
 	& .wp-block-navigation__container .wp-block-navigation__submenu-container {
-		font-size: 15px;
-		gap: 0.5em;
-		padding-top: calc(var(--wp--style--block-gap) / 2);
-		padding-bottom: calc(var(--wp--style--block-gap) / 2);
+		gap: calc(var(--wp--style--block-gap) / 4) 0;
+		padding: 0 0 0 var(--wp--style--block-gap);
 		border: none;
 		white-space: nowrap;
 
 		@media (--tablet) {
 			font-size: inherit;
 			gap: inherit;
-			padding-top: 0;
+			padding-left: 0;
+			padding-bottom: calc(var(--wp--style--block-gap) / 2);
 			left: 0;
 
 			& a:hover,
 			& a:focus {
 				text-decoration: underline;
 			}
-		}
 
-		& .wp-block-navigation-item a {
-			padding: calc(var(--wp--style--block-gap) / 4);
-
-			@media (--tablet) {
+			& .wp-block-navigation-item a {
 				padding: calc(var(--wp--style--block-gap) / 2);
 			}
 		}

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -186,6 +186,10 @@
 					background-color: var(--wp-global-header--text-color);
 				}
 			}
+
+			@media (max-width: 889px) {
+				color: var(--wp-global-header--text-color--light);
+			}
 		}
 
 		& .wp-block-navigation__submenu-icon {

--- a/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/header/menu.pcss
@@ -88,6 +88,16 @@
 			}
 		}
 
+
+		@media (max-width: 889px) {
+			.wp-block-navigation-item,
+			.wp-block-navigation-item:not(.global-header__mobile-get-wordpress) a,
+			.wp-block-navigation-submenu__toggle,
+			.wp-block-navigation-submenu {
+				width: 100%;
+			}
+		}
+
 		& .wp-block-navigation-item {
 			&:hover,
 			&:focus-within {


### PR DESCRIPTION
This applies the style changes suggested in #572 for the global header. The header height is decreased (and any alignment issues fixed), the active style is more subtle, and the mobile menu is more consistent.

The menu items with child menus (Extend, Learn, etc) are now a lighter grey, but they are still focusable & clickable — this is core behavior for "click to open" submenus in the overlay menu. Nothing happens if you click them. This could be an issue for Gutenberg, but there's nothing we can do here (I tried a few things).

I simplified & fixed the modal view javascript now that the navigation block uses the Interactivity API instead of the micromodal library, so opening the search overlay will close an open menu overlay and vice versa.

The new design removed the side border on active items on mobile (see the 4th row of screenshots), which means the only indicator of current page is color. We need to add some other non-color effect here. @WordPress/meta-design 

Fixes #572

**Screenshots**

The desktop screens are all neutral, no interactions. The mobile views were opened by keyboard, so the first element is focused. For News, it's also the current page.

| Before | After |
|---|---|
| ![before news desktop](https://github.com/user-attachments/assets/16c3dbbc-2091-40fc-b8cb-abc6b80ea562) | ![after news desktop](https://github.com/user-attachments/assets/778df31a-7e65-4339-a07f-d19e8e95dd6a)
| ![before showcase desktop](https://github.com/user-attachments/assets/f071290c-a001-444c-8306-e946083e7a98) | ![after showcase desktop](https://github.com/user-attachments/assets/b8e674e6-8b01-4afb-a3f7-d5b2eb2f2529) |
| ![before about desktop](https://github.com/user-attachments/assets/bfff3426-3e55-4bde-8af7-774d4eaec410)| ![after about desktop](https://github.com/user-attachments/assets/c8aba9c7-5689-45b6-b330-45522c91c511) |
| ![before news mobile](https://github.com/user-attachments/assets/ee534688-50c4-439c-9db2-8534083e578b) | ![after news mobile](https://github.com/user-attachments/assets/71b6f45c-10d8-406d-b081-b7c20547b7da) |
| ![before about mobile](https://github.com/user-attachments/assets/59aa244e-ea7e-4f1d-b80d-9957ad89bf3f) | ![after about mobile](https://github.com/user-attachments/assets/7cffa208-cf5f-4498-9a01-834666dcc657) |

**Video for focus & dropdown styles**

https://github.com/user-attachments/assets/0fc2da01-a94a-4175-9d23-2fcbf17dc8fc

https://github.com/user-attachments/assets/97f15185-2b15-4dda-848d-f20450c4f0b1

**To test**

- Check out & build this branch
- Use this with any of the other environments
- See the header is shorter now
- Make sure nothing looks broken