### PR TITLE
Export CSV: pass explicit formatting arguments to fputcsv()

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,7 +8,7 @@
 			"config": {
 				"WP_ENVIRONMENT_TYPE": false
 			},
-			"phpVersion": "7.4",
+			"phpVersion": "8.4",
 			"mappings": {
 				"vendor": "./vendor",
 				"phpunit": "./phpunit",

--- a/mu-plugins/utilities/class-export-csv.php
+++ b/mu-plugins/utilities/class-export-csv.php
@@ -250,11 +250,11 @@ class Export_CSV {
 		$csv = fopen( 'php://output', 'w' );
 
 		if ( ! empty( $this->header_row ) ) {
-			fputcsv( $csv, self::esc_csv( $this->header_row ) );
+			fputcsv( $csv, self::esc_csv( $this->header_row ), ',', '"', '\\', "\n" );
 		}
 
 		foreach ( $this->data_rows as $row ) {
-			fputcsv( $csv, self::esc_csv( $row ) );
+			fputcsv( $csv, self::esc_csv( $row ), ',', '"', '\\', "\n" );
 		}
 
 		fclose( $csv );


### PR DESCRIPTION
### Summary

Passes the separator, enclosure, escape, and line-ending arguments to `fputcsv()` explicitly in the CSV exporter, so the written format is deterministic rather than relying on PHP's evolving defaults.

Also bumps the wp-env **tests** environment from PHP 7.4 to 8.4 to match the versions we run now.

### Notes

- No behavior change for well-formed data; this just pins the format arguments.
- Mirrors the equivalent change already present on the deployed side, so a future mu-plugins sync won't revert it.