### PR TITLE
Allow future-scheduled posts in REST API export endpoint

### DIFF
--- a/mu-plugins/rest-api/extras/class-wporg-export-context.php
+++ b/mu-plugins/rest-api/extras/class-wporg-export-context.php
@@ -98,7 +98,8 @@ class Export_Context {
 			/*
 			 * Pretend that the post_status is publish in the results.
 			 *
-			 * This is to pass WP_REST_Posts_Controller::check_read_permission()
+			 * - the_posts: This is to pass WP_REST_Posts_Controller::check_read_permission().
+			 * - rest_prepare_*: This is so the resulting response shows the correct status.
 			 */
 			$args['_future_to_publish'] = true;
 			add_filter( 'the_posts', static function( $posts, $wp_query ) use( $args ) {
@@ -109,12 +110,25 @@ class Export_Context {
 					foreach ( $posts as $post ) {
 						if ( 'future' === $post->post_status ) {
 							$post->post_status = 'publish';
+							$post->real_post_status = 'future';
 						}
 					}
 				}
 
 				return $posts;
 			}, 10, 2 );
+			add_filter( 'rest_prepare_' . $args['post_type'], static function( $response, $post ) {
+				$prepared = $response->get_data();
+				if (
+					isset( $post->real_post_status ) &&
+					$post->real_post_status !== $prepared['status']
+				) {
+					$prepared['status'] = $post->real_post_status;
+					$response->set_data( $prepared );
+				}
+
+				return $response;
+			}, 10, 3 );
 		}
 
 		return $args;

--- a/mu-plugins/rest-api/extras/class-wporg-export-context.php
+++ b/mu-plugins/rest-api/extras/class-wporg-export-context.php
@@ -21,6 +21,8 @@
  * 		]);
  * })
  *
+ * NOTE: This will also reveal future-scheduled post content! (ie. Release pages)
+ *
  * ⚠️ Be careful to only expose public data!
  */
 
@@ -64,6 +66,7 @@ class Export_Context {
 		);
 
 		add_filter( "rest_{$post_type}_item_schema", array( $this, 'add_export_context_to_schema' ) );
+		add_filter( "rest_{$post_type}_query", array( $this, 'allow_scheduled_posts_in_export' ), 10, 2 );
 	}
 
 	/**
@@ -75,6 +78,46 @@ class Export_Context {
 		$this->update_schema_array_recursive( $schema );
 
 		return $schema;
+	}
+
+	/**
+	 * Allows future-scheduled posts to be visible in the rest-api.
+	 *
+	 * @param array           $args    The REST API query args.
+	 * @param \WP_REST_Request $request The REST API request.
+	 * @return array Modified REST API query args.
+	 */
+	public function allow_scheduled_posts_in_export( $args, $request ) {
+		if (
+			$this->context_name === $request->get_param( 'context' ) &&
+			in_array( 'publish', (array) $args['post_status'], true )
+		) {
+			// Allow future posts to be visible in the export context.
+			$args['post_status'][] = 'future';
+
+			/*
+			 * Pretend that the post_status is publish in the results.
+			 *
+			 * This is to pass WP_REST_Posts_Controller::check_read_permission()
+			 */
+			$args['_future_to_publish'] = true;
+			add_filter( 'the_posts', static function( $posts, $wp_query ) use( $args ) {
+				if (
+					$wp_query->get( '_future_to_publish' ) &&
+					$args['post_type'] === $wp_query->get( 'post_type' )
+				) {
+					foreach ( $posts as $post ) {
+						if ( 'future' === $post->post_status ) {
+							$post->post_status = 'publish';
+						}
+					}
+				}
+
+				return $posts;
+			}, 10, 2 );
+		}
+
+		return $args;
 	}
 
 	/**


### PR DESCRIPTION
Includes future-dated posts/pages in the wporg_export content, allowing it to be sync'd to GitHub and local environments ahead of it's release.

Draft and Pending-review content is not included.

This is technically a information disclosure, because the pages/posts aren't published yet, but for the purposes of the sites that use this export functionality, having future dated items made public via local environments is not a great concern (to me).

Creating this as a PR for discussion first.