### PR TITLE
REST API: Site Quality: Only load it on the main site

### DIFF
--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -16,17 +16,22 @@ add_filter( 'rest_user_query', __NAMESPACE__ . '\modify_user_query_parameters', 
  */
 function initialize_rest_endpoints() {
 	require_once __DIR__ . '/endpoints/class-wporg-rest-users-controller.php';
-	require_once __DIR__ . '/endpoints/class-wporg-site-quality-controller.php';
 
 	$users_controller = new Users_Controller();
 	$users_controller->register_routes();
 
+	// The Site Quality controller is only needed on the main site. Note: domain check is due to this plugin running on multiple networks.
+	if ( 1 === get_current_blog_id() && 'wordpress.org' === get_blog_details()->domain ) {
+		require_once __DIR__ . '/endpoints/class-wporg-site-quality-controller.php';
+	}
+	
 	if ( defined( 'WPORG_THEME_DIRECTORY_BLOGID' ) && WPORG_THEME_DIRECTORY_BLOGID === get_current_blog_id() ) {
 		require_once __DIR__ . '/endpoints/class-wporg-base-locale-banner-controller.php';
 		require_once __DIR__ . '/endpoints/class-wporg-themes-locale-banner-controller.php';
 		$locale_banner_controller = new Themes_Locale_Banner_Controller();
 		$locale_banner_controller->register_routes();
 	}
+
 	if ( class_exists( 'WordPressdotorg\Plugin_Directory\Plugin_Directory' ) ) {
 		require_once __DIR__ . '/endpoints/class-wporg-base-locale-banner-controller.php';
 		require_once __DIR__ . '/endpoints/class-wporg-plugins-locale-banner-controller.php';


### PR DESCRIPTION
The Site Quality API is loaded on all sites, even though it's only intended on being used in one specific place.

This removes the API from being loaded unless it's on literally WordPress.org.  This does not account for local sites or any tests which may exist.