### PR TITLE
Add the WordPress Mastodon account to the footer social media icons

### DIFF
--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -151,6 +151,7 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 	<ul class="wp-block-social-links is-style-logos-only">
 		<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook","label":"<?php echo esc_html_x( 'Visit our Facebook page', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.x.com/WordPress","service":"x","label":"<?php echo esc_html_x( 'Visit our X (formerly Twitter) account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://mastodon.world/@WordPress","service":"mastodon","rel":"me","label":"<?php echo esc_html_x( 'Visit our Mastodon account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.instagram.com/wordpress/","service":"instagram","label":"<?php echo esc_html_x( 'Visit our Instagram account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin","label":"<?php echo esc_html_x( 'Visit our LinkedIn account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.youtube.com/wordpress","service":"youtube","label":"<?php echo esc_html_x( 'Visit our YouTube channel', 'Menu item title', 'wporg' ); ?>"} /-->


### PR DESCRIPTION
This is to allow the Mastodon account to be verified.

| Before | After |
| --- | --- |
| <img width="294" alt="Screenshot 2025-05-09 at 12 37 07 pm" src="https://github.com/user-attachments/assets/a9487b98-a166-4fd3-9299-fd4d9a6a8e93" /> | <img width="348" alt="Screenshot 2025-05-09 at 12 39 30 pm" src="https://github.com/user-attachments/assets/5add0a5a-034d-4665-8c1c-80c3a508f0b7" /> |

The responsive views are more-or-less about the same behaviour as at present.