### PR TITLE
Global Header & Footer: Load external endpoint assets from s.w.org to avoid CORS errors

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -278,25 +278,33 @@ function rest_render_global_header( $request ) {
 		}
 	);
 
-	return do_blocks( '<!-- wp:wporg/global-header /-->' );
+	return rewrite_assets_to_cdn( do_blocks( '<!-- wp:wporg/global-header /-->' ) );
 }
 
 /**
- * Rewrite wp-content asset URLs to load from the s.w.org CDN.
+ * Rewrite local asset URLs to load from the s.w.org CDN.
  *
- * The header/footer endpoints are embedded by external software (the Codex, Trac, etc.) and
- * loaded cross-origin. wordpress.org doesn't send CORS headers, so scripts like the
+ * The header/footer endpoints are embedded by external software (the Codex, Trac, Planet, etc.)
+ * and loaded cross-origin. wordpress.org doesn't send CORS headers, so scripts like the
  * Interactivity API module throw CORS errors when loaded from there, breaking the menu and
- * search. s.w.org serves the same files with the required headers. Only the host is swapped,
- * so each per-file `?ver=` cache buster is preserved.
+ * search. s.w.org serves the same files with the required headers.
+ *
+ * Both `wp-content` and `wp-includes` are rewritten, matching the workaround Trac applies in its
+ * own `update-headers.php`. Only the host is swapped, so each asset's existing (content-hashed,
+ * and therefore unique) `?ver=` cache buster is preserved.
  *
  * @see https://meta.trac.wordpress.org/ticket/8281
+ * @see https://github.com/WordPress/wporg-mu-plugins/pull/430
  *
  * @param string $markup The rendered markup.
- * @return string The markup with wp-content asset URLs pointed at the CDN.
+ * @return string The markup with local asset URLs pointed at the CDN.
  */
 function rewrite_assets_to_cdn( $markup ) {
-	return str_replace( content_url(), 'https://s.w.org/wp-content', $markup );
+	return str_replace(
+		array( content_url(), includes_url() ),
+		array( 'https://s.w.org/wp-content', 'https://s.w.org/wp-includes' ),
+		$markup
+	);
 }
 
 /**
@@ -327,7 +335,6 @@ function rest_render_codex_global_header( $request ) {
 
 	$markup = rest_render_global_header( $request );
 	$markup = preg_replace( '!<html[^>]+>!i', '<!-- [codex head html] -->', $markup );
-	$markup = rewrite_assets_to_cdn( $markup );
 
 	return $markup;
 }

--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -282,6 +282,24 @@ function rest_render_global_header( $request ) {
 }
 
 /**
+ * Rewrite wp-content asset URLs to load from the s.w.org CDN.
+ *
+ * The header/footer endpoints are embedded by external software (the Codex, Trac, etc.) and
+ * loaded cross-origin. wordpress.org doesn't send CORS headers, so scripts like the
+ * Interactivity API module throw CORS errors when loaded from there, breaking the menu and
+ * search. s.w.org serves the same files with the required headers. Only the host is swapped,
+ * so each per-file `?ver=` cache buster is preserved.
+ *
+ * @see https://meta.trac.wordpress.org/ticket/8281
+ *
+ * @param string $markup The rendered markup.
+ * @return string The markup with wp-content asset URLs pointed at the CDN.
+ */
+function rewrite_assets_to_cdn( $markup ) {
+	return str_replace( content_url(), 'https://s.w.org/wp-content', $markup );
+}
+
+/**
  * Render the global header via a REST request for the Codex with appropriate tags.
  *
  * @return string
@@ -309,13 +327,7 @@ function rest_render_codex_global_header( $request ) {
 
 	$markup = rest_render_global_header( $request );
 	$markup = preg_replace( '!<html[^>]+>!i', '<!-- [codex head html] -->', $markup );
-
-	// Load wp-content assets (e.g. the Interactivity API script module) from the s.w.org CDN
-	// rather than wordpress.org. wordpress.org doesn't send CORS headers, so loading these
-	// scripts cross-origin from the Codex throws CORS errors, which breaks the menu and search.
-	// The host is the only part swapped, so the per-file `?ver=` cache buster is preserved.
-	// See https://meta.trac.wordpress.org/ticket/8281.
-	$markup = str_replace( content_url(), 'https://s.w.org/wp-content', $markup );
+	$markup = rewrite_assets_to_cdn( $markup );
 
 	return $markup;
 }
@@ -825,7 +837,10 @@ function rest_render_global_footer( $request ) {
 		return true;
 	}, 10, 2 );
 
-	return do_blocks( '<!-- wp:wporg/global-footer /-->' );
+	$markup = do_blocks( '<!-- wp:wporg/global-footer /-->' );
+	$markup = rewrite_assets_to_cdn( $markup );
+
+	return $markup;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #742, which fixed the Codex header. The same CORS issue affects the other endpoints that external software embeds cross-origin:

- **`/footer`** -- the Codex (and Trac) footer; loads three `wp-content` scripts cross-origin.
- **`/header`** -- consumed by Trac.
- **`/header/planet`** -- consumed by Planet (planet.wordpress.org), which suffers the same CORS errors.

All embed the global header/footer cross-origin and load assets (e.g. the Interactivity API module) from `wordpress.org/wp-content`, which does not send CORS headers, breaking the menu and search.

## Fix

A shared `rewrite_assets_to_cdn()` helper swaps the host to the `s.w.org` CDN, which serves the same files with the required CORS headers:

```php
function rewrite_assets_to_cdn( $markup ) {
    return str_replace(
        array( content_url(), includes_url() ),
        array( 'https://s.w.org/wp-content', 'https://s.w.org/wp-includes' ),
        $markup
    );
}
```

It is applied in `rest_render_global_header()` (covering `/header`, `/header/codex`, and `/header/planet`) and in `rest_render_global_footer()`.

## Notes

- Both `wp-content` and `wp-includes` are rewritten, matching the workaround Trac already applies in its own `update-headers.php`. This change is intended to eventually let that workaround be removed (see #430). No `wp-includes` assets are emitted today, but covering it future-proofs the endpoints.
- Only the host is swapped, so each asset keeps its existing content-hashed `?ver=` cache buster, which is already unique. (Trac additionally appends an md5 of the fetched content; we rely on the existing `?ver=` rather than fetching every asset at render time.)
- These REST endpoints are only used by external consumers; the on-site header/footer render directly via the block callbacks and are unaffected.
- `content_url()` / `includes_url()` are `https://wordpress.org/wp-content` / `.../wp-includes`, so only asset URLs are rewritten -- navigation links are untouched.

Fixes https://meta.trac.wordpress.org/ticket/8281

🤖 Generated with [Claude Code](https://claude.com/claude-code)