### PR TITLE
Export Context: Allow the Jetpack Subscriptions block in raw exports

### DIFF
--- a/mu-plugins/rest-api/extras/class-wporg-export-context.php
+++ b/mu-plugins/rest-api/extras/class-wporg-export-context.php
@@ -198,6 +198,7 @@ class Export_Context {
 			'wporg/*',
 			// other allowed blocks:
 			'jetpack/image-compare',
+			'jetpack/subscriptions',
 			'jetpack/tiled-gallery',
 			'syntaxhighlighter/code',
 		) );


### PR DESCRIPTION
## What

Adds `jetpack/subscriptions` to the default allow list in the `allow_raw_block_export` filter.

## Why

WordPress/wporg-main-2022#730 (Content updates from Page Editor) shows the subscription block being stripped out of exported content and replaced with the placeholder:

```php
<p><?php esc_html_e( 'Post contains a disallowed block jetpack/subscriptions', 'wporg' ); ?></p>
```

The block renders a public subscription form and exposes no private data, so it belongs alongside `jetpack/image-compare` and `jetpack/tiled-gallery`, which are already permitted.

## Testing

Re-run a Page Editor export of a page containing a Jetpack Subscriptions block (e.g. one of the pages in WordPress/wporg-main-2022#730) and confirm the raw block markup is exported instead of the placeholder paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)