### PR TITLE
Notice block: Migrate to use inner blocks

### DIFF
--- a/mu-plugins/blocks/notice/src/block.json
+++ b/mu-plugins/blocks/notice/src/block.json
@@ -26,12 +26,6 @@
 			"enum": [ "alert", "info", "warning", "tip", "success" ]
 		}
 	},
-	"example": {
-		"attributes": {
-			"type": "alert",
-			"content": "<p>This is an alert notice.</p>"
-		}
-	},
 	"textdomain": "wporg",
 	"editorScript": "file:./index.js",
 	"style": "file:./style.css"

--- a/mu-plugins/blocks/notice/src/block.json
+++ b/mu-plugins/blocks/notice/src/block.json
@@ -20,12 +20,6 @@
 		}
 	},
 	"attributes": {
-		"content": {
-			"type": "string",
-			"source": "html",
-			"selector": ".wp-block-wporg-notice__content",
-			"multiline": "p"
-		},
 		"type": {
 			"type": "string",
 			"default": "tip",
@@ -34,9 +28,9 @@
 	},
 	"example": {
 		"attributes": {
-            "type": "alert",
+			"type": "alert",
 			"content": "<p>This is an alert notice.</p>"
-        }
+		}
 	},
 	"textdomain": "wporg",
 	"editorScript": "file:./index.js",

--- a/mu-plugins/blocks/notice/src/deprecated.js
+++ b/mu-plugins/blocks/notice/src/deprecated.js
@@ -31,6 +31,7 @@ const migrateToInnerBlocks = ( attributes ) => {
 	];
 };
 
+// eslint-disable-next-line id-length
 const v1 = {
 	attributes: {
 		content: {

--- a/mu-plugins/blocks/notice/src/deprecated.js
+++ b/mu-plugins/blocks/notice/src/deprecated.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock, parseWithAttributeSchema } from '@wordpress/blocks';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+const migrateToInnerBlocks = ( attributes ) => {
+	const { content, ...restAttributes } = attributes;
+
+	return [
+		{
+			...restAttributes,
+		},
+		content
+			? parseWithAttributeSchema( content, {
+					type: 'array',
+					source: 'query',
+					selector: 'p',
+					query: {
+						content: {
+							type: 'string',
+							source: 'html',
+						},
+					},
+			  } ).map( ( { content: paragraphContent } ) =>
+					createBlock( 'core/paragraph', {
+						content: paragraphContent,
+					} )
+			  )
+			: [ createBlock( 'core/paragraph' ) ],
+	];
+};
+
+const v1 = {
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: '.wp-block-wporg-notice__content',
+			multiline: 'p',
+		},
+		type: {
+			type: 'string',
+			default: 'tip',
+			enum: [ 'alert', 'info', 'warning', 'tip', 'success' ],
+		},
+	},
+	migrate: migrateToInnerBlocks,
+	save: ( { attributes } ) => {
+		const { content, type } = attributes;
+		const className = `is-${ type }-notice`;
+
+		return (
+			<div { ...useBlockProps.save( { className } ) }>
+				<div className="wp-block-wporg-notice__icon" />
+				<div className="wp-block-wporg-notice__content">
+					<RichText.Content multiline="p" value={ content } />
+				</div>
+			</div>
+		);
+	},
+};
+
+export default [ v1 ];

