### PR TITLE
Google Map: reuse the shared href helper for the marker list

### DIFF
--- a/mu-plugins/blocks/google-map/src/components/list.js
+++ b/mu-plugins/blocks/google-map/src/components/list.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getEventDateTime } from '../utilities/date-time';
-import { formatLocation } from '../utilities/content';
+import { formatLocation, getSafeHref } from '../utilities/content';
 
 /**
  * Render a list of the map markers.
@@ -34,7 +34,7 @@ export default function List( { markers, displayLimit } ) {
 					className="wporg-marker-list-item"
 				>
 					<h3 className="wporg-marker-list-item__title">
-						<a href={ marker.url }>{ marker.title }</a>
+						<a href={ getSafeHref( marker.url ) }>{ marker.title }</a>
 					</h3>
 
 					<p className="wporg-marker-list-item__location">{ formatLocation( marker.location ) }</p>

--- a/mu-plugins/blocks/google-map/src/components/marker-content.js
+++ b/mu-plugins/blocks/google-map/src/components/marker-content.js
@@ -2,28 +2,7 @@
  * Internal dependencies
  */
 import { getEventDateTime } from '../utilities/date-time';
-import { formatLocation } from '../utilities/content';
-
-/**
- * Returns a marker link only when its protocol is safe to render as an href.
- *
- * @param {string} url Candidate link target, which comes from the block's attributes.
- *
- * @return {string|undefined} The url, or undefined to render no href.
- */
-const getSafeHref = ( url ) => {
-	if ( ! url ) {
-		return undefined;
-	}
-
-	try {
-		const { protocol } = new URL( url, window.location.href );
-
-		return 'https:' === protocol || 'http:' === protocol ? url : undefined;
-	} catch ( error ) {
-		return undefined;
-	}
-};
+import { formatLocation, getSafeHref } from '../utilities/content';
 
 /**
  * Render the content for a map marker.

--- a/mu-plugins/blocks/google-map/src/utilities/content.js
+++ b/mu-plugins/blocks/google-map/src/utilities/content.js
@@ -26,6 +26,27 @@ export function formatLocation( location ) {
 }
 
 /**
+ * Returns a marker link only when its protocol is safe to render as an href.
+ *
+ * @param {string} url Candidate link target, which comes from the block's attributes.
+ *
+ * @return {string|undefined} The url, or undefined to render no href.
+ */
+export function getSafeHref( url ) {
+	if ( ! url ) {
+		return undefined;
+	}
+
+	try {
+		const { protocol } = new URL( url, window.location.href );
+
+		return 'https:' === protocol || 'http:' === protocol ? url : undefined;
+	} catch ( error ) {
+		return undefined;
+	}
+}
+
+/**
  * Filter the list of markers based on a user's search query.
  *
  * @param {Array}  unfilteredMarkers


### PR DESCRIPTION
The marker info windows resolve their link targets through a small `getSafeHref` helper (added in #765), but the marker list built its anchors directly. This moves the helper into the block's shared `content.js` util and points both the list and the info-window views at it, so every marker link renders the same way and the helper lives in one place rather than being duplicated per component.

No behavior change for the info windows; the marker list now goes through the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)