### PR TITLE
Events: Include any event happening today (GMT) as upcoming.

### DIFF
--- a/mu-plugins/blocks/google-map/inc/event-filters.php
+++ b/mu-plugins/blocks/google-map/inc/event-filters.php
@@ -234,15 +234,16 @@ function get_all_upcoming_events( array $facets = array() ): array {
 		FROM `wporg_events`
 		WHERE
 			status = 'scheduled' AND
-			date_utc >= NOW() AND
 			{$where['clauses']}
+			AND date_utc >= %s
 		ORDER BY date_utc ASC
 		LIMIT 500"
 	;
 
-	if ( $where['values'] ) {
-		$query = $wpdb->prepare( $query, $where['values'] );
-	}
+	$where_values = $where['values'] ?? [];
+	$where_values[] = gmdate( 'Y-m-d' );
+
+	$query = $wpdb->prepare( $query, $where_values );
 
 	if ( 'latin1' === DB_CHARSET ) {
 		$events = $wpdb->get_results( $query );


### PR DESCRIPTION
When an event is happening on '2026-01-28 00:00:00' it should show up in listings even at 01:02:03. 

Full-day events (Such as WordCamps) often have a 00:00:00 start/end time.