### PR TITLE
Favorites block: Don't assume that the postID is set.

### DIFF
--- a/mu-plugins/blocks/favorite-button/render.php
+++ b/mu-plugins/blocks/favorite-button/render.php
@@ -7,7 +7,7 @@
 
 namespace WordPressdotorg\MU_Plugins\Favorite_Button_Block;
 
-$settings = get_block_settings( $block->context['postId'] );
+$settings = get_block_settings( $block->context['postId'] ?? 0 );
 if ( ! $settings ) {
 	return '';
 }


### PR DESCRIPTION
Various blocks are made available through the site editor, such as on WordCamp.

These mean the block can be previewed, which may generate warnings such as this:

```
E_WARNING Undefined array key "postId"
URL  https://example.wordcamp.org/2025/wp-json/wp/v2/block-renderer/wporg/favorite-button?context=edit&attributes%5BshowCount%5D=false&attributes%5Bvariant%5D=default&_locale=user
File  pub-sync/blocks/favorite-button/render.php:10
```

Whether these blocks should be presented for insertion is one thing, but avoiding the warning and returning nothing would be nice.