### PR TITLE
Google Map: Close info window when clicking on the map.

### DIFF
--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -83,7 +83,8 @@ export default function Map( { apiKey, markers: rawMarkers, icon, blockStyle } )
 			maps,
 			combinedMarkers.map( ( marker ) => marker.markerRef ),
 			icon,
-			blockStyle
+			blockStyle,
+			infoWindow.current
 		);
 
 		panToCenter(

--- a/mu-plugins/blocks/google-map/src/components/map.js
+++ b/mu-plugins/blocks/google-map/src/components/map.js
@@ -63,6 +63,11 @@ export default function Map( { apiKey, markers: rawMarkers, icon, blockStyle } )
 			pixelOffset: new maps.Size( icon.markerAnchorXOffset, icon.markerAnchorYOffset ),
 		} );
 
+		// Close the info window when clicking on the map (including clusters).
+		map.addListener( 'click', () => {
+			infoWindow.current.close();
+		} );
+
 		combinedMarkers = combineDuplicateLocations( rawMarkers );
 		combinedMarkers = assignMarkerReferences(
 			map,

--- a/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
+++ b/mu-plugins/blocks/google-map/src/utilities/google-maps-api.js
@@ -138,15 +138,16 @@ function openInfoWindow( infoWindow, map, markerObject, rawMarker ) {
 /**
  * Cluster the markers into groups for improved performance and UX.
  *
- * @param {google.maps.Map}      map
- * @param {google.maps}          maps
- * @param {google.maps.Marker[]} markers
- * @param {Object}               rawIcon
- * @param {string}               blockStyle
+ * @param {google.maps.Map}        map
+ * @param {google.maps}            maps
+ * @param {google.maps.Marker[]}   markers
+ * @param {Object}                 rawIcon
+ * @param {string}                 blockStyle
+ * @param {google.maps.InfoWindow} infoWindow
  *
  * @return {MarkerClusterer} The clusterer object.
  */
-export function clusterMarkers( map, maps, markers, rawIcon, blockStyle ) {
+export function clusterMarkers( map, maps, markers, rawIcon, blockStyle, infoWindow ) {
 	const clusterIcon = {
 		url: rawIcon.imagesDirUrl + `/cluster-background-${ blockStyle }.svg?v=2`,
 		size: new maps.Size( rawIcon.clusterHeight, rawIcon.clusterWidth ),
@@ -165,7 +166,15 @@ export function clusterMarkers( map, maps, markers, rawIcon, blockStyle ) {
 		},
 	};
 
-	return new MarkerClusterer( { map, markers, renderer } );
+	// Close any open info window before zooming into the cluster.
+	const onClusterClick = ( event, cluster, clusterMap ) => {
+		infoWindow.close();
+		if ( cluster.bounds ) {
+			clusterMap.fitBounds( cluster.bounds );
+		}
+	};
+
+	return new MarkerClusterer( { map, markers, renderer, onClusterClick } );
 }
 
 /**


### PR DESCRIPTION
Clicking a cluster while an info window was open would pan back to the info window instead of zooming into the cluster. Closing the info window on any map click prevents this and improves UX.

Fixes #488