### PR TITLE
Revert wp-env tests environment to PHP 7.4

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,7 +8,7 @@
 			"config": {
 				"WP_ENVIRONMENT_TYPE": false
 			},
-			"phpVersion": "8.4",
+			"phpVersion": "7.4",
 			"mappings": {
 				"vendor": "./vendor",
 				"phpunit": "./phpunit",


### PR DESCRIPTION
### Summary

Reverts the test environment's `phpVersion` from `8.4` back to `7.4`.

### Why

The bump to 8.4 (in #761) broke CI. On the 8.4 wp-env container, `phpunit` fails to start:

```
Call to undefined method PHPUnit\Framework\TestSuite::empty()
  in .../TextUI/Configuration/Xml/TestSuiteMapper.php:48
```

wp-env provisions a newer PHPUnit for PHP 8.4, but the project pins PHPUnit **9.6** (via `vendor/`), and the two versions collide before any test runs. The 7.4 container provisions a PHPUnit that matches 9.6, so the suite runs cleanly there.

This restores a green build (and lets the `build` branch update again). Moving the test environment to 8.4 properly requires upgrading `phpunit/phpunit` and `yoast/phpunit-polyfills` to matching majors and updating `phpunit.xml.dist` — worth doing, but as its own change.