### PR TITLE
Revert "Fix rendering callout blocks as notice blocks"

### DIFF
--- a/mu-plugins/blocks/notice/index.php
+++ b/mu-plugins/blocks/notice/index.php
@@ -9,8 +9,6 @@ namespace WordPressdotorg\MU_Plugins\Notice;
 // Run after `WPorg_Handbook_Callout_Boxes` registers the shortcodes.
 add_action( 'init', __NAMESPACE__ . '\init', 11 );
 
-add_filter( 'pre_render_block', __NAMESPACE__ . '\render_callout_block_as_notice', 11, 2 );
-
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it registers also all assets so they can be enqueued
@@ -23,20 +21,20 @@ function init() {
 
 	foreach ( [ 'info', 'tip', 'alert', 'tutorial', 'warning' ] as $shortcode ) {
 		remove_shortcode( $shortcode );
-		add_shortcode( $shortcode, __NAMESPACE__ . '\render_callout_as_notice' );
+		add_shortcode( $shortcode, __NAMESPACE__ . '\render_shortcode' );
 	}
 }
 
 /**
- * Display a callout using the notice block.
+ * Display the callout shortcodes using the notice block.
  *
- * @param array|string $attr    Callout shortcode attributes array or empty string.
- * @param string       $content Callout content.
- * @param string       $tag     Callout type.
+ * @param array|string $attr    Shortcode attributes array or empty string.
+ * @param string       $content Shortcode content.
+ * @param string       $tag     Shortcode name.
  *
- * @return string Callout output as HTML markup.
+ * @return string Shortcode output as HTML markup.
  */
-function render_callout_as_notice( $attr, $content, $tag ) {
+function render_shortcode( $attr, $content, $tag ) {
 	$shortcode_mapping = array(
 		'info'     => 'info',
 		'tip'      => 'tip',
@@ -71,29 +69,4 @@ EOT;
 	$final_markup = str_replace( $placeholder, $content, $processed_markup );
 
 	return $final_markup;
-}
-
-/**
- * Renders a callout block as a notice.
- *
- * @param string|null $pre_render The pre-rendered content or null.
- * @param array       $parsed_block The parsed block array.
- * @return string|null The rendered notice or the original pre-render value.
- */
-function render_callout_block_as_notice( $pre_render, $parsed_block ) {
-	if ( is_admin() || 'wporg/callout' !== $parsed_block['blockName'] ) {
-		return $pre_render;
-	}
-
-	$callout_wrapper = $parsed_block['innerHTML'];
-	// Extract the specific "callout-*" class and remove the "callout-" prefix
-	preg_match( '/\bcallout-([\w-]+)\b/', $callout_wrapper, $matches );
-	$tag = $matches[1] ?? 'tip';
-
-	$content = '';
-	foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
-		$content .= render_block( $inner_block );
-	}
-
-	return render_callout_as_notice( '', $content, $tag );
 }

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -27,6 +27,18 @@
 		align-self: start;
 	}
 
+	& p:first-child {
+		margin-block-start: 0;
+	}
+
+	& p:last-child {
+		margin-block-end: 0;
+	}
+
+	& br:first-child {
+		display: none;
+	}
+
 	&.alignleft,
 	&.alignright {
 		max-width: calc(var(--wp--style--global--content-size, 680px) * 0.66);
@@ -66,23 +78,4 @@
 
 .wp-block-wporg-notice__content {
 	align-self: center;
-
-	& :empty:not(br),
-	& br:first-child {
-		display: none;
-	}
-
-	& :first-child,
-	&:has(:first-child:empty) :nth-child(2) {
-		margin-block-start: 0;
-	}
-
-	& :last-child,
-	&:has(:last-child:empty) :nth-last-child(2),
-	/* o2 adds a data script tag to the notice content on some Make blogs.
-	 * In this case we need to remove bottom margin from the second to last element instead.
-	 */
-	&:has(.o2-data) :nth-last-child(2) {
-		margin-block-end: 0;
-	}
 }


### PR DESCRIPTION
Reverts WordPress/wporg-mu-plugins#662

Still issues with infinite loops