### PR TITLE
Header: Restore Mercantile link under About menu

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -572,6 +572,11 @@ function get_global_menu_items() {
 					'url'   => 'https://wordpress.org/gutenberg/',
 					'type'  => 'custom',
 				),
+				array(
+					'title' => esc_html_x( 'Swag Store ↗︎', 'Menu item title', 'wporg' ),
+					'url'   => 'https://mercantile.wordpress.org/',
+					'type'  => 'custom',
+				),
 			),
 		),
 	);


### PR DESCRIPTION
Previously removed in #615 but the swag store is open again.

cc @bjmcsherry