### PR TITLE
ToC block: Update link icon

### DIFF
--- a/mu-plugins/blocks/table-of-contents/postcss/style.pcss
+++ b/mu-plugins/blocks/table-of-contents/postcss/style.pcss
@@ -122,7 +122,7 @@
 			text-decoration: none !important;
 
 			/* stylelint-disable-next-line function-url-quotes */
-			background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724%27 height=%2713%27 fill=%27none%27%3E%3Cpath fill=%27%233858E9%27 fill-rule=%27evenodd%27 d=%27M10.083 9.91H6.32a3.069 3.069 0 0 1 0-6.139h3.764v1.5H6.32a1.569 1.569 0 0 0 0 3.138h3.764v1.5Zm3.834-6.138h3.764a3.069 3.069 0 0 1 0 6.137h-3.764v-1.5h3.764a1.569 1.569 0 0 0 0-3.137h-3.764zM9.333 7.304h5.334v-1.5H9.333z%27 clip-rule=%27evenodd%27/%3E%3C/svg%3E");
+			background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzM4NThFOSIgZD0iTTEwIDE3LjM4OUg4LjQ0NEE1LjE5NCA1LjE5NCAwIDEgMSA4LjQ0NCA3SDEwdjEuNUg4LjQ0NGEzLjY5NCAzLjY5NCAwIDAgMCAwIDcuMzg5SDEwdjEuNVpNMTQgN2gxLjU1NmE1LjE5NCA1LjE5NCAwIDAgMSAwIDEwLjM5SDE0di0xLjVoMS41NTZhMy42OTQgMy42OTQgMCAwIDAgMC03LjM5SDE0VjdabS00LjUgNmg1di0xLjVoLTVWMTNaIj48L3BhdGg+PC9zdmc+');
 			background-position: right center;
 			background-repeat: no-repeat;
 			background-size: contain;

--- a/mu-plugins/blocks/table-of-contents/postcss/style.pcss
+++ b/mu-plugins/blocks/table-of-contents/postcss/style.pcss
@@ -122,7 +122,7 @@
 			text-decoration: none !important;
 
 			/* stylelint-disable-next-line function-url-quotes */
-			background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzM4NThFOSIgZD0iTTEwIDE3LjM4OUg4LjQ0NEE1LjE5NCA1LjE5NCAwIDEgMSA4LjQ0NCA3SDEwdjEuNUg4LjQ0NGEzLjY5NCAzLjY5NCAwIDAgMCAwIDcuMzg5SDEwdjEuNVpNMTQgN2gxLjU1NmE1LjE5NCA1LjE5NCAwIDAgMSAwIDEwLjM5SDE0di0xLjVoMS41NTZhMy42OTQgMy42OTQgMCAwIDAgMC03LjM5SDE0VjdabS00LjUgNmg1di0xLjVoLTVWMTNaIj48L3BhdGg+PC9zdmc+');
+			background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzM4NThFOSIgZD0iTTEwIDE3LjM4OUg4LjQ0NEE1LjE5NCA1LjE5NCAwIDEgMSA4LjQ0NCA3SDEwdjEuNUg4LjQ0NGEzLjY5NCAzLjY5NCAwIDAgMCAwIDcuMzg5SDEwdjEuNVpNMTQgN2gxLjU1NmE1LjE5NCA1LjE5NCAwIDAgMSAwIDEwLjM5SDE0di0xLjVoMS41NTZhMy42OTQgMy42OTQgMCAwIDAgMC03LjM5SDE0VjdabS00LjUgNmg1di0xLjVoLTVWMTNaIj48L3BhdGg+PC9zdmc+");
 			background-position: right center;
 			background-repeat: no-repeat;
 			background-size: contain;

--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -21,9 +21,9 @@ function initialize_rest_endpoints() {
 	$users_controller->register_routes();
 
 	// The Site Quality controller is only needed on the main site. Note: domain check is due to this plugin running on multiple networks.
-	if ( 1 === get_current_blog_id() && 'wordpress.org' === get_blog_details()->domain ) {
-		require_once __DIR__ . '/endpoints/class-wporg-site-quality-controller.php';
-	}
+	// if ( 1 === get_current_blog_id() && 'wordpress.org' === get_blog_details()->domain ) {
+	// 	require_once __DIR__ . '/endpoints/class-wporg-site-quality-controller.php';
+	// }
 	
 	if ( defined( 'WPORG_THEME_DIRECTORY_BLOGID' ) && WPORG_THEME_DIRECTORY_BLOGID === get_current_blog_id() ) {
 		require_once __DIR__ . '/endpoints/class-wporg-base-locale-banner-controller.php';

--- a/mu-plugins/rest-api/index.php
+++ b/mu-plugins/rest-api/index.php
@@ -21,9 +21,9 @@ function initialize_rest_endpoints() {
 	$users_controller->register_routes();
 
 	// The Site Quality controller is only needed on the main site. Note: domain check is due to this plugin running on multiple networks.
-	// if ( 1 === get_current_blog_id() && 'wordpress.org' === get_blog_details()->domain ) {
-	// 	require_once __DIR__ . '/endpoints/class-wporg-site-quality-controller.php';
-	// }
+	if ( 1 === get_current_blog_id() && 'wordpress.org' === get_blog_details()->domain ) {
+		require_once __DIR__ . '/endpoints/class-wporg-site-quality-controller.php';
+	}
 	
 	if ( defined( 'WPORG_THEME_DIRECTORY_BLOGID' ) && WPORG_THEME_DIRECTORY_BLOGID === get_current_blog_id() ) {
 		require_once __DIR__ . '/endpoints/class-wporg-base-locale-banner-controller.php';


### PR DESCRIPTION
Closes #653

Use the same SVG data as the link icons exposed in the icon library for the heading link icons.

| Before | After |
|--------|--------|
| <img width="262" height="197" alt="image" src="https://github.com/user-attachments/assets/4fb20310-9bf8-49fc-83ae-ca87842b2b13" /> | <img width="271" height="199" alt="image" src="https://github.com/user-attachments/assets/010cea5a-f6cf-494f-a359-b98badb65fed" /> | 

### Testing Instructions

- Activate Twenty Twenty-Five
- Appearance > Editor > Template > Single Post
- Insert a ToC block _outside_ the Content block. Otherwise, [the the_content hook](https://github.com/WordPress/wporg-mu-plugins/blob/433e9cc12ce5394c7c74fae31bb88554b6872d98/mu-plugins/blocks/table-of-contents/index.php#L96-L102) won't work properly.
- Create a new post and insert multiple headings.
- Open the post on the frontend and check the icon.