### PR TITLE
Global Header & Footer: Remove FEATURE_2021_GLOBAL_HEADER_FOOTER feature flag

### DIFF
--- a/mu-plugins/blocks/global-header-footer/blocks.php
+++ b/mu-plugins/blocks/global-header-footer/blocks.php
@@ -161,14 +161,6 @@ function preload_google_fonts() {
  * Output styles for themes that don't use `wp4-styles`. This provides compat with the classic header.php.
  */
 function enqueue_compat_wp4_styles() {
-	// See https://wordpress.slack.com/archives/C02QB8GMM/p1642056619063500
-	if (
-		( defined( 'FEATURE_2021_GLOBAL_HEADER_FOOTER' ) && ! FEATURE_2021_GLOBAL_HEADER_FOOTER ) &&
-		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST )
-	) {
-		return;
-	}
-
 	if ( defined( 'IS_WORDCAMP_NETWORK' ) ) {
 		return;
 	}


### PR DESCRIPTION
The `FEATURE_2021_GLOBAL_HEADER_FOOTER` flag gated the 2021 header/footer rollout and has been enabled everywhere since launch. The only remaining usage was an early return in `enqueue_compat_wp4_styles()` that could never trigger anymore, so this removes it (along with the Slack-thread comment that explained the flag check).

See #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)