### PR TITLE
Add search results context block

### DIFF
--- a/mu-plugins/blocks/search-results-context/index.php
+++ b/mu-plugins/blocks/search-results-context/index.php
@@ -72,7 +72,7 @@ function render( $attributes ) {
  */
 function init() {
 	register_block_type(
-		dirname( dirname( __DIR__ ) ) . '/build',
+		__DIR__ . '/build',
 		array(
 			'render_callback' => __NAMESPACE__ . '\render',
 		)

--- a/mu-plugins/blocks/search-results-context/index.php
+++ b/mu-plugins/blocks/search-results-context/index.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Block Name: Search Results Context
+ * Description: Displays context information for search results.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\MU_Plugins\Search_Results_Context;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Render the block content.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes ) {
+	global $wp_query;
+
+	if ( ! is_search() ) {
+		return '';
+	}
+
+	$results_count = $wp_query->found_posts;
+
+	if ( 0 === $results_count ) {
+		return;
+	}
+
+	$posts_per_page = get_query_var( 'posts_per_page' );
+	$current_page = get_query_var( 'paged' ) ?: 1;
+	$first_result = ( $current_page - 1 ) * $posts_per_page + 1;
+	$last_result = min( $current_page * $posts_per_page, $results_count );
+
+	$content = sprintf(
+		/* translators: %1$s number of results; %2$s keyword. */
+		_n(
+			'%1$s result found for "%2$s".',
+			'%1$s results found for "%2$s".',
+			$results_count,
+			'wporg'
+		),
+		number_format_i18n( $results_count ),
+		esc_html( $wp_query->query['s'] ),
+	);
+
+	$showing = sprintf(
+		/* translators: %1$s number of first displayed result, %2$s number of last displayed result. */
+		'Showing results %1$s to %2$s.',
+		number_format_i18n( $first_result ),
+		number_format_i18n( $last_result ),
+	);
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+
+	return sprintf(
+		'<%1$s %2$s>%3$s %4$s</%1$s>',
+		esc_attr( $attributes['tagName'] ),
+		$wrapper_attributes,
+		$content,
+		$showing,
+	);
+}
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}

--- a/mu-plugins/blocks/search-results-context/src/block.json
+++ b/mu-plugins/blocks/search-results-context/src/block.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/search-results-context",
+	"version": "0.1.0",
+	"title": "Search Results Context",
+	"category": "design",
+	"icon": "",
+	"description": "Displays context information for search results.",
+	"textdomain": "wporg",
+	"attributes": {
+		"tagName": {
+			"type": "string",
+			"default": "p"
+		}
+	},
+	"supports": {
+		"align": true,
+		"color": true,
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": false
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true,
+				"fontAppearance": true,
+				"textTransform": true
+			}
+		}
+	},
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./index.js"
+}

--- a/mu-plugins/blocks/search-results-context/src/index.js
+++ b/mu-plugins/blocks/search-results-context/src/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+function Edit() {
+	return <div { ...useBlockProps() }>Search Results Context</div>;
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/mu-plugins/loader.php
+++ b/mu-plugins/loader.php
@@ -47,6 +47,7 @@ require_once __DIR__ . '/blocks/ratings-stars/index.php';
 require_once __DIR__ . '/blocks/sidebar-container/index.php';
 require_once __DIR__ . '/blocks/screenshot-preview/block.php';
 require_once __DIR__ . '/blocks/screenshot-preview-block/block.php';
+require_once __DIR__ . '/blocks/search-results-context/index.php';
 require_once __DIR__ . '/blocks/site-breadcrumbs/index.php';
 require_once __DIR__ . '/blocks/table-of-contents/index.php';
 require_once __DIR__ . '/blocks/time/index.php';


### PR DESCRIPTION
Moves the [Search Results Context block from the Developer theme](https://github.com/WordPress/wporg-developer/tree/trunk/source/wp-content/themes/wporg-developer-2023/src/search-results-context), so that it can be reused for the Make handbooks.

See https://github.com/WordPress/wporg-make/issues/3