### PR TITLE
Expand / Include all of the WordPress social media accounts

### DIFF
--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -149,12 +149,16 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 
 	<!-- wp:social-links {"className":"is-style-logos-only"} -->
 	<ul class="wp-block-social-links is-style-logos-only">
-		<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook","label":"<?php echo esc_html_x( 'Visit our Facebook page', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.x.com/WordPress","service":"x","label":"<?php echo esc_html_x( 'Visit our X (formerly Twitter) account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://bsky.app/profile/wordpress.org","service":"bluesky","label":"<?php echo esc_html_x( 'Visit our Bluesky account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://mastodon.world/@WordPress","service":"mastodon","rel":"me","label":"<?php echo esc_html_x( 'Visit our Mastodon account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://www.threads.net/@wordpress","service":"threads","label":"<?php echo esc_html_x( 'Visit our Threads account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook","label":"<?php echo esc_html_x( 'Visit our Facebook page', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.instagram.com/wordpress/","service":"instagram","label":"<?php echo esc_html_x( 'Visit our Instagram account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin","label":"<?php echo esc_html_x( 'Visit our LinkedIn account', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://www.tiktok.com/@wordpress","service":"tiktok","label":"<?php echo esc_html_x( 'Visit our TikTok account', 'Menu item title', 'wporg' ); ?>"} /-->
 		<!-- wp:social-link {"url":"https://www.youtube.com/wordpress","service":"youtube","label":"<?php echo esc_html_x( 'Visit our YouTube channel', 'Menu item title', 'wporg' ); ?>"} /-->
+		<!-- wp:social-link {"url":"https://wordpress.tumblr.com/","service":"tumblr","label":"<?php echo esc_html_x( 'Visit our Tumblr account', 'Menu item title', 'wporg' ); ?>"} /-->
 	</ul> <!-- /wp:social-links -->
 
 	<?php if ( str_starts_with( get_locale(), 'en_' ) ) : ?>

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/logos.pcss
@@ -2,11 +2,13 @@
 	position: relative;
 	display: flex;
 	flex-wrap: wrap;
+	gap: var(--wp--style--block-gap) calc(var(--wp--style--block-gap) * 3);
 	margin-top: 60px;
 
 	@media (--tablet) {
 		justify-content: space-between;
 		flex-wrap: nowrap;
+		align-items: center;
 	}
 
 	& .global-footer__wporg-logo-full,
@@ -87,8 +89,8 @@
 	/* An image is used on `en_*` locales. */
 	& .wp-block-image.global-footer__code_is_poetry {
 		flex-basis: 100%;
-		margin-top: 9px;
 		margin-bottom: 0;
+		text-align: center;
 
 		@media (--tablet) {
 			flex-basis: unset;
@@ -98,7 +100,7 @@
 				width: 188px;
 				height: 13px;
 				left: calc(50% - (188px / 2)); /* Align horizontally. Width must match width of the image. */
-				top: 6px; /* Align baseline of "code is poetry" with "wordpress.org" logo. */
+				top: calc(50% - (13px/2)); /* Align vertically. 13px is the image height. */
 			}
 		}
 	}
@@ -106,17 +108,16 @@
 	/* The translated text is used on non-English locales. */
 	& span.global-footer__code_is_poetry {
 		flex-basis: 100%;
-		margin-top: 12px;
-		margin-bottom: 0;
 		font-family: serif; /* MrsEaves doesn't support non-latin characters well. */
 		font-size: 20px;
 		color: rgba(255, 255, 255, 0.25);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
+		text-align: center;
 
 		@media (--tablet) {
-			margin-top: 0;
-			text-align: center;
+			flex-basis: max-content;
+			flex-grow: 1;
 		}
 	}
 }

--- a/mu-plugins/blocks/global-header-footer/postcss/footer/social-links.pcss
+++ b/mu-plugins/blocks/global-header-footer/postcss/footer/social-links.pcss
@@ -11,12 +11,12 @@
 
 .wp-block-group.global-footer .wp-block-social-links {
 	position: relative;
-	top: -3px; /* Align with W logo. */
 	justify-content: flex-end;
 	align-content: flex-start;
 	min-width: 100px;
 
 	@media (--tablet) {
+		top: -3px; /* Align with W logo. */
 		justify-content: flex-end;
 		flex-basis: 33%;
 		order: 3;


### PR DESCRIPTION
#687 added the Mastodon account to get it verified, but we have a lot more accounts on every other platform that has been asked to be listed.

@eidolonnight @bjmcsherry have asked to increase this to all of the accounts.

These include:
[X](https://twitter.com/WordPress/)
[Bluesky](https://bsky.app/profile/wordpress.org)
[Mastodon](https://mastodon.world/@WordPress)
[Threads](https://www.threads.net/@wordpress)
[Facebook](https://www.facebook.com/WordPress/)
[Instagram](https://www.instagram.com/wordpress/)
[Linkedin](https://www.linkedin.com/company/wordpress/)
[TikTok](https://www.tiktok.com/@wordpress)
[YouTube](https://www.youtube.com/wordpress)
[Tumblr](https://wordpress.tumblr.com/)

The proposed layout would be:
> X  |  Bluesky  |  Mastodon  |  Threads  |  Facebook  |  Instagram  |  LinkedIn  |  TikTok  |  YouTube  |  Tumblr

The visual representation of these gets a bit busy, but not overly bad in my opinion.
There's some responsive work that could/should be done here, although this pre-dates this change, this just makes it a little more obvious.

<table>
<tr><td colspan=2><img width="1728" alt="Screenshot 2025-05-12 at 12 24 59 pm" src="https://github.com/user-attachments/assets/69eec4b9-e49b-488a-8764-3f7c4d11b4dd" /></td></tr>
<tr><td><img width="524" alt="Screenshot 2025-05-12 at 12 26 00 pm" src="https://github.com/user-attachments/assets/1aac7533-7398-46df-830f-2db25c6955cd" /></td><td><img width="379" alt="Screenshot 2025-05-12 at 12 26 18 pm" src="https://github.com/user-attachments/assets/8475acdb-c829-4028-a976-02486c053f73" /></td></tr>
<tr><td><img width="379" alt="Screenshot 2025-05-12 at 12 26 18 pm" src="https://github.com/user-attachments/assets/20ad4873-ee0e-4c88-88ea-b0aebadff5f6" /></td><td><img width="542" alt="Screenshot 2025-05-12 at 12 26 44 pm" src="https://github.com/user-attachments/assets/67b6b4fc-7e7b-440a-8a7b-493bc0654f7b" /></td></tr>
</table>


