### PR TITLE
Fix rendering callout blocks as notice blocks

### DIFF
--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -9,6 +9,8 @@ namespace WordPressdotorg\MU_Plugins\Notice;
 // Run after `WPorg_Handbook_Callout_Boxes` registers the shortcodes.
 add_action( 'init', __NAMESPACE__ . '\init', 11 );
 
+add_filter( 'pre_render_block', __NAMESPACE__ . '\render_callout_block_as_notice', 11, 2 );
+
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it registers also all assets so they can be enqueued
@@ -21,20 +23,20 @@ function init() {
 
 	foreach ( [ 'info', 'tip', 'alert', 'tutorial', 'warning' ] as $shortcode ) {
 		remove_shortcode( $shortcode );
-		add_shortcode( $shortcode, __NAMESPACE__ . '\render_shortcode' );
+		add_shortcode( $shortcode, __NAMESPACE__ . '\render_callout_as_notice' );
 	}
 }
 
 /**
- * Display the callout shortcodes using the notice block.
+ * Display a callout using the notice block.
  *
- * @param array|string $attr    Shortcode attributes array or empty string.
- * @param string       $content Shortcode content.
- * @param string       $tag     Shortcode name.
+ * @param array|string $attr    Callout shortcode attributes array or empty string.
+ * @param string       $content Callout content.
+ * @param string       $tag     Callout type.
  *
- * @return string Shortcode output as HTML markup.
+ * @return string Callout output as HTML markup.
  */
