### PR TITLE
Ratings bars: add 2px border-radius

### DIFF
--- a/mu-plugins/blocks/ratings-bars/src/style.scss
+++ b/mu-plugins/blocks/ratings-bars/src/style.scss
@@ -35,6 +35,7 @@
 .wporg-ratings-bars__bar-background {
 	display: inline-block;
 	background-color: var(--wp--preset--color--light-grey-2);
+	border-radius: 2px;
 	position: relative;
 	width: 100%;
 	height: var(--wp--preset--spacing--20);
@@ -44,6 +45,7 @@
 	position: absolute;
 	inset: 0;
 	right: auto;
+	border-radius: 2px;
 	background-color: var(--wp--custom--wporg-ratings-stars--color--fill, #e26f56);
 }
 


### PR DESCRIPTION
## Summary
- Adds `border-radius: 2px` to `.wporg-ratings-bars__bar-background` and `.wporg-ratings-bars__bar-foreground` so rating bars match the rounded style of buttons and other form elements.

Fixes WordPress/wordpress.org#317.

## Test plan
- [ ] Verify rating bars on plugin pages now have a subtle 2px rounded corner on both the background track and filled portion

🤖 Generated with [Claude Code](https://claude.com/claude-code)