### PR TITLE
Modal: keep element references out of the reactive context

### DIFF
--- a/mu-plugins/blocks/modal/render.php
+++ b/mu-plugins/blocks/modal/render.php
@@ -67,7 +67,9 @@ $html_id = wp_unique_id( 'modal-' );
 		<div
 			class="wporg-modal__modal"
 			id="<?php echo esc_attr( $html_id ); ?>"
+			tabindex="-1"
 			data-wp-bind--hidden="!context.isOpen"
+			data-wp-watch="callbacks.focusModal"
 		>
 			<button
 				class="wporg-modal__modal-close"

--- a/mu-plugins/blocks/modal/render.php
+++ b/mu-plugins/blocks/modal/render.php
@@ -33,7 +33,6 @@ $html_id = wp_unique_id( 'modal-' );
 <div
 	<?php echo get_block_wrapper_attributes( [ 'style' => $style ]); // phpcs:ignore ?>
 	data-wp-interactive="wporg/modal"
-	data-wp-watch="callbacks.init"
 	data-wp-on--keydown="actions.handleKeydown"
 	data-wp-class--is-modal-open="context.isOpen"
 	<?php echo wp_interactivity_data_wp_context( $init_state ); // phpcs:ignore ?>

--- a/mu-plugins/blocks/modal/render.php
+++ b/mu-plugins/blocks/modal/render.php
@@ -67,6 +67,9 @@ $html_id = wp_unique_id( 'modal-' );
 		<div
 			class="wporg-modal__modal"
 			id="<?php echo esc_attr( $html_id ); ?>"
+			role="dialog"
+			aria-modal="true"
+			aria-label="<?php echo esc_attr( wp_strip_all_tags( $attributes['label'] ) ); ?>"
 			tabindex="-1"
 			data-wp-bind--hidden="!context.isOpen"
 			data-wp-watch="callbacks.focusModal"

