### PR TITLE
Query Filter: Avoid trailing ? when submitting with no filters selected

### DIFF
--- a/mu-plugins/blocks/query-filter/render.php
+++ b/mu-plugins/blocks/query-filter/render.php
@@ -109,6 +109,7 @@ if ( $selected_count && $has_multiple ) {
 		<form
 			action="<?php echo esc_attr( $settings['action'] ); ?>"
 			data-wp-on--change="actions.handleFormChange"
+			data-wp-on--submit="actions.handleFormSubmit"
 		>
 			<div class="wporg-query-filter__modal-header">
 				<h2><?php echo wp_kses_post( $settings['title'] ); ?></h2>

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -116,6 +116,15 @@ const { actions } = store( 'wporg/query-filter', {
 			const count = context.form.querySelectorAll( 'input:checked' ).length;
 			actions.updateButtons( count );
 		},
+		handleFormSubmit: ( event ) => {
+			const form = event.target;
+			// Submitting a GET form without any data appends a lone `?` to
+			// the URL, so navigate to the clean action URL instead.
+			if ( ! Array.from( new FormData( form ).keys() ).length ) {
+				event.preventDefault();
+				window.location.href = form.action;
+			}
+		},
 		clearSelection: () => {
 			const context = getContext();
 			const { ref } = getElement();

--- a/mu-plugins/blocks/query-filter/src/view.js
+++ b/mu-plugins/blocks/query-filter/src/view.js
@@ -118,11 +118,12 @@ const { actions } = store( 'wporg/query-filter', {
 		},
 		handleFormSubmit: ( event ) => {
 			const form = event.target;
-			// Submitting a GET form without any data appends a lone `?` to
-			// the URL, so navigate to the clean action URL instead.
+			// Submitting a GET form without any data appends a lone `?` to the URL.
 			if ( ! Array.from( new FormData( form ).keys() ).length ) {
 				event.preventDefault();
-				window.location.href = form.action;
+				const url = new URL( form.getAttribute( 'action' ) || '', window.location.href );
+				url.search = '';
+				window.location.href = url.toString();
 			}
 		},
 		clearSelection: () => {


### PR DESCRIPTION
Fixes https://meta.trac.wordpress.org/ticket/8379.

## Problem

On the [Showcase archives](https://wordpress.org/showcase/archives/), selecting a category, applying it, then unchecking it and applying again leaves the URL as `https://wordpress.org/showcase/archives/?` — with an unnecessary trailing `?`.

This affects any use of the query-filter block: submitting the filter form with nothing selected performs a native GET submission with no form data, and per the HTML spec the browser appends a lone `?` to the action URL.

## Solution

Add a `submit` handler (wired via `data-wp-on--submit`, alongside the existing `data-wp-on--change`) that checks whether the form has any data to submit. When it's empty, it cancels the native submission and navigates to the clean form action URL instead.

When any filters are selected — including hidden inputs injected by themes via `wporg_query_filter_in_form` — the form data is non-empty and submission proceeds exactly as before. Without JavaScript, behavior is unchanged.

## Testing

Verified against the live Showcase by attaching the equivalent submit handler and running the reproduction steps from the ticket:

1. Open `/showcase/archives/`, select a category, Apply → redirects to the canonical term archive as before.
2. Uncheck the category, Apply → lands on `https://wordpress.org/showcase/archives/` with no trailing `?` (previously `…/archives/?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)