### PR TITLE
REST API: Check if get_blog_details() is callable

### DIFF
--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -21,11 +21,11 @@ function initialize_rest_endpoints() {
 	$users_controller->register_routes();
 
 	// The Site Quality controller is only needed on the main site. Note: domain check is due to this plugin running on multiple networks.
-	if ( 1 === get_current_blog_id() && 'wordpress.org' === get_blog_details()->domain ) {
+	if ( 1 === \get_current_blog_id() && function_exists( '\get_blog_details' ) && 'wordpress.org' === \get_blog_details()->domain ) {
 		require_once __DIR__ . '/endpoints/class-wporg-site-quality-controller.php';
 	}
-	
-	if ( defined( 'WPORG_THEME_DIRECTORY_BLOGID' ) && WPORG_THEME_DIRECTORY_BLOGID === get_current_blog_id() ) {
+
+	if ( defined( 'WPORG_THEME_DIRECTORY_BLOGID' ) && WPORG_THEME_DIRECTORY_BLOGID === \get_current_blog_id() ) {
 		require_once __DIR__ . '/endpoints/class-wporg-base-locale-banner-controller.php';
 		require_once __DIR__ . '/endpoints/class-wporg-themes-locale-banner-controller.php';
 		$locale_banner_controller = new Themes_Locale_Banner_Controller();

--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -21,11 +21,11 @@ function initialize_rest_endpoints() {
 	$users_controller->register_routes();
 
 	// The Site Quality controller is only needed on the main site. Note: domain check is due to this plugin running on multiple networks.
-	if ( 1 === \get_current_blog_id() && function_exists( '\get_blog_details' ) && 'wordpress.org' === \get_blog_details()->domain ) {
+	if ( 1 === get_current_blog_id() && function_exists( 'get_blog_details' ) && 'wordpress.org' === get_blog_details()->domain ) {
 		require_once __DIR__ . '/endpoints/class-wporg-site-quality-controller.php';
 	}
 
-	if ( defined( 'WPORG_THEME_DIRECTORY_BLOGID' ) && WPORG_THEME_DIRECTORY_BLOGID === \get_current_blog_id() ) {
+	if ( defined( 'WPORG_THEME_DIRECTORY_BLOGID' ) && WPORG_THEME_DIRECTORY_BLOGID === get_current_blog_id() ) {
 		require_once __DIR__ . '/endpoints/class-wporg-base-locale-banner-controller.php';
 		require_once __DIR__ . '/endpoints/class-wporg-themes-locale-banner-controller.php';
 		$locale_banner_controller = new Themes_Locale_Banner_Controller();


### PR DESCRIPTION
When developing locally, the typical setup is a single-site environment, so get_blog_details is not callable. This results in the following error:

```
Fatal error: Uncaught Error: Call to undefined function WordPressdotorg\MU_Plugins\REST_API\get_blog_details() in /var/www/html/wp-content/mu-plugins/rest-api/index.php:24 Stack trace: #0 /var/www/html/wp-includes/class-wp-hook.php(341): WordPressdotorg\MU_Plugins\REST_API\initialize_rest_endpoints(Object(WP_REST_Server)) #1 /var/www/html/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters(NULL, Array) #2 /var/www/html/wp-includes/plugin.php(522): WP_Hook->do_action(Array) #3 /var/www/html/wp-includes/rest-api.php(636): do_action('rest_api_init', Object(WP_REST_Server)) #4 /var/www/html/wp-includes/rest-api.php(594): rest_get_server() #5 /var/www/html/wp-includes/rest-api.php(2981): rest_do_request(Object(WP_REST_Request)) #6 [internal function]: rest_preload_api_request(Array, '/wp/v2/types?co...') #7 /var/www/html/wp-includes/block-editor.php(762): array_reduce(Array, 'rest_preload_ap...', Array) #8 /var/www/html/wp-admin/edit-form-blocks.php(114): block_editor_rest_api_preload(Array, Object(WP_Block_Editor_Context)) #9 /var/www/html/wp-admin/post.php(187): require('/var/www/html/w...') #10 {main} thrown in /var/www/html/wp-content/mu-plugins/rest-api/index.php on line 24
```

I think we should check whether the function exists.

Additionally, I add `\` to make it clear that we are calling a global function within a namespace.