### PR TITLE
Render Callout blocks as Notice blocks

### DIFF
--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -51,8 +51,10 @@ function render_callout_as_notice( $attr, $content, $tag ) {
 	$content = wp_kses_post( $content );
 	// Temporarily disable o2 processing while formatting content.
 	add_filter( 'o2_process_the_content', '__return_false', 1 );
+	remove_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
 	$content = apply_filters( 'the_content', $content );
 	remove_filter( 'o2_process_the_content', '__return_false', 1 );
+	add_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
 
 	// Create a unique placeholder for the content.
 	// Directly processing `$content` with `do_blocks` can lead to buggy layouts on make.wp.org.


### PR DESCRIPTION
Builds on previous work to render Callout shortcodes as Notice blocks.

This enhancement saves admins of sites like the Make blogs and Learn WordPress from having to update all the existing Callouts in content to match the redesigned UI.

Closes https://github.com/WordPress/wordpress.org/issues/374

Note that we added [style overrides in Developer Resources](https://github.com/WordPress/wporg-developer/blob/034722c393dc768ad00b78887b04d781d87d6f67/source/wp-content/themes/wporg-developer-2023/src/style/style.scss#L579), and these will still be required as the callouts have been parsed from GitHub markdown and exist as post content, not blocks.

### Screenshots from [Make/Support](https://make.wordpress.org/support/?new-theme=1)

| Before | After |
|-|-|
| ![Screenshot 2024-10-21 at 10 56 25 AM](https://github.com/user-attachments/assets/359d8042-06f8-4fda-a30d-f173d732187b) | ![Screenshot 2024-10-21 at 10 57 18 AM](https://github.com/user-attachments/assets/7bb5c9f2-83c9-4791-92da-4ff35d0978da) |

| Admin | Frontend |
|-|-|
| ![Screenshot 2024-10-21 at 11 25 22 AM](https://github.com/user-attachments/assets/36838c9f-99c9-4c9a-b1e1-8a6b2c9de569) | ![Screenshot 2024-10-21 at 11 25 32 AM](https://github.com/user-attachments/assets/783abbed-7237-45cf-b98e-e48ce7784ced) |

### Testing

1. Load this branch in a local environment or sandbox
2. Add Callout blocks to a page or post. In the admin the block should display as a Callout.
3. On the frontend the block should render as a Notice, with all inner blocks rendered as expected.
