### PR TITLE
Global Header: Reorder top items and consolidate dropdowns

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -461,13 +461,18 @@ function is_rosetta_site() {
 function get_global_menu_items() {
 	$global_items = array(
 		array(
-			'title'   => esc_html_x( 'News', 'Menu item title', 'wporg' ),
-			'url'     => 'https://wordpress.org/news/',
-			'type'    => 'custom',
-		),
-		array(
 			'title' => esc_html_x( 'Showcase', 'Menu item title', 'wporg' ),
 			'url'   => 'https://wordpress.org/showcase/',
+			'type'  => 'custom',
+		),
+		array(
+			'title' => esc_html_x( 'Plugins', 'Menu item title', 'wporg' ),
+			'url'   => 'https://wordpress.org/plugins/',
+			'type'  => 'custom',
+		),
+		array(
+			'title' => esc_html_x( 'Themes', 'Menu item title', 'wporg' ),
+			'url'   => 'https://wordpress.org/themes/',
 			'type'  => 'custom',
 		),
 		array(
@@ -476,39 +481,12 @@ function get_global_menu_items() {
 			'type'  => 'custom',
 		),
 		array(
-			'title'   => esc_html_x( 'Extend', 'Menu item title', 'wporg' ),
-			'url'     => '#',
-			'type'    => 'custom',
-			'submenu' => array(
-				array(
-					'title' => esc_html_x( 'Themes', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/themes/',
-					'type'  => 'custom',
-				),
-				array(
-					'title' => esc_html_x( 'Plugins', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/plugins/',
-					'type'  => 'custom',
-				),
-				array(
-					'title' => esc_html_x( 'Patterns', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/patterns/',
-					'type'  => 'custom',
-				),
-				array(
-					'title' => esc_html_x( 'Blocks', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/blocks/',
-					'type'  => 'custom',
-				),
-				array(
-					'title' => esc_html_x( 'Openverse ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://openverse.org/',
-					'type'  => 'custom',
-				),
-			),
+			'title' => esc_html_x( 'News', 'Menu item title', 'wporg' ),
+			'url'   => 'https://wordpress.org/news/',
+			'type'  => 'custom',
 		),
 		array(
-			'title'   => esc_html_x( 'Learn', 'Menu item title', 'wporg' ),
+			'title'   => esc_html_x( 'Resources', 'Menu item title', 'wporg' ),
 			'url'     => '#',
 			'type'    => 'custom',
 			'submenu' => array(
@@ -523,6 +501,11 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
+					'title' => esc_html_x( 'Education', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/education/',
+					'type'  => 'custom',
+				),
+				array(
 					'title' => esc_html_x( 'Forums', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/support/forums/',
 					'type'  => 'custom',
@@ -533,45 +516,28 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'WordPress.tv ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.tv/',
-					'type'  => 'custom',
-				),
-			),
-		),
-		array(
-			'title'   => esc_html_x( 'Community', 'Menu item title', 'wporg' ),
-			'url'     => '#',
-			'type'    => 'custom',
-			'submenu' => array(
-				array(
-					'title' => esc_html_x( 'Make WordPress', 'Menu item title', 'wporg' ),
-					'url'   => 'https://make.wordpress.org/',
+					'title' => esc_html_x( 'Blocks', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/blocks/',
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'Education', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/education/',
+					'title' => esc_html_x( 'Patterns', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/patterns/',
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'Photo Directory', 'Menu item title', 'wporg' ),
+					'title' => esc_html_x( 'Photos', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/photos/',
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'Five for the Future', 'Menu item title', 'wporg' ),
-					'url'   => 'https://wordpress.org/five-for-the-future/',
+					'title' => esc_html_x( 'Openverse ↗︎', 'Menu item title', 'wporg' ),
+					'url'   => 'https://openverse.org/',
 					'type'  => 'custom',
 				),
 				array(
-					'title' => esc_html_x( 'Events', 'Menu item title', 'wporg' ),
-					'url'   => 'https://events.wordpress.org/',
-					'type'  => 'custom',
-				),
-				array(
-					'title' => esc_html_x( 'Job Board ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://jobs.wordpress.net/',
+					'title' => esc_html_x( 'WordPress.tv ↗︎', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.tv/',
 					'type'  => 'custom',
 				),
 			),
@@ -587,6 +553,21 @@ function get_global_menu_items() {
 					'type'  => 'custom',
 				),
 				array(
+					'title' => esc_html_x( 'Make WordPress', 'Menu item title', 'wporg' ),
+					'url'   => 'https://make.wordpress.org/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Events', 'Menu item title', 'wporg' ),
+					'url'   => 'https://events.wordpress.org/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Five for the Future', 'Menu item title', 'wporg' ),
+					'url'   => 'https://wordpress.org/five-for-the-future/',
+					'type'  => 'custom',
+				),
+				array(
 					'title' => esc_html_x( 'Enterprise', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/enterprise/',
 					'type'  => 'custom',
@@ -594,6 +575,11 @@ function get_global_menu_items() {
 				array(
 					'title' => esc_html_x( 'Gutenberg ↗︎', 'Menu item title', 'wporg' ),
 					'url'   => 'https://wordpress.org/gutenberg/',
+					'type'  => 'custom',
+				),
+				array(
+					'title' => esc_html_x( 'Job Board ↗︎', 'Menu item title', 'wporg' ),
+					'url'   => 'https://jobs.wordpress.net/',
 					'type'  => 'custom',
 				),
 				array(


### PR DESCRIPTION
Simplifies the global header's information architecture by moving **Showcase** first, followed by **Plugins** and **Themes**, collapsing the **Extend**, **Learn**, and **Community** dropdowns into two clearer umbrellas — **Resources** and **About** — while keeping every destination reachable.

This PR **does not** remove items from the header navigation, or change styles.

https://meta.trac.wordpress.org/ticket/8233

## Why

From [Matt in Making WordPress Slack](https://wordpress.slack.com/archives/C18723MQ8/p1776034303785159):

> people who make core, to get to plugins, themes, blocks, or patterns on our homepage you have to click on extend, now pretend you are a wp-admin user coming to .org to find those things... is there anywhere we say extend as nav or even naming in core?

"Extend" isn't language that appears anywhere in core or wp-admin — it's org-specific jargon that adds a layer between the visitor and what they're actually looking for. "Learn" and "Community" had a similar problem: they were conceptual groupings that didn't map to the way visitors searched. Three narrow dropdowns also mean visitors have to guess which one holds what they want.

Consolidating into **Resources** (tools, docs, media libraries) and **About** (project + community) removes one layer of guessing, drops a label core users don't recognize, and opens room in the header — picking up part of #34 and echoing the 2022 [make/meta discussion](https://make.wordpress.org/meta/2022/08/18/navigation/).

## What changes

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td valign="top">

- Showcase
- Plugins
- Themes
- News
- Hosting
- **Extend** ▾
    - Patterns
    - Blocks
    - Openverse ↗
- **Learn** ▾
    - Learn WordPress
    - Documentation
    - Forums
    - Developers
    - WordPress.tv ↗
- **Community** ▾
    - Make WordPress
    - Education
    - Photo Directory
    - Five for the Future
    - Events
    - Job Board ↗
- **About** ▾
    - About WordPress
    - Enterprise
    - Gutenberg ↗
    - Swag Store ↗

</td>
<td valign="top">

- Showcase
- Plugins
- Themes
- Hosting
- News
- **Resources** ▾
    - Learn WordPress
    - Documentation
    - Education
    - Forums
    - Developers
    - Blocks
    - Patterns
    - Photos
    - Openverse ↗
    - WordPress.tv ↗
- **About** ▾
    - About WordPress
    - Make WordPress
    - Events
    - Five for the Future
    - Enterprise
    - Gutenberg ↗
    - Job Board ↗
    - Swag Store ↗

</td>
</tr>
</table>

One rename: *Photo Directory* → *Photos*.

## Visual 
https://github.com/user-attachments/assets/ad9e1396-e3cb-4fab-8460-c6ac5aa1ce85



## What does **not** change

**No items are dropped.** Every destination from the previous menu is still in the nav — just under a different parent. This is an IA change, not a pruning pass. That's a separate conversation worth having, but not here.

## Testing

Previewed on a sandbox. Verify on any site using the global header — the same structure renders everywhere.