### PR TITLE
Fix rendering callout blocks as notice blocks, again

### DIFF
--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -67,7 +67,9 @@
 .wp-block-wporg-notice__content {
 	align-self: center;
 
-	& :empty:not(br),
+	& p:empty,
+	& ul:empty,
+	& ol:empty,
 	& br:first-child {
 		display: none;
 	}

--- a/mu-plugins/blocks/notice/postcss/style.pcss
+++ b/mu-plugins/blocks/notice/postcss/style.pcss
@@ -27,18 +27,6 @@
 		align-self: start;
 	}
 
-	& p:first-child {
-		margin-block-start: 0;
-	}
-
-	& p:last-child {
-		margin-block-end: 0;
-	}
-
-	& br:first-child {
-		display: none;
-	}
-
 	&.alignleft,
 	&.alignright {
 		max-width: calc(var(--wp--style--global--content-size, 680px) * 0.66);
@@ -78,4 +66,23 @@
 
 .wp-block-wporg-notice__content {
 	align-self: center;
+
+	& :empty:not(br),
+	& br:first-child {
+		display: none;
+	}
+
+	& :first-child,
+	&:has(:first-child:empty) :nth-child(2) {
+		margin-block-start: 0;
+	}
+
+	& :last-child,
+	&:has(:last-child:empty) :nth-last-child(2),
+	/* o2 adds a data script tag to the notice content on some Make blogs.
+	 * In this case we need to remove bottom margin from the second to last element instead.
+	 */
+	&:has(.o2-data) :nth-last-child(2) {
+		margin-block-end: 0;
+	}
 }


### PR DESCRIPTION
Closes https://github.com/WordPress/wordpress.org/issues/374

Avoids infinite loops caused by running `the_content` filtering, and instead renders the callout content [exactly as the handbook plugin does](https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/plugins/handbook/scripts/src/blocks/callout/index.js#L53).

### Testing

Follow the same as https://github.com/WordPress/wporg-mu-plugins/pull/662, plus these new URLs which caused alerts:

https://make.wordpress.org/training/handbook/guidelines/tutorials/tutorial-subtitles-and-transcripts/
https://make.wordpress.org/hosting/2023/05/15/is-wordpress-compatible-with-php-8/
https://make.wordpress.org/hosting/tag/core/