### PR TITLE
Global header/footer: Restore Swag to the footer, tidy the header link

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -608,12 +608,12 @@ function get_global_menu_items() {
 					'url'   => 'https://jobs.wordpress.net/',
 					'type'  => 'custom',
 				),
-				array(
-					'title' => esc_html_x( 'Swag Store ↗︎', 'Menu item title', 'wporg' ),
-					'url'   => 'https://mercantile.wordpress.org/',
-					'type'  => 'custom',
-				),
 			),
+		),
+		array(
+			'title' => esc_html_x( 'Swag ↗︎', 'Menu item title', 'wporg' ),
+			'url'   => 'https://mercantile.wordpress.org/',
+			'type'  => 'custom',
 		),
 	);
 

--- a/mu-plugins/blocks/global-header-footer/footer.php
+++ b/mu-plugins/blocks/global-header-footer/footer.php
@@ -92,7 +92,7 @@ $code_is_poetry_src = isset( $attributes['textColor'] ) && str_contains( $attrib
 		<li><a href="https://wordpressfoundation.org/donate/"><?php echo esc_html_x( 'Donate ↗', 'Menu item title', 'wporg' ); ?></a></li>
 		<!-- /wp:list-item -->
 		<!-- wp:list-item -->
-		<li><a href="https://wordpress.org/five-for-the-future/"><?php echo esc_html_x( 'Five for the Future', 'Menu item title', 'wporg' ); ?></a></li>
+		<li><a href="https://mercantile.wordpress.org/"><?php echo esc_html_x( 'Swag ↗', 'Menu item title', 'wporg' ); ?></a></li>
 		<!-- /wp:list-item -->
 	</ul>
 	<!-- /wp:list -->


### PR DESCRIPTION
## What & why

The [Mercantile swag store](https://mercantile.wordpress.org/) has reopened, and Matt asked that it be linked from the main .org navigation. It's already reachable in the header's About menu (last changed in #739); this PR tidies that link and restores it to the footer. Both links open the store in a **new tab** — it's a separate site — with screen-reader-only "opens in a new tab" text for accessibility.

### Footer — restore Swag to the "Get Involved" column

Swag used to hold the footer's **4th column, 4th item**. The history:

- **#615** removed it from header and footer because the store was closed (#614 — *"to reduce inbound traffic"* while it had *"no plans to reopen"*).
- That left, in the author's words, *"a hole in the footer links."*
- **#619** filled the hole with **Five for the Future**, explicitly *"to replace the Swag store links which have been removed while the store is closed."*

The store has reopened, so this reverses that swap. **Five for the Future keeps its own place in the header's About menu.** Swag carries the `↗` to match the store link in the header's About menu and flag the jump to the separate store.

| Get Involved (before) | Get Involved (after) |
|---|---|
| Get Involved | Get Involved |
| Events | Events |
| Donate ↗ | Donate ↗ |
| **Five for the Future** | **Swag ↗** |

### Header — promoted out of the About menu

- Renamed "Swag Store ↗" → "Swag ↗": shorter, matches the `wordpress.org/about/swag` redirect and the store's own name, and consistent with the other external dropdown links (Job Board ↗, Openverse ↗).
- `Swag Store` was under `About`, but with this PR, `Swag` will sit next to it at the top-level menu

## Notes

- We are promoting `Swag` to a top-level menu item after `About`. BUT, I do want to acknowledge that a top-level item should _ideally_ behave like its peers — shared header, an active/selected state on the destination — and the store right now is a separate site with its own chrome and no global nav. Doing that properly means getting Mercantile to adopt the global header, plus a more holistic look at the global nav to include the store. I will take a look at that for a better long-term solution, outside this PR. 

- Separately, [jobs.wordpress.net](https://jobs.wordpress.net/) was flagged as another surface whose footer could be aligned with the global footer; out of scope here.