### PR TITLE
Global Header & Footer: Fix wp-includes CDN rewrite dropping a slash

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -302,7 +302,7 @@ function rest_render_global_header( $request ) {
 function rewrite_assets_to_cdn( $markup ) {
 	return str_replace(
 		array( content_url(), includes_url() ),
-		array( 'https://s.w.org/wp-content', 'https://s.w.org/wp-includes' ),
+		array( 'https://s.w.org/wp-content', 'https://s.w.org/wp-includes/' ),
 		$markup
 	);
 }


### PR DESCRIPTION
`rewrite_assets_to_cdn()` replaces `includes_url()` — which returns a URL **with** a trailing slash (`https://wordpress.org/wp-includes/`) — with `https://s.w.org/wp-includes`, which has none. The endpoint output therefore contains URLs like:

```
https://s.w.org/wp-includesjs/wp-emoji-release.min.js?ver=7.1-RC2-63157
https://s.w.org/wp-includesjs/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.17
```

These 301-redirect to the wordpress.org homepage, so the mediaelement stylesheets and the emoji fallback script are broken for every consumer of the header/footer endpoints (Trac, Codex, Planet, …). `content_url()` returns no trailing slash, so `wp-content` URLs are unaffected.

This adds the missing trailing slash to the replacement string.

Currently blocks WordPress/wordpress.org#772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)