### PR TITLE
Global Header/Navigation: Switch to observer for menu open & close actions

### DIFF
--- a/mu-plugins/blocks/global-header-footer/js/view.js
+++ b/mu-plugins/blocks/global-header-footer/js/view.js
@@ -1,3 +1,4 @@
+/* global MutationObserver */
 /**
  * File wporg-global-header-script.js.
  *
@@ -195,7 +196,7 @@
 
 		const openButtons = document.querySelectorAll(
 			'.global-header__navigation [data-wp-on-async--click="actions.openMenuOnClick"],' +
-			'.global-header__search [data-wp-on-async--click="actions.openMenuOnClick"]'
+				'.global-header__search [data-wp-on-async--click="actions.openMenuOnClick"]'
 		);
 		openButtons.forEach( function ( button ) {
 			// When any open menu button is clicked, find any existing close buttons and click them.
@@ -215,15 +216,28 @@
 			} );
 		} );
 
-		const closeButtons = document.querySelectorAll(
-			'.global-header__navigation [data-wp-on-async--click="actions.closeMenuOnClick"],' +
-			'.global-header__search [data-wp-on-async--click="actions.closeMenuOnClick"]'
-		);
-		// When the global menus are closed (close button is clicked), remove the helper class.
-		closeButtons.forEach( function ( button ) {
-			button.addEventListener( 'click', function () {
-				document.documentElement.classList.remove( 'has-global-modal-open' );
+		// Watching for changes to the html element's class, which indicates open/close state of navigation.
+		const observer = new MutationObserver( ( mutations ) => {
+			mutations.forEach( ( mutation ) => {
+				const oldClass = mutation.oldValue || '';
+				const newClass = mutation.target.className || '';
+				if ( oldClass.includes( 'has-modal-open' ) && ! newClass.includes( 'has-modal-open' ) ) {
+					// Menu has closed, remove the helper class if it exists. If the previously
+					// open menu was not the global nav, there will be not effect here.
+					mutation.target.classList.remove( 'has-global-modal-open' );
+				} else if ( ! oldClass.includes( 'has-modal-open' ) && newClass.includes( 'has-modal-open' ) ) {
+					// Any nav menu has opened, scroll to the top of the page to show the
+					// entire menu (and prevent incorrect positioning).
+					window.scrollTo( { top: 0, behavior: 'instant' } );
+				}
 			} );
+		} );
+
+		// Observe the html element for changes only to the class attribute.
+		observer.observe( document.documentElement, {
+			attributes: true,
+			attributeFilter: [ 'class' ],
+			attributeOldValue: true,
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #678. The global header nav adds a class when opened, `has-global-modal-open`, but this was only being removed when the nav was closed by button click. This changes the way _that_ class is removed by watching the `has-modal-open` class, which the core block adds, so that the custom class is always removed when the nav modal closes.

I then used the same observer to fix #681, by simply scrolling to the top of the page when a nav is opened. I did try to fix the alignment via CSS, but it's fixed to the viewport position. Switching to `absolute` + some other tweaks worked, but then the bottom was cut off.

![Screen Shot 2025-04-14 at 18 42 58](https://github.com/user-attachments/assets/81443252-0847-4930-8b29-092bbf412f8b)

So I'm on the fence about whether this is too hacky — it does make the screen jump, but then everything is positioned perfectly… Here's an example:

https://github.com/user-attachments/assets/c98b6494-4262-4fcd-b7c2-9091cdfbaa3d

**To test**

Global header fix:
1. Use a viewport < 890px
2. Open the global header menu
3. Hit escape
4. It should close the menu, and behave like before the menu was open
    - The local navigation bar should still be visible
    - The global header should not be sticky

Detached menu fix:
1. Use a viewport < 600px
2. Scroll down slightly
3. Open the global header or local navigation dropdown
4. It should scroll back to the top of the page
5. The open menu's close button should be correctly aligned with the previous open button
6. None of the page itself should be visible

This issue ^ appears on both the global header menus and local nav menus, so you can test both.