### PR TITLE
Remove custom admin header spacing modifications.

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -9,7 +9,6 @@ defined( 'WPINC' ) || die();
 require_once __DIR__ . '/admin-bar.php';
 
 add_action( 'init', __NAMESPACE__ . '\register_block_types' );
-add_action( 'admin_bar_init', __NAMESPACE__ . '\remove_admin_bar_callback', 15 );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_routes' );
 add_filter( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_block_assets', 200 ); // Always last.
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_compat_wp4_styles', 5 ); // Before any theme CSS.
@@ -81,16 +80,6 @@ function register_block_assets() {
 			'overflowMenuLabel' => __( 'More menu', 'wporg' ),
 		)
 	);
-}
-
-/**
- * Remove the default margin-top added when the admin bar is used.
- *
- * The core handling uses `!important`, which overrides the sticky header offset in `common.pcss`.
- */
-function remove_admin_bar_callback() {
-	remove_action( 'gp_head', '_admin_bar_bump_cb' );
-	remove_action( 'wp_head', '_admin_bar_bump_cb' );
 }
 
 /**

--- a/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/_common.pcss
@@ -21,9 +21,6 @@
 html {
 	--wp--custom--alignment--scroll-bar-width: 8px;
 
-	/* Offset from the top of the page which is covered by "stuck" items (admin bar & header). */
-	--wp-global-header-offset: calc(var(--wp-global-header-height, 0px) + var(--wp-admin--admin-bar--height, 0px));
-	margin-top: var(--wp-admin--admin-bar--height, 0);
 	height: unset; /* Let height use default browser height. */
 }
 


### PR DESCRIPTION
As suggested by @ryelle in https://github.com/WordPress/wordcamp.org/issues/1410#issuecomment-2438237211, this PR removes custom CSS styles that were added when the WordPress.org header was [sticky](https://github.com/WordPress/wporg-mu-plugins/commit/433d57f3b7f679c0585836ac81375814472bcd1e).

This fixes issues on WordCamp sites where the Admin bar is positioned on top of the site's header. 

**Example**

| Before | After |
|--------|--------|
| <img width="974" alt="Screenshot 2024-10-28 at 1 19 30 PM" src="https://github.com/user-attachments/assets/65237ab7-ea11-42de-91a6-9d720a710296"> | <img width="978" alt="Screenshot 2024-10-28 at 1 19 14 PM" src="https://github.com/user-attachments/assets/89fd9e16-98c6-4af9-bedc-9f78f470cbeb"> |

Related: As suggested by @ryelle in https://github.com/WordPress/wordcamp.org/issues/1410.

## How to Test

Edit: Apply https://github.com/WordPress/wporg-parent-2021/pull/162 first.

1. Apply these changes in your sandbox.
2. Navigate around WordPress.org and WordCamp sites and make sure the spacing between the header and the admin bar is expected. Not overlapping, or has an extra space.


