### PR TITLE
Fix mobile navigation toggle icon overlap in local navigation bar

### DIFF
--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -261,7 +261,13 @@
 				border-radius: 2px;
 				box-shadow: inset 0 0 0 1.5px var(--wp--custom--local-navigation-bar--focus--color);
 			}
-		}
+
+            /* Hide the hamburger lines in the toggle icon (keep the chevron only). */
+            & svg path:nth-of-type(2),
+            & svg path:nth-of-type(3) {
+                display: none;
+            }
+        }
 
 		&  .wp-block-navigation__responsive-container-close {
 			margin-block-start: calc(var(--wp--custom--local-navigation-bar--spacing--height) * -1) !important;

--- a/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
+++ b/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss
@@ -263,11 +263,11 @@
 			}
 
             /* Hide the hamburger lines in the toggle icon (keep the chevron only). */
-            & svg path:nth-of-type(2),
-            & svg path:nth-of-type(3) {
-                display: none;
-            }
-        }
+			& svg path:nth-of-type(2),
+			& svg path:nth-of-type(3) {
+				display: none;
+			}
+		}
 
 		&  .wp-block-navigation__responsive-container-close {
 			margin-block-start: calc(var(--wp--custom--local-navigation-bar--spacing--height) * -1) !important;


### PR DESCRIPTION
## Summary

This PR fixes an issue on small screens where the navigation toggle icon in the local navigation bar displayed both the chevron and hamburger lines at the same time, resulting in a visually cluttered toggle.

The update hides the horizontal “hamburger” paths in the toggle SVG while keeping the chevron visible, aligning the icon with the intended collapsed navigation design.

## Details

- Scoped to the local navigation bar only.
- Uses CSS to target the extra SVG paths rendered by `core/navigation`.
- No changes to markup or JavaScript behavior.
- Improves visual clarity without affecting accessibility or interaction.

## Testing

- Tested on mobile viewport sizes.
- Verified that only the chevron icon is visible for the navigation toggle.
- Confirmed that opening and closing the navigation menu behaves as expected.

Fixes https://meta.trac.wordpress.org/ticket/8139
