### PR TITLE
Events Map: Allow facet filtering of past events.

### DIFF
--- a/mu-plugins/blocks/google-map/inc/event-filters.php
+++ b/mu-plugins/blocks/google-map/inc/event-filters.php
@@ -97,7 +97,7 @@ function get_events( string $filter_slug, int $start_timestamp, int $end_timesta
 				break;
 
 			case 'all-past':
-				$events = get_all_past_events( $page );
+				$events = get_all_past_events( $page, $facets );
 				break;
 
 			case 'wp20':
@@ -320,27 +320,31 @@ function get_where_clauses( array $facets ): array {
 /**
  * Get a list of all upcoming events across all sites.
  */
-function get_all_past_events( int $page ): array {
+function get_all_past_events( int $page, array $facets = array() ): array {
 	global $wpdb;
 
 	$limit  = 50;
 	$offset = ( $page - 1 ) * $limit;
+	$where  = get_where_clauses( $facets );
+
+	$limit_sql = $wpdb->prepare( "LIMIT %d, %d", $offset, $limit );
 
 	// wporg_events.status doesn't have a separate value for "completed", it's just scheduled events that have
 	// a date in the past.
-	$query = $wpdb->prepare( '
-		SELECT
+	$query = "SELECT
 			id, `type`, title, url, meetup, location, latitude, longitude, date_utc,
 			date_utc_offset AS tz_offset
 		FROM `wporg_events`
 		WHERE
-			status = "scheduled" AND
-			date_utc < NOW()
+			status = 'scheduled' AND
+			date_utc < NOW() AND
+			{$where['clauses']}
 		ORDER BY date_utc DESC
-		LIMIT %d, %d',
-		$offset,
-		$limit
-	);
+		{$limit_sql}";
+
+	if ( $where['values'] ) {
+		$query = $wpdb->prepare( $query, $where['values'] );
+	}
 
 	if ( 'latin1' === DB_CHARSET ) {
 		$events = $wpdb->get_results( $query );


### PR DESCRIPTION
Viewing https://events.wordpress.org/past-events/filtered/country/AU/format/in-person/ should result in a filtered list of Australian events.

Currently, the facets don't apply, although the UI is present, and the URL works.

This adds the needed support.

The past events is still limited to showing the first page of results, which is 50 events.

The upcoming events page simply shows up-to 500, rather than the up-to 50 for the past-events page.