### PR TITLE
Build: allow the build workflow to be triggered manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build and push to build branch.
 on:
     push:
         branches: [trunk]
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow }}


### PR DESCRIPTION
### Summary

Adds a `workflow_dispatch` trigger to **Build and push to build branch** so it can be started on demand from the Actions tab.

### Why

Today the workflow's only trigger is `push` to `trunk`. When a push-triggered run fails to *start* — a GitHub Actions **startup failure**, which creates no jobs and therefore cannot be re-run — there's no way to refresh the `build` branch except pushing another commit to `trunk`. This happened on the #759 merge: the build run hit a startup failure, so the `build` branch was left behind trunk.

With `workflow_dispatch`, that situation is a one-click "Run workflow" instead.

### Notes

- The manual trigger becomes available once this is on `trunk` (the default branch).
- No behavior change to the existing push trigger, and the build job still runs behind `needs: [lint, test]`.