--- a/mu-plugins/blocks/modal/src/view.js
+++ b/mu-plugins/blocks/modal/src/view.js
@@ -25,7 +25,7 @@ const focusableSelectors = [
  *
  * @return {HTMLElement|null} The root element, or null when it can't be resolved.
  */
-const getRoot = () => getElement().ref?.closest( '.wp-block-wporg-modal' ) ?? null;
+const getRoot = () => getElement().ref?.closest( '[data-wp-interactive="wporg/modal"]' ) ?? null;
 
 const { actions } = store( 'wporg/modal', {
 	actions: {
@@ -53,7 +53,6 @@ const { actions } = store( 'wporg/modal', {
 		open: () => {
 			const context = getContext();
 			context.isOpen = true;
-			getRoot()?.querySelector( '.wporg-modal__modal' )?.focus();
 		},
 
 		close: () => {
@@ -93,6 +92,19 @@ const { actions } = store( 'wporg/modal', {
 					event.preventDefault();
 					firstFocusableElement.focus();
 				}
+			}
+		},
+	},
+
+	callbacks: {
+		/**
+		 * Runs after the render that unhides the modal; focusing in `open()` would
+		 * target a still-hidden element and no-op.
+		 */
+		focusModal: () => {
+			const context = getContext();
+			if ( context.isOpen ) {
+				getElement().ref?.focus();
 			}
 		},
 	},

--- a/mu-plugins/blocks/modal/src/view.js
+++ b/mu-plugins/blocks/modal/src/view.js
@@ -84,8 +84,12 @@ const { actions } = store( 'wporg/modal', {
 				const firstFocusableElement = focusableElements[ 0 ];
 				const lastFocusableElement = focusableElements[ focusableElements.length - 1 ];
 
-				// If shift + tab it change the direction.
-				if ( event.shiftKey && window.document.activeElement === firstFocusableElement ) {
+				// The container itself holds focus right after opening; treat it as a boundary too.
+				if (
+					event.shiftKey &&
+					( window.document.activeElement === firstFocusableElement ||
+						window.document.activeElement === modal )
+				) {
 					event.preventDefault();
 					lastFocusableElement.focus();
 				} else if ( ! event.shiftKey && window.document.activeElement === lastFocusableElement ) {

--- a/mu-plugins/blocks/modal/src/view.js
+++ b/mu-plugins/blocks/modal/src/view.js
@@ -61,7 +61,13 @@ const { actions } = store( 'wporg/modal', {
 			getRoot()?.querySelector( '.wporg-modal__toggle' )?.focus();
 		},
 
-		// Wrapped in `withSyncEvent` because the focus trap calls `event.preventDefault()` synchronously.
+		/**
+		 * Handle modal keydown: Escape closes it, Tab traps focus within the dialog.
+		 *
+		 * Wrapped in `withSyncEvent` because the focus trap calls `event.preventDefault()` synchronously.
+		 *
+		 * @param {KeyboardEvent} event
+		 */
 		handleKeydown: withSyncEvent( ( event ) => {
 			const context = getContext();
 			// Only handle key events if the dropdown is open.

--- a/mu-plugins/blocks/modal/src/view.js
+++ b/mu-plugins/blocks/modal/src/view.js
@@ -15,9 +15,9 @@ const focusableSelectors = [
 ];
 
 /*
- * Elements are queried at action time rather than cached: context is a public namespace other
- * markup can read by path (`wporg/modal::context.…`), so element references must not live in it,
- * and the modal content is arbitrary inner blocks that can change while the modal is open.
+ * Context is a public namespace, readable from other markup as `wporg/modal::context.…`, so only
+ * the serializable `isOpen` flag lives there. Focus-trap boundaries are computed per keydown
+ * because the modal content is arbitrary inner blocks that can change while the modal is open.
  */
 
 /**

--- a/mu-plugins/blocks/modal/src/view.js
+++ b/mu-plugins/blocks/modal/src/view.js
@@ -14,6 +14,21 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
+/**
+ * Per-modal element references, keyed by each modal's interactive root.
+ *
+ * Kept here rather than in the store context: context is a public namespace other markup can read by
+ * path (`wporg/modal::context.…`), so element references must not live in it.
+ */
+const modalRefs = new WeakMap();
+
+/**
+ * The interactive modal root for whichever element triggered the current action.
+ *
+ * @return {HTMLElement|null} The root element, or null when it can't be resolved.
+ */
+const getRoot = () => getElement().ref?.closest( '[data-wp-interactive="wporg/modal"]' ) ?? null;
+
 const { actions } = store( 'wporg/modal', {
 	actions: {
 		toggle: () => {
@@ -40,13 +55,13 @@ const { actions } = store( 'wporg/modal', {
 		open: () => {
 			const context = getContext();
 			context.isOpen = true;
-			context.modal.focus();
+			modalRefs.get( getRoot() )?.modal?.focus();
 		},
 
 		close: () => {
 			const context = getContext();
 			context.isOpen = false;
-			context.toggleButton.focus();
+			modalRefs.get( getRoot() )?.toggleButton?.focus();
 		},
 
 		handleKeydown: ( event ) => {
@@ -64,13 +79,18 @@ const { actions } = store( 'wporg/modal', {
 
 			// Trap focus.
 			if ( event.key === 'Tab' ) {
+				const refs = modalRefs.get( getRoot() );
+				if ( ! refs ) {
+					return;
+				}
+
 				// If shift + tab it change the direction.
-				if ( event.shiftKey && window.document.activeElement === context.firstFocusableElement ) {
+				if ( event.shiftKey && window.document.activeElement === refs.firstFocusableElement ) {
 					event.preventDefault();
-					context.lastFocusableElement.focus();
-				} else if ( ! event.shiftKey && window.document.activeElement === context.lastFocusableElement ) {
+					refs.lastFocusableElement.focus();
+				} else if ( ! event.shiftKey && window.document.activeElement === refs.lastFocusableElement ) {
 					event.preventDefault();
-					context.firstFocusableElement.focus();
+					refs.firstFocusableElement.focus();
 				}
 			}
 		},
@@ -80,14 +100,20 @@ const { actions } = store( 'wporg/modal', {
 		init: () => {
 			const context = getContext();
 			const { ref } = getElement();
-			context.toggleButton = ref.querySelector( '.wporg-modal__toggle' );
-			context.modal = ref.querySelector( '.wporg-modal__modal' );
+			const refs = {
+				toggleButton: ref.querySelector( '.wporg-modal__toggle' ),
+				modal: ref.querySelector( '.wporg-modal__modal' ),
+				firstFocusableElement: null,
+				lastFocusableElement: null,
+			};
 
 			if ( context.isOpen ) {
-				const focusableElements = context.modal.querySelectorAll( focusableSelectors );
-				context.firstFocusableElement = focusableElements[ 0 ];
-				context.lastFocusableElement = focusableElements[ focusableElements.length - 1 ];
+				const focusableElements = refs.modal.querySelectorAll( focusableSelectors );
+				refs.firstFocusableElement = focusableElements[ 0 ];
+				refs.lastFocusableElement = focusableElements[ focusableElements.length - 1 ];
 			}
+
+			modalRefs.set( ref, refs );
 		},
 	},
 } );

--- a/mu-plugins/blocks/modal/src/view.js
+++ b/mu-plugins/blocks/modal/src/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { getContext, getElement, store } from '@wordpress/interactivity';
+import { getContext, getElement, store, withSyncEvent } from '@wordpress/interactivity';
 
 // See https://github.com/WordPress/gutenberg/blob/37f52ae884a40f7cb77ac2484648b4e4ad973b59/packages/block-library/src/navigation/view-interactivity.js
 const focusableSelectors = [
@@ -61,7 +61,8 @@ const { actions } = store( 'wporg/modal', {
 			getRoot()?.querySelector( '.wporg-modal__toggle' )?.focus();
 		},
 
-		handleKeydown: ( event ) => {
+		// Wrapped in `withSyncEvent` because the focus trap calls `event.preventDefault()` synchronously.
+		handleKeydown: withSyncEvent( ( event ) => {
 			const context = getContext();
 			// Only handle key events if the dropdown is open.
 			if ( ! context.isOpen ) {
@@ -97,7 +98,7 @@ const { actions } = store( 'wporg/modal', {
 					firstFocusableElement.focus();
 				}
 			}
-		},
+		} ),
 	},
 
 	callbacks: {

--- a/mu-plugins/blocks/modal/src/view.js
+++ b/mu-plugins/blocks/modal/src/view.js
@@ -14,20 +14,18 @@ const focusableSelectors = [
 	'[tabindex]:not([tabindex^="-"])',
 ];
 
-/**
- * Per-modal element references, keyed by each modal's interactive root.
- *
- * Kept here rather than in the store context: context is a public namespace other markup can read by
- * path (`wporg/modal::context.…`), so element references must not live in it.
+/*
+ * Elements are queried at action time rather than cached: context is a public namespace other
+ * markup can read by path (`wporg/modal::context.…`), so element references must not live in it,
+ * and the modal content is arbitrary inner blocks that can change while the modal is open.
  */
-const modalRefs = new WeakMap();
 
 /**
- * The interactive modal root for whichever element triggered the current action.
+ * The block wrapper for whichever element triggered the current action.
  *
  * @return {HTMLElement|null} The root element, or null when it can't be resolved.
  */
-const getRoot = () => getElement().ref?.closest( '[data-wp-interactive="wporg/modal"]' ) ?? null;
+const getRoot = () => getElement().ref?.closest( '.wp-block-wporg-modal' ) ?? null;
 
 const { actions } = store( 'wporg/modal', {
 	actions: {
@@ -55,13 +53,13 @@ const { actions } = store( 'wporg/modal', {
 		open: () => {
 			const context = getContext();
 			context.isOpen = true;
-			modalRefs.get( getRoot() )?.modal?.focus();
+			getRoot()?.querySelector( '.wporg-modal__modal' )?.focus();
 		},
 
 		close: () => {
 			const context = getContext();
 			context.isOpen = false;
-			modalRefs.get( getRoot() )?.toggleButton?.focus();
+			getRoot()?.querySelector( '.wporg-modal__toggle' )?.focus();
 		},
 
 		handleKeydown: ( event ) => {
@@ -79,41 +77,23 @@ const { actions } = store( 'wporg/modal', {
 
 			// Trap focus.
 			if ( event.key === 'Tab' ) {
-				const refs = modalRefs.get( getRoot() );
-				if ( ! refs ) {
+				const modal = getRoot()?.querySelector( '.wporg-modal__modal' );
+				const focusableElements = modal ? modal.querySelectorAll( focusableSelectors ) : [];
+				if ( ! focusableElements.length ) {
 					return;
 				}
+				const firstFocusableElement = focusableElements[ 0 ];
+				const lastFocusableElement = focusableElements[ focusableElements.length - 1 ];
 
 				// If shift + tab it change the direction.
-				if ( event.shiftKey && window.document.activeElement === refs.firstFocusableElement ) {
+				if ( event.shiftKey && window.document.activeElement === firstFocusableElement ) {
 					event.preventDefault();
-					refs.lastFocusableElement.focus();
-				} else if ( ! event.shiftKey && window.document.activeElement === refs.lastFocusableElement ) {
+					lastFocusableElement.focus();
+				} else if ( ! event.shiftKey && window.document.activeElement === lastFocusableElement ) {
 					event.preventDefault();
-					refs.firstFocusableElement.focus();
+					firstFocusableElement.focus();
 				}
 			}
-		},
-	},
-
-	callbacks: {
-		init: () => {
-			const context = getContext();
-			const { ref } = getElement();
-			const refs = {
-				toggleButton: ref.querySelector( '.wporg-modal__toggle' ),
-				modal: ref.querySelector( '.wporg-modal__modal' ),
-				firstFocusableElement: null,
-				lastFocusableElement: null,
-			};
-
-			if ( context.isOpen ) {
-				const focusableElements = refs.modal.querySelectorAll( focusableSelectors );
-				refs.firstFocusableElement = focusableElements[ 0 ];
-				refs.lastFocusableElement = focusableElements[ focusableElements.length - 1 ];
-			}
-
-			modalRefs.set( ref, refs );
 		},
 	},
 } );


### PR DESCRIPTION
## What

Reworks the modal's Interactivity view module so it no longer keeps DOM state on the public store context, and tidies up the focus handling while there.

Previously the view module cached DOM references — the toggle button, the modal element, and the focus-trap boundary elements — on the Interactivity **context**:

```js
context.toggleButton = ref.querySelector( '.wporg-modal__toggle' );
context.modal = ref.querySelector( '.wporg-modal__modal' );
```

Context is a public, per-namespace surface: other markup on the page can read it by path (e.g. `data-wp-bind--src="wporg/modal::context.toggleButton.href"` on a neighbouring element). Storing live elements there exposes them — and any URL they carry — beyond the block.

## Changes

- **Keep only `isOpen` on the context.** DOM references are no longer stored there. The block wrapper is resolved at action time via `getElement().ref.closest( '[data-wp-interactive="wporg/modal"]' )`, and focus-trap boundaries are computed per keydown (the modal content is arbitrary inner blocks that can change while it's open).
- **Focus the dialog only after it's unhidden.** `open()` used to call `context.modal.focus()` synchronously, before the render that removes `hidden` — so it targeted a still-hidden element and no-op'd. A `callbacks.focusModal` watch on the modal element now moves focus in once it's visible.
- **Dialog semantics.** The modal element gets `role="dialog"`, `aria-modal="true"`, an `aria-label` (from the block label), and `tabindex="-1"` so it can hold focus.
- **Shift+Tab boundary.** Since focus lands on the dialog container right after opening, a backward Tab from it would otherwise escape the modal; the trap now treats the container as a boundary and wraps to the last focusable.
- **`withSyncEvent`.** The focus trap calls `event.preventDefault()` synchronously, which the Interactivity API now requires an action to opt into; `handleKeydown` is wrapped accordingly (this also clears a runtime deprecation warning slated to break in WP 7.0).

## Verified

Driven in a live browser against a rendered modal (WordPress trunk):

- Open → modal shows, focus moves into the dialog; no focus steal on page load.
- Focus trap: Tab from the last focusable wraps to the first; Shift+Tab from the first (and from the dialog container) wraps to the last; focus stays inside.
- Escape and backdrop click both close and return focus to the toggle.
- Only `isOpen` is present on the context (confirmed against the built bundle), so `wporg/modal::context.…` exposes no element or URL.
- No console errors or deprecation warnings; `lint:js` and the block build are clean.

## Notes

`src/view.js` and `render.php` only; `build/` is gitignored and produced by the deploy build.