### PR TITLE
Modal: Expand shortcodes in href before escaping

### DIFF
--- a/mu-plugins/blocks/modal/render.php
+++ b/mu-plugins/blocks/modal/render.php
@@ -39,7 +39,7 @@ $html_id = wp_unique_id( 'modal-' );
 		<div class="<?php echo esc_attr( $button_class ); ?>">
 		<?php if ( ! empty( $attributes['href'] ) ) : ?>
 			<a
-				href="<?php echo esc_url( $attributes['href'] ); ?>"
+				href="<?php echo esc_url( do_shortcode( $attributes['href'] ) ); ?>"
 				download
 				class="wporg-modal__toggle wp-block-button__link"
 				data-wp-on--click="actions.toggle"


### PR DESCRIPTION
## What
Expands shortcodes in the modal block's `href` attribute before running it through `esc_url()`.

## Why
Follow-up to 63a9c9b0d171ba0232b340a49aaeed61b9d3304c (#754), which switched the `href` output from `esc_attr()` to `esc_url()`. That broke the download button on wordpress.org/download:

- The download pattern stores a shortcode as the block attribute: `<!-- wp:wporg/modal {"href":"[download_link]", ... } -->`
- Blocks render on `the_content` at priority 9, shortcodes at priority 11, so when the modal renders, `$attributes['href']` is still the literal string `[download_link]`.
- `esc_url()` keeps `[` and `]` (they're in its allowed-character set), finds no scheme, and prepends `http://` → `http://[download_link]`.
- Two priorities later, `do_shortcode()` expands the still-intact shortcode inside that string → `http://https://wordpress.org/latest.zip`.

`esc_attr()` left the token untouched, which is why this only surfaced with #754.

## How
Run `do_shortcode()` on the attribute before escaping, so `esc_url()` receives the resolved URL with a valid scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)