### PR TITLE
Export Context: Remove leftover debug bypass in the post guard

### DIFF
--- a/mu-plugins/rest-api/extras/class-wporg-export-context.php
+++ b/mu-plugins/rest-api/extras/class-wporg-export-context.php
@@ -208,8 +208,12 @@ class Export_Context {
 			$post = get_post();
 		}
 
+		if ( ! $post ) {
+			return '';
+		}
+
 		// Exit early if the post contains any blocks that are not explicitly allowed.
-		if ( $post && has_blocks( $post->post_content ) || true ) {
+		if ( has_blocks( $post->post_content ) ) {
 
 			$regexes = array();
 			foreach ( $allowed_blocks as $allowed_block_name ) {


### PR DESCRIPTION
## The bug

`class-wporg-export-context.php:211`:

```php
// Exit early if the post contains any blocks that are not explicitly allowed.
if ( $post && has_blocks( $post->post_content ) || true ) {
```

`&&` binds tighter than `||`, so PHP reads this as `( $post && has_blocks( ... ) ) || true` — always true. The guard is dead code and the body always runs.

## Where it came from

Not intentional. Tracing it back through the port from WordPress/Learn#249:

- `89c9b36` "First stab at exposing raw content" — line is correct: `if ( $post && has_blocks( $post->post_content ) ) {`
- `39297bc` "Allow wildcards in the allowed block names / Also fix a couple of bugs" — `|| true` appears

That same commit fixes a real bug two lines below: `get_all_block_names( $block_names )` → `get_all_block_names( $blocks )`, which had been passing an undefined variable so the block-name list always came back empty and the loop never ran. Forcing the body to execute is the natural way to debug that, and the bypass was left behind when the actual fix landed. It arrived here intact in #227 and has been dead since July 2022.

## What it actually breaks

The `$post` null check. If `get_post()` returns null — deleted post, or no global post in the REST context — execution continues into:

```php
$blocks = parse_blocks( $post->post_content );
...
return $post->post_content;
```

On PHP 8 that is `Warning: Attempt to read property "post_content" on null`, a `parse_blocks( null )` deprecation, and a `null` return where the REST schema expects a string.

The `has_blocks()` half is only an optimization: classic content parses to a single block with a null `blockName`, which `get_all_block_names()` already filters out, so the loop finds nothing to reject either way. Restoring that check changes no behavior — it just skips a pointless parse.

## The fix

Handle the null case explicitly at the top, and let the block check be a plain block check.

## Testing

- `php -l` clean.
- `composer lint` (with the generated `phpcs.xml.dist`) reports no violations on the changed lines; the 7 it does report are pre-existing, all in the file's header docblock.
- Behavior: exporting a normal block post is unchanged; exporting a post containing a disallowed block still returns the placeholder; requesting a non-existent post now returns an empty string with no PHP warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)