### PR TITLE
Meetup OAuth: take the authorization code from the caller

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,7 +8,7 @@
 			"config": {
 				"WP_ENVIRONMENT_TYPE": false
 			},
-			"phpVersion": "7.4",
+			"phpVersion": "8.2",
 			"mappings": {
 				"vendor": "./vendor",
 				"phpunit": "./phpunit",

--- a/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -207,9 +207,13 @@ class Meetup_OAuth2_Client extends API_Client {
 	 *
 	 * This stores a successfully retrieved token array to the database for repeated use, until it expires.
 	 *
+	 * @param string $auth_code Optional. An authorization code that the caller has already established
+	 *                          belongs to an authorization it started itself. Default empty, which falls
+	 *                          back to the code stored in the site option.
+	 *
 	 * @return string
 	 */
-	public function get_oauth_token() {
+	public function get_oauth_token( $auth_code = '' ) {
 		if ( $this->oauth_token && ! $this->is_expired_token( $this->oauth_token ) ) {
 			return $this->oauth_token['access_token'];
 		}
@@ -226,15 +230,13 @@ class Meetup_OAuth2_Client extends API_Client {
 
 		// If it's not a valid token, or the refresh token wasn't valid, check to see if we're able to fetch a new one.
 		if ( ! $valid ) {
-			$auth_code = get_site_option( self::SITE_OPTION_KEY_AUTHORIZATION, false );
-
-			// The token is stored network-wide, so binding it is a network administrator's call.
-			if ( isset( $_GET['code'], $_GET['state'] )
-				&& 'meetup-oauth' === $_GET['state']
-				&& is_admin()
-				&& current_user_can( 'manage_network_options' )
-			) {
-				$auth_code = sanitize_text_field( wp_unslash( $_GET['code'] ) );
+			/*
+			 * Nothing is read from the request here. An authorization code arrives on a redirect from
+			 * Meetup, which can't carry a nonce, so only a caller that minted and matched a `state` of its
+			 * own is in a position to say the code belongs to an authorization it started.
+			 */
+			if ( ! is_string( $auth_code ) || ! $auth_code ) {
+				$auth_code = get_site_option( self::SITE_OPTION_KEY_AUTHORIZATION, false );
 			}
 
 			if ( $auth_code ) {
@@ -248,15 +250,33 @@ class Meetup_OAuth2_Client extends API_Client {
 
 		// If we're unable to find a valid token, and we're not mid-refresh, throw a Warning & Notice.
 		if ( ! $valid ) {
+			/**
+			 * Filters the URL an operator should visit to start a new Meetup authorization.
+			 *
+			 * The `state` on an authorization request has to be minted and remembered by whoever handles the
+			 * callback, so a host that runs one should point this at the screen that starts its own flow.
+			 * The default carries no `state`, and so is only good for the wp-cli route described below.
+			 *
+			 * @param string $authorize_url
+			 */
+			$authorize_url = apply_filters(
+				'meetup_oauth2_authorize_url',
+				add_query_arg(
+					array(
+						// `add_query_arg()` doesn't encode, so the values are encoded on the way in.
+						'client_id'     => rawurlencode( self::CONSUMER_KEY ),
+						'response_type' => 'code',
+						'redirect_uri'  => rawurlencode( self::REDIRECT_URI ),
+					),
+					self::URL_AUTHORIZE
+				)
+			);
+
 			$message = sprintf(
-				"Meetup.com oAuth expired. Please access the following url while logged into the %s meetup.com account: \n\n%s\n\n" .
+				"Meetup.com oAuth expired. Please start a new authorization at the following url while logged into the %s meetup.com account: \n\n%s\n\n" .
 				"For sites other than WordCamp Central, the ?code=... parameter will need to be stored on this site via wp-cli and this task run again: `wp --url=%s site option update '%s' '...'`",
 				self::EMAIL,
-				sprintf(
-					'https://secure.meetup.com/oauth2/authorize?client_id=%s&response_type=code&redirect_uri=%s&state=meetup-oauth',
-					self::CONSUMER_KEY,
-					self::REDIRECT_URI
-				),
+				$authorize_url,
 				network_site_url('/'),
 				self::SITE_OPTION_KEY_AUTHORIZATION
 			);

--- a/mu-plugins/utilities/class-meetup-oauth2-client.php
+++ b/mu-plugins/utilities/class-meetup-oauth2-client.php
@@ -230,11 +230,6 @@ class Meetup_OAuth2_Client extends API_Client {
 
 		// If it's not a valid token, or the refresh token wasn't valid, check to see if we're able to fetch a new one.
 		if ( ! $valid ) {
-			/*
-			 * Nothing is read from the request here. An authorization code arrives on a redirect from
-			 * Meetup, which can't carry a nonce, so only a caller that minted and matched a `state` of its
-			 * own is in a position to say the code belongs to an authorization it started.
-			 */
 			if ( ! is_string( $auth_code ) || ! $auth_code ) {
 				$auth_code = get_site_option( self::SITE_OPTION_KEY_AUTHORIZATION, false );
 			}
@@ -250,6 +245,16 @@ class Meetup_OAuth2_Client extends API_Client {
 
 		// If we're unable to find a valid token, and we're not mid-refresh, throw a Warning & Notice.
 		if ( ! $valid ) {
+			$authorize_url = add_query_arg(
+				array(
+					// `add_query_arg()` doesn't encode, so the values are encoded on the way in.
+					'client_id'     => rawurlencode( self::CONSUMER_KEY ),
+					'response_type' => 'code',
+					'redirect_uri'  => rawurlencode( self::REDIRECT_URI ),
+				),
+				self::URL_AUTHORIZE
+			);
+
 			/**
 			 * Filters the URL an operator should visit to start a new Meetup authorization.
 			 *
@@ -259,18 +264,7 @@ class Meetup_OAuth2_Client extends API_Client {
 			 *
 			 * @param string $authorize_url
 			 */
-			$authorize_url = apply_filters(
-				'meetup_oauth2_authorize_url',
-				add_query_arg(
-					array(
-						// `add_query_arg()` doesn't encode, so the values are encoded on the way in.
-						'client_id'     => rawurlencode( self::CONSUMER_KEY ),
-						'response_type' => 'code',
-						'redirect_uri'  => rawurlencode( self::REDIRECT_URI ),
-					),
-					self::URL_AUTHORIZE
-				)
-			);
+			$authorize_url = apply_filters( 'meetup_oauth2_authorize_url', $authorize_url );
 
 			$message = sprintf(
 				"Meetup.com oAuth expired. Please start a new authorization at the following url while logged into the %s meetup.com account: \n\n%s\n\n" .

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"setup:tools": "npm install && composer install && TEXTDOMAIN=wporg composer exec update-configs",
 		"update:tools": "composer update && TEXTDOMAIN=wporg composer exec update-configs",
 		"wp-env": "wp-env",
-		"test:php": "wp-env run tests-cli --env-cwd=/var/www/html/ phpunit"
+		"test:php": "wp-env run tests-cli --env-cwd=/var/www/html/ ./vendor/bin/phpunit"
 	},
 	"rtlcssConfig": {},
 	"stylelint": {

--- a/phpunit/test-encryption.php
+++ b/phpunit/test-encryption.php
@@ -5,7 +5,7 @@ use function WordPressdotorg\MU_Plugins\Encryption\{encrypt, decrypt, is_encrypt
 
 class Test_WPORG_Encryption extends WP_UnitTestCase {
 
-	public function wpSetUpBeforeClass() {
+	public static function wpSetUpBeforeClass() {
 		self::_wporg_encryption_keys();
 	}
 

--- a/phpunit/test-encryption.php
+++ b/phpunit/test-encryption.php
@@ -158,8 +158,8 @@ class Test_WPORG_Encryption extends WP_UnitTestCase {
 		try {
 			decrypt( PREFIX . 'TESTSTRINGTESTSTRINGTESTSTRINGTESTSTRINGTESTSTRINGTESTSTRING', $context );
 		} catch( Exception $e ) {
-			// This is thrown by sodium_hex2bin().
-			$this->assertEquals( 'invalid hex string', $e->getMessage() );
+			// This is thrown by sodium_hex2bin(), whose wording varies by PHP version.
+			$this->assertStringContainsStringIgnoringCase( 'hex', $e->getMessage() );
 		} finally {
 			$this->assertNotEmpty( $e, 'No Exception thrown?' );
 			unset( $e );

--- a/phpunit/test-meetup-oauth2-client.php
+++ b/phpunit/test-meetup-oauth2-client.php
@@ -1,0 +1,185 @@
+<?php
+
+use WordPressdotorg\MU_Plugins\Utilities\Meetup_OAuth2_Client;
+
+/*
+ * The client reads these at class-load time and nothing else in this repo defines them. The values only need
+ * to be non-empty -- no request in this file leaves the process.
+ */
+foreach ( array(
+	'MEETUP_OAUTH_CONSUMER_KEY'          => 'test-consumer-key',
+	'MEETUP_OAUTH_CONSUMER_SECRET'       => 'test-consumer-secret',
+	'MEETUP_OAUTH_CONSUMER_REDIRECT_URI' => 'https://meetup-client.test/wp-admin/',
+	'MEETUP_USER_EMAIL'                  => 'meetup-client@example.org',
+	'MEETUP_USER_PASSWORD'               => 'test-password',
+) as $meetup_constant => $meetup_value ) {
+	defined( $meetup_constant ) || define( $meetup_constant, $meetup_value );
+}
+
+// `utilities/` isn't loaded by the mu-plugin loader, since it isn't used globally.
+require_once dirname( __DIR__ ) . '/mu-plugins/utilities/class-api-client.php';
+require_once dirname( __DIR__ ) . '/mu-plugins/utilities/class-meetup-oauth2-client.php';
+
+/**
+ * Tests for where `Meetup_OAuth2_Client` takes an authorization code from.
+ *
+ * @group meetup
+ */
+class Test_Meetup_OAuth2_Client extends WP_UnitTestCase {
+	/**
+	 * The `code` on each token request the client tried to send.
+	 *
+	 * @var array
+	 */
+	protected $requested_codes = array();
+
+	/**
+	 * Intercept token requests instead of letting them reach Meetup.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->requested_codes = array();
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_token_request' ), 10, 3 );
+	}
+
+	/**
+	 * Clear everything the client reads or writes between tests.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', array( $this, 'intercept_token_request' ), 10 );
+
+		$_GET = array();
+
+		delete_site_option( 'meetup_oauth_authorization' );
+		delete_site_option( 'meetup_access_token' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Record the code a token request carried, and hand back a usable token.
+	 *
+	 * @param false|array|WP_Error $preempt
+	 * @param array                $args
+	 * @param string               $url
+	 *
+	 * @return false|array|WP_Error
+	 */
+	public function intercept_token_request( $preempt, $args, $url ) {
+		if ( false === strpos( $url, 'secure.meetup.com' ) ) {
+			return $preempt;
+		}
+
+		$this->requested_codes[] = isset( $args['body']['code'] ) ? $args['body']['code'] : null;
+
+		return array(
+			'headers'  => array(),
+			'cookies'  => array(),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => wp_json_encode( array(
+				'access_token'  => 'ACCESS',
+				'refresh_token' => 'REFRESH',
+				'expires_in'    => HOUR_IN_SECONDS,
+			) ),
+		);
+	}
+
+	/**
+	 * A client with nothing cached, ready for a test to drive `get_oauth_token()` itself.
+	 *
+	 * The constructor pre-caches a token, and raises a warning if it can't get one, so it's given a code to
+	 * spend and then everything it left behind is cleared away.
+	 *
+	 * @return Meetup_OAuth2_Client
+	 */
+	protected function get_reset_client() {
+		update_site_option( 'meetup_oauth_authorization', 'FROM_CONSTRUCTOR' );
+
+		$client = new Meetup_OAuth2_Client();
+
+		$oauth_token = new ReflectionProperty( Meetup_OAuth2_Client::class, 'oauth_token' );
+		$oauth_token->setAccessible( true );
+		$oauth_token->setValue( $client, array() );
+
+		delete_site_option( 'meetup_access_token' );
+		delete_site_option( 'meetup_oauth_authorization' );
+
+		$this->requested_codes = array();
+
+		return $client;
+	}
+
+	/**
+	 * A code in the request is never what gets spent, whatever else is on the request.
+	 *
+	 * @covers Meetup_OAuth2_Client::get_oauth_token
+	 */
+	public function test_authorization_code_is_not_taken_from_the_request() {
+		$client = $this->get_reset_client();
+
+		$_GET = array(
+			'code'  => 'FROM_REQUEST',
+			'state' => 'meetup-oauth',
+		);
+		update_site_option( 'meetup_oauth_authorization', 'FROM_OPTION' );
+
+		$client->get_oauth_token();
+
+		$this->assertSame( array( 'FROM_OPTION' ), $this->requested_codes );
+	}
+
+	/**
+	 * A caller that has vouched for a code can hand it over directly.
+	 *
+	 * @covers Meetup_OAuth2_Client::get_oauth_token
+	 */
+	public function test_authorization_code_is_taken_from_the_caller() {
+		$client = $this->get_reset_client();
+
+		$_GET = array(
+			'code'  => 'FROM_REQUEST',
+			'state' => 'meetup-oauth',
+		);
+
+		$client->get_oauth_token( 'FROM_CALLER' );
+
+		$this->assertSame( array( 'FROM_CALLER' ), $this->requested_codes );
+	}
+
+	/**
+	 * The caller's code wins over one left in the site option by an earlier attempt.
+	 *
+	 * @covers Meetup_OAuth2_Client::get_oauth_token
+	 */
+	public function test_caller_code_takes_precedence_over_the_stored_one() {
+		$client = $this->get_reset_client();
+
+		update_site_option( 'meetup_oauth_authorization', 'FROM_OPTION' );
+
+		$client->get_oauth_token( 'FROM_CALLER' );
+
+		$this->assertSame( array( 'FROM_CALLER' ), $this->requested_codes );
+	}
+
+	/**
+	 * With no code from the caller, the site option is still the fallback it always was.
+	 *
+	 * @covers Meetup_OAuth2_Client::get_oauth_token
+	 */
+	public function test_stored_code_is_still_the_fallback() {
+		$client = $this->get_reset_client();
+
+		update_site_option( 'meetup_oauth_authorization', 'FROM_OPTION' );
+
+		$this->assertSame( 'ACCESS', $client->get_oauth_token() );
+		$this->assertSame( array( 'FROM_OPTION' ), $this->requested_codes );
+
+		// The client clears the option once it has spent what was in it.
+		$this->assertFalse( get_site_option( 'meetup_oauth_authorization', false ) );
+	}
+}

--- a/phpunit/test-meetup-oauth2-client.php
+++ b/phpunit/test-meetup-oauth2-client.php
@@ -16,9 +16,12 @@ foreach ( array(
 	defined( $meetup_constant ) || define( $meetup_constant, $meetup_value );
 }
 
-// `utilities/` isn't loaded by the mu-plugin loader, since it isn't used globally.
-require_once dirname( __DIR__ ) . '/mu-plugins/utilities/class-api-client.php';
-require_once dirname( __DIR__ ) . '/mu-plugins/utilities/class-meetup-oauth2-client.php';
+/*
+ * `utilities/` isn't loaded by the mu-plugin loader, since it isn't used globally. `WPMU_PLUGIN_DIR` rather
+ * than a path relative to this file, because wp-env mounts the two directories in different places.
+ */
+require_once WPMU_PLUGIN_DIR . '/utilities/class-api-client.php';
+require_once WPMU_PLUGIN_DIR . '/utilities/class-meetup-oauth2-client.php';
 
 /**
  * Tests for where `Meetup_OAuth2_Client` takes an authorization code from.


### PR DESCRIPTION
`get_oauth_token()` read `$_GET['code']` itself. It now takes the code as a parameter and reads nothing from the request — an authorization code arrives on a redirect, so the caller that handled that redirect is the one positioned to say it belongs to an authorization it started. The site option fallback is unchanged.

The reconnection notice can't build a usable authorize link for the same reason, so the URL it prints is filterable via `meetup_oauth2_authorize_url` and no longer carries a `state`.

`wcorg-meetup-oauth.php` in WordPress/wordcamp.org is the only consumer of this flow and pairs with this change: WordPress/wordcamp.org#2002. That side queues the code in the site option as well as passing it, which the client reads the same way before and after this change, so the two can land in either order.

Note this also covers `wcpt`'s `update_meetup_data()`, which instantiates `Meetup_Client` during `save_post` and could previously pick a code out of the request on any admin page load.

### Testing

- `php -l` clean.
- `Meetup_Client::get_oauth_token()` and `reset_oauth_token()` both call with no arguments and fall through to the site option exactly as before.
- No test suite covers `mu-plugins/utilities/`, so there's nothing to extend here; the paired PR carries unit tests for the callback side.
