### PR TITLE
Language Suggest: resolve the endpoint server-side

### DIFF
--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -51,7 +51,12 @@ function get_endpoint() {
 	 * @param string $endpoint Endpoint URL. Must be an HTTPS wordpress.org URL.
 	 */
 	$endpoint = apply_filters( 'wporg_language_suggest_endpoint', $default );
-	$parts    = wp_parse_url( $endpoint );
+
+	if ( ! is_string( $endpoint ) ) {
+		return $default;
+	}
+
+	$parts = wp_parse_url( $endpoint );
 
 	// A backslash is a path separator to the browser, so it and PHP can disagree on the host.
 	if ( str_contains( $endpoint, '\\' ) ) {

--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -29,12 +29,58 @@ function language_suggest_block_init() {
 add_action( 'init', __NAMESPACE__ . '\language_suggest_block_init' );
 
 /**
+ * Returns the endpoint the front-end script should request.
+ *
+ * The response is rendered into the block, so the endpoint is resolved here
+ * rather than read back out of the DOM: block markup lives in `post_content`,
+ * where kses permits arbitrary `data-*` attributes, and any author could
+ * otherwise point the fetch wherever they liked.
+ *
+ * Sites with a context-aware suggestion API -- the plugin directory returns a
+ * per-plugin notice -- filter in their own URL. Anything that is not an HTTPS
+ * wordpress.org URL falls back to the network-wide default.
+ *
+ * @return string The endpoint URL.
+ */
+function get_endpoint() {
+	$default = 'https://wordpress.org/lang-guess/lang-guess-ajax.php';
+
+	/**
+	 * Filters the language suggestion endpoint for the current site.
+	 *
+	 * @param string $endpoint Endpoint URL. Must be an HTTPS wordpress.org URL.
+	 */
+	$endpoint = apply_filters( 'wporg_language_suggest_endpoint', $default );
+	$host     = wp_parse_url( $endpoint, PHP_URL_HOST );
+
+	// A backslash is a path separator to the browser, so it and PHP can disagree on the host.
+	if ( str_contains( $endpoint, '\\' ) ) {
+		return $default;
+	}
+
+	if ( 'https' !== wp_parse_url( $endpoint, PHP_URL_SCHEME ) || ! $host ) {
+		return $default;
+	}
+
+	if ( 'wordpress.org' !== $host && ! str_ends_with( $host, '.wordpress.org' ) ) {
+		return $default;
+	}
+
+	return $endpoint;
+}
+
+/**
  * Inject the locale data for use in viewScript.
  */
 function add_locale_data() {
+	$data = array(
+		'locale'   => get_locale(),
+		'endpoint' => get_endpoint(),
+	);
+
 	wp_add_inline_script(
 		'wporg-language-suggest-view-script',
-		'var languageSuggestData = ' . wp_json_encode( array( 'locale' => get_locale() ) ) . ';',
+		'var languageSuggestData = ' . wp_json_encode( $data ) . ';',
 		'before'
 	);
 }

--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -31,14 +31,8 @@ add_action( 'init', __NAMESPACE__ . '\language_suggest_block_init' );
 /**
  * Returns the endpoint the front-end script should request.
  *
- * The response is rendered into the block, so the endpoint is resolved here
- * rather than read back out of the DOM: block markup lives in `post_content`,
- * where kses permits arbitrary `data-*` attributes, and any author could
- * otherwise point the fetch wherever they liked.
- *
- * Sites with a context-aware suggestion API -- the plugin directory returns a
- * per-plugin notice -- filter in their own URL. Anything that is not an HTTPS
- * wordpress.org URL falls back to the network-wide default.
+ * Sites with a context-aware suggestion API filter in their own URL. Anything
+ * that is not an HTTPS wordpress.org URL falls back to the network-wide default.
  *
  * @return string The endpoint URL.
  */

--- a/mu-plugins/blocks/language-suggest/language-suggest.php
+++ b/mu-plugins/blocks/language-suggest/language-suggest.php
@@ -51,14 +51,18 @@ function get_endpoint() {
 	 * @param string $endpoint Endpoint URL. Must be an HTTPS wordpress.org URL.
 	 */
 	$endpoint = apply_filters( 'wporg_language_suggest_endpoint', $default );
-	$host     = wp_parse_url( $endpoint, PHP_URL_HOST );
+	$parts    = wp_parse_url( $endpoint );
 
 	// A backslash is a path separator to the browser, so it and PHP can disagree on the host.
 	if ( str_contains( $endpoint, '\\' ) ) {
 		return $default;
 	}
 
-	if ( 'https' !== wp_parse_url( $endpoint, PHP_URL_SCHEME ) || ! $host ) {
+	// Schemes and hosts are case-insensitive, so compare them in one case.
+	$scheme = strtolower( $parts['scheme'] ?? '' );
+	$host   = strtolower( $parts['host'] ?? '' );
+
+	if ( 'https' !== $scheme || ! $host ) {
 		return $default;
 	}
 

--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -74,11 +74,9 @@ const copyAllowed = ( source, target ) => {
 			return;
 		}
 
-		// An anchor is only kept when it carries a usable https link.
 		const href = 'A' === node.tagName ? getSafeHref( node.getAttribute( 'href' ) ) : null;
 		const keep = ALLOWED_TAGS.includes( node.tagName ) && ( 'A' !== node.tagName || href );
 
-		// Anything not kept contributes its text, so a suggestion still reads as a sentence.
 		if ( ! keep ) {
 			copyAllowed( node, target );
 			return;

--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -12,9 +12,43 @@ const ALLOWED_TAGS = [ 'P', 'DIV', 'A' ];
  * Elements whose contents are source text rather than prose.
  *
  * These are dropped whole. Recursing into them would paste the script or style
- * body into the page as visible text.
+ * body into the page as visible text. Compared in lower case because foreign
+ * content keeps the authored casing, so `<svg><script>` is not `SCRIPT`.
  */
-const SKIPPED_TAGS = [ 'SCRIPT', 'STYLE', 'TEMPLATE', 'NOSCRIPT', 'TITLE', 'TEXTAREA' ];
+const SKIPPED_TAGS = [
+	'script',
+	'style',
+	'template',
+	'noscript',
+	'title',
+	'textarea',
+	'iframe',
+	'xmp',
+	'plaintext',
+	'noembed',
+	'noframes',
+];
+
+/**
+ * Returns a link target only when it is safe to render as an href.
+ *
+ * @param {string|null} value The parsed anchor's href attribute.
+ *
+ * @return {string|null} The resolved url, or null to drop the anchor.
+ */
+const getSafeHref = ( value ) => {
+	if ( ! value ) {
+		return null;
+	}
+
+	try {
+		const url = new URL( value, window.location.href );
+
+		return 'https:' === url.protocol ? url.toString() : null;
+	} catch ( error ) {
+		return null;
+	}
+};
 
 /**
  * Copies the allowed parts of a parsed node into a node being built.
@@ -36,36 +70,24 @@ const copyAllowed = ( source, target ) => {
 			return;
 		}
 
-		if ( SKIPPED_TAGS.includes( node.tagName ) ) {
+		if ( SKIPPED_TAGS.includes( node.tagName.toLowerCase() ) ) {
 			return;
 		}
 
-		if ( ! ALLOWED_TAGS.includes( node.tagName ) ) {
+		// An anchor is only kept when it carries a usable https link.
+		const href = 'A' === node.tagName ? getSafeHref( node.getAttribute( 'href' ) ) : null;
+		const keep = ALLOWED_TAGS.includes( node.tagName ) && ( 'A' !== node.tagName || href );
+
+		// Anything not kept contributes its text, so a suggestion still reads as a sentence.
+		if ( ! keep ) {
 			copyAllowed( node, target );
 			return;
 		}
 
 		const element = document.createElement( node.tagName );
 
-		if ( 'A' === node.tagName ) {
-			const value = node.getAttribute( 'href' );
-			let href = null;
-
-			if ( value ) {
-				try {
-					href = new URL( value, window.location.href );
-				} catch ( error ) {
-					href = null;
-				}
-			}
-
-			// An anchor without a usable https link contributes its text only.
-			if ( ! href || 'https:' !== href.protocol ) {
-				copyAllowed( node, target );
-				return;
-			}
-
-			element.setAttribute( 'href', href.toString() );
+		if ( href ) {
+			element.setAttribute( 'href', href );
 		}
 
 		// The legacy network endpoint wraps its notice in a separately styled ID.

--- a/mu-plugins/blocks/language-suggest/src/front.js
+++ b/mu-plugins/blocks/language-suggest/src/front.js
@@ -1,4 +1,98 @@
-/* global languageSuggestData */
+/* global languageSuggestData, Node, DOMParser */
+
+/**
+ * Elements the suggestion endpoints are allowed to return.
+ *
+ * The responses are a single wrapper holding text and language links, so the
+ * wrapper has to survive: the block's padding comes from a `> *` child selector.
+ */
+const ALLOWED_TAGS = [ 'P', 'DIV', 'A' ];
+
+/**
+ * Elements whose contents are source text rather than prose.
+ *
+ * These are dropped whole. Recursing into them would paste the script or style
+ * body into the page as visible text.
+ */
+const SKIPPED_TAGS = [ 'SCRIPT', 'STYLE', 'TEMPLATE', 'NOSCRIPT', 'TITLE', 'TEXTAREA' ];
+
+/**
+ * Copies the allowed parts of a parsed node into a node being built.
+ *
+ * Text is kept verbatim. Disallowed elements are dropped but their text is
+ * kept, so a suggestion still reads as a sentence if one link is rejected.
+ *
+ * @param {Node} source Parsed node to read from.
+ * @param {Node} target Node to append the sanitized copy to.
+ */
+const copyAllowed = ( source, target ) => {
+	source.childNodes.forEach( ( node ) => {
+		if ( Node.TEXT_NODE === node.nodeType ) {
+			target.appendChild( document.createTextNode( node.nodeValue ) );
+			return;
+		}
+
+		if ( Node.ELEMENT_NODE !== node.nodeType ) {
+			return;
+		}
+
+		if ( SKIPPED_TAGS.includes( node.tagName ) ) {
+			return;
+		}
+
+		if ( ! ALLOWED_TAGS.includes( node.tagName ) ) {
+			copyAllowed( node, target );
+			return;
+		}
+
+		const element = document.createElement( node.tagName );
+
+		if ( 'A' === node.tagName ) {
+			const value = node.getAttribute( 'href' );
+			let href = null;
+
+			if ( value ) {
+				try {
+					href = new URL( value, window.location.href );
+				} catch ( error ) {
+					href = null;
+				}
+			}
+
+			// An anchor without a usable https link contributes its text only.
+			if ( ! href || 'https:' !== href.protocol ) {
+				copyAllowed( node, target );
+				return;
+			}
+
+			element.setAttribute( 'href', href.toString() );
+		}
+
+		// The legacy network endpoint wraps its notice in a separately styled ID.
+		if ( 'lang-guess' === node.getAttribute( 'id' ) ) {
+			element.setAttribute( 'id', 'lang-guess' );
+		}
+
+		copyAllowed( node, element );
+		target.appendChild( element );
+	} );
+};
+
+/**
+ * Rebuilds a suggestion response out of nodes this block is willing to render.
+ *
+ * @param {string} html Response body.
+ *
+ * @return {DocumentFragment} The sanitized markup.
+ */
+const sanitize = ( html ) => {
+	const parsed = new DOMParser().parseFromString( html, 'text/html' );
+	const fragment = document.createDocumentFragment();
+
+	copyAllowed( parsed.body, fragment );
+
+	return fragment;
+};
 
 const init = () => {
 	const container = document.querySelector( '.wp-block-wporg-language-suggest' );
@@ -7,8 +101,10 @@ const init = () => {
 		return;
 	}
 
-	// Fixed first-party URL only: the response lands in innerHTML, so it must come from a trusted endpoint.
-	const endpoint = new URL( 'https://wordpress.org/lang-guess/lang-guess-ajax.php' );
+	// Resolved server-side, never from the DOM; the literal only covers pages cached before that existed.
+	const endpoint = new URL(
+		languageSuggestData.endpoint || 'https://wordpress.org/lang-guess/lang-guess-ajax.php'
+	);
 	endpoint.searchParams.set( 'uri', window.location.pathname );
 	endpoint.searchParams.set( 'locale', languageSuggestData.locale );
 
@@ -20,7 +116,9 @@ const init = () => {
 
 			return response.text();
 		} )
-		.then( ( body ) => ( container.innerHTML = body ) )
+		.then( ( body ) => {
+			container.replaceChildren( sanitize( body ) );
+		} )
 		.catch( () => {} );
 };
 


### PR DESCRIPTION
Sites with a context-aware suggestion API can supply their endpoint through a new `wporg_language_suggest_endpoint` filter, which is passed to the view script alongside the locale. Previously the front end read it from a `data-endpoint` attribute on the block container, so the value had to travel through block markup.

### Why

The plugin and theme directories both return a notice naming the plugin or theme being viewed. On trunk they set `data-endpoint`, which #763 stopped reading, so both currently fall back to the network-wide suggestion:

| | Now | With this change |
|---|---|---|
| `/plugins/activitypub/` | WordPress ist auch auf Deutsch verfügbar. | Dieses Plugin ist auch auf Deutsch verfügbar. Hilf mit, die Übersetzung zu verbessern! |
| `/themes/twentytwentyfour/` | WordPress ist auch auf Deutsch verfügbar. | Dieses Theme ist auch auf Deutsch verfügbar. Hilf mit, die Übersetzung zu verbessern. |

### Changes

- `get_endpoint()` resolves the URL in PHP and validates it to an HTTPS wordpress.org host, falling back to the network-wide default otherwise.
- The resolved value rides along in the existing `languageSuggestData` inline script, so no new request or handle.
- The response is built into the block as text and links rather than assigned as markup — the block is now explicit about the small set of elements these endpoints return.

### Needs to land together with

- `WordPress/wordpress.org` — plugin directory moves from `data-endpoint` to the filter
- `WordPress/wporg-theme-directory` — theme directory does the same

Merging this alone leaves both directories on the generic notice, which is where they already are, so there is no regression in either order.

### Testing

- Both directory endpoints and the network default render identically to before, across single-language, multi-language, and untranslated responses, in `<p>` and `<div id="lang-guess">` wrappers.
- Endpoint resolution verified against the real plugin and theme URLs plus non-wordpress.org, plain HTTP, relative, and empty values.
- `npm run lint:js` and `php -l` clean; block builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)