-function render_shortcode( $attr, $content, $tag ) {
+function render_callout_as_notice( $attr, $content, $tag ) {
 	$shortcode_mapping = array(
 		'info'     => 'info',
 		'tip'      => 'tip',
@@ -49,8 +51,10 @@ function render_shortcode( $attr, $content, $tag ) {
 	$content = wp_kses_post( $content );
 	// Temporarily disable o2 processing while formatting content.
 	add_filter( 'o2_process_the_content', '__return_false', 1 );
+	remove_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
 	$content = apply_filters( 'the_content', $content );
 	remove_filter( 'o2_process_the_content', '__return_false', 1 );
+	add_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
 
 	// Create a unique placeholder for the content.
 	// Directly processing `$content` with `do_blocks` can lead to buggy layouts on make.wp.org.
@@ -69,4 +73,29 @@ EOT;
 	$final_markup = str_replace( $placeholder, $content, $processed_markup );
 
 	return $final_markup;
+}
+
+/**
+ * Renders a callout block as a notice.
+ *
+ * @param string|null $pre_render The pre-rendered content or null.
+ * @param array       $parsed_block The parsed block array.
+ * @return string|null The rendered notice or the original pre-render value.
+ */
+function render_callout_block_as_notice( $pre_render, $parsed_block ) {
+	if ( is_admin() || 'wporg/callout' !== $parsed_block['blockName'] ) {
+		return $pre_render;
+	}
+
+	$callout_wrapper = $parsed_block['innerHTML'];
+	// Extract the specific "callout-*" class and remove the "callout-" prefix
+	preg_match( '/\bcallout-([\w-]+)\b/', $callout_wrapper, $matches );
+	$tag = $matches[1] ?? 'tip';
+
+	$content = '';
+	foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
+		$content .= render_block( $inner_block );
+	}
+
+	return render_callout_as_notice( '', $content, $tag );
 }

--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -49,19 +49,6 @@ function render_callout_as_notice( $attr, $content, $tag ) {
 
 	// Sanitize message content.
 	$content = wp_kses_post( $content );
-	// Temporarily disable o2 processing while formatting content, if the class exists.
-	$o2_exists = class_exists( 'o2' );
-	if ( $o2_exists ) {
-		add_filter( 'o2_process_the_content', '__return_false', 1 );
-		remove_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
-	}
-
-	$content = apply_filters( 'the_content', $content );
-
-	if ( $o2_exists ) {
-		remove_filter( 'o2_process_the_content', '__return_false', 1 );
-		add_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
-	}
 
 	// Create a unique placeholder for the content.
 	// Directly processing `$content` with `do_blocks` can lead to buggy layouts on make.wp.org.

--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -49,6 +49,10 @@ function render_callout_as_notice( $attr, $content, $tag ) {
 
 	// Sanitize message content.
 	$content = wp_kses_post( $content );
+	// Temporarily disable o2 processing while formatting content.
+	add_filter( 'o2_process_the_content', '__return_false', 1 );
+	$content = apply_filters( 'the_content', $content );
+	remove_filter( 'o2_process_the_content', '__return_false', 1 );
 
 	// Create a unique placeholder for the content.
 	// Directly processing `$content` with `do_blocks` can lead to buggy layouts on make.wp.org.

--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -49,12 +49,19 @@ function render_callout_as_notice( $attr, $content, $tag ) {
 
 	// Sanitize message content.
 	$content = wp_kses_post( $content );
-	// Temporarily disable o2 processing while formatting content.
-	add_filter( 'o2_process_the_content', '__return_false', 1 );
-	remove_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
+	// Temporarily disable o2 processing while formatting content, if the class exists.
+	$o2_exists = class_exists( 'o2' );
+	if ( $o2_exists ) {
+		add_filter( 'o2_process_the_content', '__return_false', 1 );
+		remove_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
+	}
+
 	$content = apply_filters( 'the_content', $content );
-	remove_filter( 'o2_process_the_content', '__return_false', 1 );
-	add_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
+
+	if ( $o2_exists ) {
+		remove_filter( 'o2_process_the_content', '__return_false', 1 );
+		add_filter( 'the_content', array( 'o2', 'add_json_data' ), 999999 );
+	}
 
 	// Create a unique placeholder for the content.
 	// Directly processing `$content` with `do_blocks` can lead to buggy layouts on make.wp.org.

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -27,11 +27,20 @@
 		align-self: start;
 	}
 
+	& p:empty {
+		display: none;
+	}
+
 	& p:first-child {
 		margin-block-start: 0;
 	}
 
-	& p:last-child {
+	/* o2 adds a data script tag to the notice content on some Make blogs.
+	 * In this case we need to remove bottom margin from the second to last element instead.
+	 */
+
+	& p:last-child,
+	&:has(.o2-data) :nth-last-child(2) {
 		margin-block-end: 0;
 	}
 

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -27,25 +27,6 @@
 		align-self: start;
 	}
 
-	& :empty,
-	br:first-child {
-		display: none;
-	}
-
-	& :first-child,
-	&:has(:first-child:empty) :nth-child(2) {
-		margin-block-start: 0;
-	}
-
-	& :last-child,
-	&:has(:last-child:empty) :nth-last-child(2),
-	/* o2 adds a data script tag to the notice content on some Make blogs.
-	 * In this case we need to remove bottom margin from the second to last element instead.
-	 */
-	&:has(.o2-data) :nth-last-child(2) {
-		margin-block-end: 0;
-	}
-
 	&.alignleft,
 	&.alignright {
 		max-width: calc(var(--wp--style--global--content-size, 680px) * 0.66);
@@ -85,4 +66,23 @@
 
 .wp-block-wporg-notice__content {
 	align-self: center;
+
+	& :empty,
+	br:first-child {
+		display: none;
+	}
+
+	& :first-child,
+	&:has(:first-child:empty) :nth-child(2) {
+		margin-block-start: 0;
+	}
+
+	& :last-child,
+	&:has(:last-child:empty) :nth-last-child(2),
+	/* o2 adds a data script tag to the notice content on some Make blogs.
+	 * In this case we need to remove bottom margin from the second to last element instead.
+	 */
+	&:has(.o2-data) :nth-last-child(2) {
+		margin-block-end: 0;
+	}
 }

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -67,8 +67,8 @@
 .wp-block-wporg-notice__content {
 	align-self: center;
 
-	& :empty,
-	br:first-child {
+	& :empty:not(br),
+	& br:first-child {
 		display: none;
 	}
 

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -37,13 +37,12 @@
 		margin-block-start: 0;
 	}
 
+	& :last-child,
+	&:has(:last-child:empty) :nth-last-child(2),
 	/* o2 adds a data script tag to the notice content on some Make blogs.
 	 * In this case we need to remove bottom margin from the second to last element instead.
 	 */
-
-	& :last-child,
-	&:has(.o2-data) :nth-last-child(2),
-	&:has(:last-child:empty) :nth-last-child(2) {
+	&:has(.o2-data) :nth-last-child(2) {
 		margin-block-end: 0;
 	}
 

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -27,11 +27,13 @@
 		align-self: start;
 	}
 
-	& p:empty {
+	& :empty,
+	br:first-child {
 		display: none;
 	}
 
-	& p:first-child {
+	& :first-child,
+	&:has(:first-child:empty) :nth-child(2) {
 		margin-block-start: 0;
 	}
 
@@ -39,13 +41,10 @@
 	 * In this case we need to remove bottom margin from the second to last element instead.
 	 */
 
-	& p:last-child,
-	&:has(.o2-data) :nth-last-child(2) {
+	& :last-child,
+	&:has(.o2-data) :nth-last-child(2),
+	&:has(:last-child:empty) :nth-last-child(2) {
 		margin-block-end: 0;
-	}
-
-	& br:first-child {
-		display: none;
 	}
 
 	&.alignleft,


### PR DESCRIPTION
Render Callout blocks as Notice blocks, this time without infinite loops caused by o2 filters.

Uses CSS to adjust layout if an o2-data script tag has been added after running `the_content` filter, instead of [removing and adding filters](https://github.com/WordPress/wporg-mu-plugins/pull/660).

| Before (Prod) | After (Sandbox) |
|--------|--------|
| ![Screenshot 2024-10-24 at 11 52 08 AM](https://github.com/user-attachments/assets/c05dd17f-9421-4187-8504-633552508bcf) | ![Screenshot 2024-10-24 at 11 52 30 AM](https://github.com/user-attachments/assets/d6b435a3-280c-46e7-9dee-3cc126bd31b7) |
| ![Screenshot 2024-10-24 at 11 55 48 AM](https://github.com/user-attachments/assets/e2f4f5c1-4767-4214-a0a3-a2ccde88e4f7) | ![Screenshot 2024-10-24 at 11 56 12 AM](https://github.com/user-attachments/assets/77732dab-279b-4c59-ad4c-9635561ec44c) |

Closes https://github.com/WordPress/wordpress.org/issues/374

### Testing

All Callouts should be rendered as Notices. Content should include glossary links, etc.

Load this branch in sandbox, and test callout rendering on the following pages:

https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/
https://developer.wordpress.org/advanced-administration/
https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/
https://make.wordpress.org/core/handbook/about/release-cycle/releasing-major-versions/
https://make.wordpress.org/test/handbook/test-reports/
https://learn.wordpress.org/lesson/saving-your-work-create-block-theme/
https://make.wordpress.org/support/

Pages which cause the recent alerts:
https://make.wordpress.org/community/category/diversity-2/page/2/ (expand the content on the first post)
https://make.wordpress.org/training/tag/faculty-program/
https://make.wordpress.org/training/page/23/
https://make.wordpress.org/community/category/community-management/
https://make.wordpress.org/training/category/note/page/6/
https://make.wordpress.org/training/page/10/
https://make.wordpress.org/community/tag/proposal/
https://make.wordpress.org/community/tag/sponsorship/