### PR TITLE
Remove unused PASSWORD constant from Meetup OAuth2 client

### DIFF
--- a/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -43,11 +43,6 @@ class Meetup_OAuth2_Client extends API_Client {
 	/**
 	 * @var string
 	 */
-	const PASSWORD = MEETUP_USER_PASSWORD;
-
-	/**
-	 * @var string
-	 */
 	const URL_AUTHORIZE = 'https://secure.meetup.com/oauth2/authorize';
 
 	/**


### PR DESCRIPTION
The `PASSWORD` constant (mapped to `MEETUP_USER_PASSWORD`) is no longer referenced anywhere after the password-based authentication flow was removed in [meta changeset 11498](https://meta.trac.wordpress.org/changeset/11498).

This removes the constant so the class no longer depends on the `MEETUP_USER_PASSWORD` define.

🤖 Generated with [Claude Code](https://claude.com/claude-code)