### PR TITLE
Admin bar: Add CSS to hide icons in "Edit" submenu

### DIFF
--- a/mu-plugins/blocks/global-header-footer/admin-bar.php
+++ b/mu-plugins/blocks/global-header-footer/admin-bar.php
@@ -9,6 +9,7 @@ defined( 'WPINC' ) || die();
 /* Actions & filters */
 add_action( 'admin_bar_menu', __NAMESPACE__ . '\filter_admin_bar_links', 10000 ); // 10000 to run after all items are added to the menu.
 add_filter( 'show_admin_bar', __NAMESPACE__ . '\should_show_admin_bar' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_inline_css' );
 
 /**
  * Hide the admin bar for logged out users.
@@ -138,4 +139,11 @@ function filter_admin_bar_links( $wp_admin_bar ) {
 			$wp_admin_bar->add_node( $args );
 		}
 	}
+}
+
+function enqueue_inline_css() {
+	wp_add_inline_style(
+		'admin-bar',
+		'#wpadminbar #wp-admin-bar-edit-actions .ab-item::before { content: "" !important; }'
+	);
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordcamp.org/issues/1259 — This is just a visual issue on WordCamp sites, where each item is offset like a staircase due to the icons. Submenu items don't need icons, so this just removes them, which is the same behavior as the rest of wporg.

| Before | After |
|---|---|
| <img width="498" height="336" alt="" src="https://github.com/user-attachments/assets/2a9685aa-6f80-4088-b95a-c5a10f0cac30" /> | <img width="490" height="312" alt="" src="https://github.com/user-attachments/assets/87c7cfc6-4b9c-4a7c-b58e-14c3df5edb07" /> |

This should have no effect on the w.org sites, since they already have CSS that does this (from the global header CSS).

**To test**

- Sync this file to the WordCamp `pub-sync` location
- View any WordCamp site you have admin permissions on (to see both Customize and Edit Site)
- Hover over the "Edit …" item in the admin bar
- The dropdown should be in alignment, and not have icons
