### PR TITLE
Google Map & Modal: Tidy escaping of block attribute output

### DIFF
--- a/mu-plugins/blocks/google-map/index.php
+++ b/mu-plugins/blocks/google-map/index.php
@@ -64,8 +64,8 @@ function render( $attributes, $content, $block ) {
 			$handle,
 			sprintf(
 				'var wporgGoogleMap = wporgGoogleMap || {};
-				wporgGoogleMap["%s"] = %s;',
-				$attributes['id'],
+				wporgGoogleMap[%s] = %s;',
+				wp_json_encode( (string) $attributes['id'] ),
 				wp_json_encode( $attributes )
 			),
 			'before'

--- a/mu-plugins/blocks/modal/render.php
+++ b/mu-plugins/blocks/modal/render.php
@@ -39,7 +39,7 @@ $html_id = wp_unique_id( 'modal-' );
 		<div class="<?php echo esc_attr( $button_class ); ?>">
 		<?php if ( ! empty( $attributes['href'] ) ) : ?>
 			<a
-				href="<?php echo esc_attr( $attributes['href'] ); ?>"
+				href="<?php echo esc_url( $attributes['href'] ); ?>"
 				download
 				class="wporg-modal__toggle wp-block-button__link"
 				data-wp-on--click="actions.toggle"


### PR DESCRIPTION
Two small escaping corrections in the block render output:

- **Google Map** (`blocks/google-map/index.php`): pass the `id` attribute through `wp_json_encode()` when building the inline `wporgGoogleMap[…]` script, so the key is always emitted as a valid JS string literal (matching how the second value is already encoded).
- **Modal** (`blocks/modal/render.php`): use `esc_url()` instead of `esc_attr()` for the button `href`, which is the correct escaper for a URL attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)