### PR TITLE
Global Header: Load Codex wp-content assets from s.w.org to avoid CORS errors

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -310,6 +310,13 @@ function rest_render_codex_global_header( $request ) {
 	$markup = rest_render_global_header( $request );
 	$markup = preg_replace( '!<html[^>]+>!i', '<!-- [codex head html] -->', $markup );
 
+	// Load wp-content assets (e.g. the Interactivity API script module) from the s.w.org CDN
+	// rather than wordpress.org. wordpress.org doesn't send CORS headers, so loading these
+	// scripts cross-origin from the Codex throws CORS errors, which breaks the menu and search.
+	// The host is the only part swapped, so the per-file `?ver=` cache buster is preserved.
+	// See https://meta.trac.wordpress.org/ticket/8281.
+	$markup = str_replace( content_url(), 'https://s.w.org/wp-content', $markup );
+
 	return $markup;
 }
 


### PR DESCRIPTION
Scripts loaded from `wordpress.org`, such as the Interactivity API script module, throw CORS errors when embedded in the Codex because `wordpress.org` does not send the required CORS headers. This breaks the header menu and search trigger.

## Fix

In `rest_render_codex_global_header()`, rewrite `wp-content` asset URLs in the rendered markup to load from the `s.w.org` CDN, which does send the necessary CORS headers:

```php
$markup = str_replace( content_url(), 'https://s.w.org/wp-content', $markup );
```

## Notes

- Verified against the live endpoint (`/wp-json/global-header-footer/v1/header/codex`): the only `wp-content` asset is the Interactivity API script module, which appears in both the `<script type="importmap">` JSON and the `<link rel="modulepreload">` href. A markup-level `str_replace` catches both, whereas a `script_loader_src` filter would miss script modules.
- Because `content_url()` is `https://wordpress.org/wp-content`, only asset URLs are rewritten; navigation links (`wordpress.org/plugins/`, `/themes/`, etc.) are untouched.
- Only the host is swapped, so the per-file content-hash `?ver=` cache buster is preserved and remains unique, ensuring the CDN serves fresh content when a file changes.

Fixes https://meta.trac.wordpress.org/ticket/8281

🤖 Generated with [Claude Code](https://claude.com/claude-code)