### PR TITLE
Implement wporg_icons_filepath_shim for compatibility

### DIFF
--- a/mu-plugins/plugin-tweaks/gutenberg.php
+++ b/mu-plugins/plugin-tweaks/gutenberg.php
@@ -102,7 +102,7 @@ function wporg_icons_filepath_shim() {
 	$registry = WP_Icons_Registry::get_instance();
 
 	try {
-    	// `registered_icons` is declared protected on the base class, so reflect the
+		// `registered_icons` is declared protected on the base class, so reflect the
 		// base class even when the live instance is the Gutenberg subclass.
 		// NB: do NOT use $registry->get_registered_i
 		// get_content() and would throw the exact fatal we're fixing.

--- a/mu-plugins/plugin-tweaks/gutenberg.php
+++ b/mu-plugins/plugin-tweaks/gutenberg.php
@@ -86,3 +86,48 @@ function fix_rtl_style_includes() {
 		}
 	}
 }
+
+/*
+ * Until Gutenberg 23.5.0 is released, this workaround avoids a fatal with incompatible
+ * core WP code, where GB expects `filePath`, but core has `file_path`.
+ *
+ */
+function wporg_icons_filepath_shim() {
+	if ( ! class_exists( 'WP_Icons_Registry', false ) ) {
+		return;
+	}
+
+	// The active singleton may be core's WP_Icons_Registry OR the plugin's
+	// WP_Icons_Registry_Gutenberg (swapped in at init:1). Patch whichever is live.
+	$registry = WP_Icons_Registry::get_instance();
+
+	try {
+    	// `registered_icons` is declared protected on the base class, so reflect the
+		// base class even when the live instance is the Gutenberg subclass.
+		// NB: do NOT use $registry->get_registered_i
+		// get_content() and would throw the exact fatal we're fixing.
+		$prop = new ReflectionProperty( 'WP_Icons_Registry', 'registered_icons' );
+	} catch ( ReflectionException $e ) {
+		return; // Core changed shape; nothing to do.
+	}
+
+	$icons   = $prop->getValue( $registry );
+	$patched = 0;
+
+	foreach ( $icons as $name => $icon ) {
+		// THE CONDITIONAL: only bridge entries that still carry the old camelCase key
+		// without the new snake_case one. Once Gutente
+		// `file_path` (core #64847), `file_path` is already set (or `filePath` is gone),
+		// this is false for every icon, and the shim
+		if ( empty( $icon['file_path'] ) && ! empty( $icon['filePath'] ) ) {
+			$icons[ $name ]['file_path'] = $icon['filePath'];
+			++$patched;
+		}
+	}
+
+	if ( 0 === $patched ) {
+		return; // Already compatible: core is live, or the Gutenberg fix has shipped.
+	}
+
+	$prop->setValue( $registry, $icons );
+}


### PR DESCRIPTION
Added a shim function to resolve compatibility issues between Gutenberg and core WP regarding icon file paths.