--- a/mu-plugins/blocks/notice/src/edit.js
+++ b/mu-plugins/blocks/notice/src/edit.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	BlockControls,
-	useBlockProps,
-	useInnerBlocksProps,
-} from '@wordpress/block-editor';
+import { BlockControls, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { ToolbarDropdownMenu } from '@wordpress/components';
 
 /**
@@ -62,9 +58,7 @@ export function Edit( { attributes, setAttributes } ) {
 			</BlockControls>
 			<div { ...blockProps }>
 				<div className="wp-block-wporg-notice__icon" />
-				<div className="wp-block-wporg-notice__content">
-					{ innerBlocksProps.children }
-				</div>
+				<div className="wp-block-wporg-notice__content">{ innerBlocksProps.children }</div>
 			</div>
 		</>
 	);

--- a/mu-plugins/blocks/notice/src/edit.js
+++ b/mu-plugins/blocks/notice/src/edit.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { BlockControls, RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import { ToolbarDropdownMenu } from '@wordpress/components';
 
 /**
@@ -30,8 +34,13 @@ function getOptionLabel( type ) {
 }
 
 export function Edit( { attributes, setAttributes } ) {
-	const { content, type } = attributes;
-	const className = `is-${ type }-notice`;
+	const { type } = attributes;
+	const blockProps = useBlockProps( {
+		className: `is-${ type }-notice`,
+	} );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/paragraph' ],
+	} );
 
 	return (
 		<>
@@ -51,15 +60,11 @@ export function Edit( { attributes, setAttributes } ) {
 					} ) ) }
 				/>
 			</BlockControls>
-			<div { ...useBlockProps( { className } ) }>
+			<div { ...blockProps }>
 				<div className="wp-block-wporg-notice__icon" />
-				<RichText
-					tagName="div"
-					multiline="p"
-					className="wp-block-wporg-notice__content"
-					onChange={ ( newContent ) => setAttributes( { content: newContent } ) }
-					value={ content }
-				/>
+				<div className="wp-block-wporg-notice__content">
+					{ innerBlocksProps.children }
+				</div>
 			</div>
 		</>
 	);

--- a/mu-plugins/blocks/notice/src/edit.js
+++ b/mu-plugins/blocks/notice/src/edit.js
@@ -35,7 +35,7 @@ export function Edit( { attributes, setAttributes } ) {
 		className: `is-${ type }-notice`,
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: [ 'core/paragraph' ],
+		allowedBlocks: [ 'core/paragraph', 'core/list' ],
 	} );
 
 	return (

--- a/mu-plugins/blocks/notice/src/index.js
+++ b/mu-plugins/blocks/notice/src/index.js
@@ -24,4 +24,15 @@ registerBlockType( metadata.name, {
 		scope: [ 'transform' ],
 		attributes: { type: value },
 	} ) ),
+	example: {
+		attributes: {
+			type: 'alert',
+		},
+		innerBlocks: [
+			{
+				name: 'core/paragraph',
+				attributes: { content: __( '<p>This is an alert notice.</p>', 'wporg' ) },
+			},
+		],
+	},
 } );

--- a/mu-plugins/blocks/notice/src/index.js
+++ b/mu-plugins/blocks/notice/src/index.js
@@ -15,13 +15,12 @@ import deprecated from './deprecated';
 registerBlockType( metadata.name, {
 	edit: Edit,
 	save: save,
-	deprecated,
+	deprecated: deprecated,
 	variations: typeOptions.map( ( { value, label } ) => ( {
 		name: value,
 		/* translators: %s is the notice type. */
 		title: sprintf( __( 'Notice: %s', 'wporg' ), label ),
-		isActive: ( blockAttributes, variationAttributes ) =>
-			blockAttributes.type === variationAttributes.type,
+		isActive: ( blockAttributes, variationAttributes ) => blockAttributes.type === variationAttributes.type,
 		scope: [ 'transform' ],
 		attributes: { type: value },
 	} ) ),

--- a/mu-plugins/blocks/notice/src/index.js
+++ b/mu-plugins/blocks/notice/src/index.js
@@ -10,15 +10,18 @@ import { registerBlockType } from '@wordpress/blocks';
 import { Edit, typeOptions } from './edit';
 import save from './save';
 import metadata from './block.json';
+import deprecated from './deprecated';
 
 registerBlockType( metadata.name, {
 	edit: Edit,
 	save: save,
+	deprecated,
 	variations: typeOptions.map( ( { value, label } ) => ( {
 		name: value,
 		/* translators: %s is the notice type. */
 		title: sprintf( __( 'Notice: %s', 'wporg' ), label ),
-		isActive: ( blockAttributes, variationAttributes ) => blockAttributes.type === variationAttributes.type,
+		isActive: ( blockAttributes, variationAttributes ) =>
+			blockAttributes.type === variationAttributes.type,
 		scope: [ 'transform' ],
 		attributes: { type: value },
 	} ) ),

--- a/mu-plugins/blocks/notice/src/save.js
+++ b/mu-plugins/blocks/notice/src/save.js
@@ -1,17 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { content, type } = attributes;
+	const { type } = attributes;
 	const className = `is-${ type }-notice`;
 
 	return (
 		<div { ...useBlockProps.save( { className } ) }>
 			<div className="wp-block-wporg-notice__icon" />
 			<div className="wp-block-wporg-notice__content">
-				<RichText.Content multiline="p" value={ content } />
+				<InnerBlocks.Content />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
The `multiline` prop of the RichText` component is deprecated. As a result, the following warning will be displayed in the browser console:

```
installHook.js:1 wp.blockEditor.RichText multiline prop is deprecated since version 6.1 and will be removed in version 6.3. Please use nested blocks (InnerBlocks) instead. See: https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/
```

To avoid this, migrate from the RichText component to Inner Blocks.

### Testing Instructions 

- Check out the trunk branch and insert some Notice blocks with some variations.
- Check out this branch and reload your browser.
  - You should see `Updated Block: wporg/notice` in your browser console.
  - All content in the Notice block should be preserved.