### PR TITLE
Query Filter: Guard against missing key attribute

### DIFF
--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -3,6 +3,10 @@
  * Render the query filter.
  */
 
+if ( empty( $attributes['key'] ) ) {
+	return;
+}
+
 /**
  * Get configuration for this filter from a filter, so that child themes can
  * dynamically configure the output without needing to rebuild the HTML.


### PR DESCRIPTION
## Summary

- Adds an early return in the query-filter block render when the `key` attribute is not set, preventing an `Undefined array key "key"` PHP warning.
- The guard is placed before the docblock and `apply_filters` call, matching the existing early-return pattern used for missing options.

## Test plan

- Verify that query-filter blocks with a `key` attribute still render correctly.
- Verify that query-filter blocks without a `key` attribute render nothing and produce no PHP warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)