### PR TITLE
CI: only update build branch after lint and tests pass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,15 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    # Run the linting and test suites first. The build job below depends on both,
+    # so a failing lint/test run prevents the build branch from being updated.
+    lint:
+        uses: ./.github/workflows/linters.yml
+    test:
+        uses: ./.github/workflows/tests.yml
+
     build:
+        needs: [lint, test]
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,10 +1,10 @@
 name: Static Analysis (Linting)
 
-# This workflow is triggered on pushes to trunk, and any PRs.
+# Runs on any PR, and is also called by build.yml (on trunk) so the build branch
+# is only updated after linting succeeds.
 on:
-    push:
-        branches: [trunk]
     pull_request:
+    workflow_call:
 
 jobs:
     check:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,15 @@
 name: CI
 
+# Runs on PRs (and the try/phpunit-tests branch), and is also called by build.yml
+# (on trunk) so the build branch is only updated after tests pass.
 on:
   push:
-    branches: [ trunk, try/phpunit-tests ]
+    branches: [ try/phpunit-tests ]
   pull_request:
     branches: [ trunk ]
 
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   run-tests:


### PR DESCRIPTION
## Problem

`build.yml` force-pushes to the `build` branch on every push to `trunk`, **independently** of `linters.yml` and `tests.yml` — they run in parallel and the build pushes regardless of their result. Since the deploy sync script does `git clone … --branch build`, a commit that fails CI can still reach `build` and be synced/deployed.

This actually happened: on commit 7eecd08e ("Add init action for wporg_icons_filepath_shim") the **CI run failed** with a fatal —

```
PHP Fatal error: Uncaught Error: Class "WordPressdotorg\\MU_Plugins\\Plugin_Tweaks\\Gutenberg\\WP_Icons_Registry" not found in .../mu-plugins/plugin-tweaks/gutenberg.php:103
```

— but `Build and push to build branch` went green on the same SHA and force-pushed the broken code to `build` anyway.

## Change

- Make `linters.yml` and `tests.yml` reusable via `workflow_call` (and stop them triggering directly on `trunk` pushes — `build.yml` now drives them there, so no duplicate runs; PR behaviour is unchanged).
- `build.yml` now runs `lint` and `test` as prerequisite jobs and gates the build job with `needs: [lint, test]`.

A red lint or test run now leaves the `build` branch untouched, so it can't be synced/deployed. With this in place, 7eecd08e would not have updated `build`.

## Notes
- No duplicate runs on `trunk`: only `build.yml` triggers there and it calls the other two.
- PRs still run lint + tests directly (no build).
- `try/phpunit-tests` push trigger and `workflow_dispatch` on tests are preserved.