### PR TITLE
Modal: expand shortcodes in the label before escaping

### DIFF
--- a/mu-plugins/blocks/modal/render.php
+++ b/mu-plugins/blocks/modal/render.php
@@ -14,7 +14,8 @@ $style .= get_style_decl_from_attr( $attributes, 'overlayColor' );
 $style .= get_style_decl_from_attr( $attributes, 'closeButtonColor' );
 
 // Expand first, then drop any shortcode the expansion emitted; it would otherwise expand again later.
-$href = strip_shortcodes( do_shortcode( $attributes['href'] ?? '' ) );
+$href  = strip_shortcodes( do_shortcode( $attributes['href'] ?? '' ) );
+$label = strip_shortcodes( do_shortcode( $attributes['label'] ) );
 
 $button_class = 'wp-block-button';
 if ( ! empty( $attributes['buttonStyle'] ) ) {
@@ -47,14 +48,14 @@ $html_id = wp_unique_id( 'modal-' );
 				data-wp-on--click="actions.toggle"
 				data-wp-bind--aria-expanded="context.isOpen"
 				aria-controls="<?php echo esc_attr( $html_id ); ?>"
-			><?php echo wp_kses_post( $attributes['label'] ); ?></a>
+			><?php echo wp_kses_post( $label ); ?></a>
 		<?php else : ?>
 			<button
 				class="wporg-modal__toggle wp-block-button__link"
 				data-wp-on--click="actions.toggle"
 				data-wp-bind--aria-expanded="context.isOpen"
 				aria-controls="<?php echo esc_attr( $html_id ); ?>"
-			><?php echo wp_kses_post( $attributes['label'] ); ?></button>
+			><?php echo wp_kses_post( $label ); ?></button>
 		<?php endif; ?>
 		</div>
 	</div>
@@ -69,7 +70,7 @@ $html_id = wp_unique_id( 'modal-' );
 			id="<?php echo esc_attr( $html_id ); ?>"
 			role="dialog"
 			aria-modal="true"
-			aria-label="<?php echo esc_attr( wp_strip_all_tags( $attributes['label'] ) ); ?>"
+			aria-label="<?php echo esc_attr( wp_strip_all_tags( $label ) ); ?>"
 			tabindex="-1"
 			data-wp-bind--hidden="!context.isOpen"
 			data-wp-watch="callbacks.focusModal"

--- a/phpunit/test-modal.php
+++ b/phpunit/test-modal.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Tests for the Modal block's rendered output.
+ *
+ * @package wporg
+ */
+
+/**
+ * Renders the modal block through `do_blocks()` and checks the markup it produces.
+ */
+class Test_Modal extends WP_UnitTestCase {
+
+	/**
+	 * Register the shortcodes the tests put in block attributes.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_shortcode( 'modal_test_version', fn() => '7.1' );
+		add_shortcode( 'modal_test_link', fn() => 'https://wordpress.org/latest.zip' );
+		add_shortcode( 'modal_test_emits_shortcode', fn() => 'Get [modal_test_version]' );
+	}
+
+	/**
+	 * Remove the test shortcodes.
+	 */
+	public function tear_down() {
+		remove_shortcode( 'modal_test_version' );
+		remove_shortcode( 'modal_test_link' );
+		remove_shortcode( 'modal_test_emits_shortcode' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Render a modal block with the given attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string The rendered block.
+	 */
+	private function render_modal( array $attributes ): string {
+		return do_blocks(
+			'<!-- wp:wporg/modal ' . wp_json_encode( $attributes ) . ' -->' .
+			'<!-- wp:paragraph --><p>Inner</p><!-- /wp:paragraph -->' .
+			'<!-- /wp:wporg/modal -->'
+		);
+	}
+
+	/**
+	 * A shortcode in the label expands in the button text and the dialog's aria-label.
+	 */
+	public function test_expands_shortcodes_in_label_and_href() {
+		$output = $this->render_modal(
+			array(
+				'href'  => '[modal_test_link]',
+				'label' => 'Download WordPress [modal_test_version]',
+			)
+		);
+
+		$this->assertStringContainsString( '>Download WordPress 7.1</a>', $output );
+		$this->assertStringContainsString( 'aria-label="Download WordPress 7.1"', $output );
+		$this->assertStringContainsString( 'href="https://wordpress.org/latest.zip"', $output );
+		$this->assertStringNotContainsString( '[modal_test_', $output );
+	}
+
+	/**
+	 * Without an href the label renders in a button, expanded the same way.
+	 */
+	public function test_expands_shortcodes_in_button_label() {
+		$output = $this->render_modal( array( 'label' => 'Version [modal_test_version]' ) );
+
+		$this->assertStringContainsString( '>Version 7.1</button>', $output );
+		$this->assertStringNotContainsString( '<a', $output );
+	}
+
+	/**
+	 * Markup in the label is still filtered after the shortcode pass.
+	 */
+	public function test_label_markup_is_filtered_after_expansion() {
+		$output = $this->render_modal(
+			array( 'label' => 'Open <script>alert(1)</script><strong>[modal_test_version]</strong>' )
+		);
+
+		$this->assertStringContainsString( '<strong>7.1</strong>', $output );
+		$this->assertStringNotContainsString( '<script>', $output );
+		$this->assertStringContainsString( 'aria-label="Open 7.1"', $output );
+	}
+
+	/**
+	 * A shortcode the expansion emits is dropped rather than left for a later pass.
+	 */
+	public function test_shortcode_emitted_by_expansion_is_stripped() {
+		$output = $this->render_modal( array( 'label' => '[modal_test_emits_shortcode]' ) );
+
+		$this->assertStringContainsString( '>Get </button>', $output );
+		$this->assertStringNotContainsString( '[modal_test_version]', $output );
+	}
+}


### PR DESCRIPTION
The download button on https://wordpress.org/download/ has read "Download WordPress [latest_version]" since September 4 (Meta Trac #8143, reopened: https://meta.trac.wordpress.org/ticket/8143).

The download pattern carries that shortcode in the block's `label` attribute. Since wporg-parent-2021 moved pattern shortcodes from the rendered output to the pattern source (WordPress/wporg-parent-2021#183 and #184), block attributes are not reached anymore: `do_shortcode()` skips HTML comments, and block delimiters are HTML comments. The `href` attribute kept working only because #755 expands it in `render.php` itself.

This does the same for `label`. Expand it, drop anything the expansion emitted so `the_content` can't run it a second time, then `wp_kses_post()` and `esc_attr()` as before. The dialog's `aria-label` from #767 reads the same attribute, so it picks up the expanded value too.

## Tests

New `phpunit/test-modal.php` renders the block through `do_blocks()` and checks the button text, the `aria-label`, the `href`, that markup in the label is still filtered after the pass, and that a shortcode emitted by the expansion is dropped. On trunk all four fail, on this branch the suite is 30/30.

I grepped the block delimiters in wporg-main-2022 and in the themes in the wordpress.org repo for shortcodes. The download pattern's modal label is the only one, so nothing else is waiting on this.

## Testing it in a browser

The bug only shows when the modal is rendered from a template or a pattern. In post content `the_content` runs `do_shortcode()` over the output and hides it, so the page has to come from a block template. With `wp-env start` running from this repo:

1. Stand in for the theme shortcodes with a throwaway mu-plugin (don't commit it):

    ```php
    // mu-plugins/zz-demo-shortcodes.php
    <?php
    add_shortcode( 'latest_version', fn() => '7.1' );
    add_shortcode( 'download_link', fn() => 'https://wordpress.org/latest.zip' );
    ```

2. Create a `page-download` template holding the modal, and a page that uses it:

    ```sh
    npx wp-env run cli wp post create --post_type=wp_template --post_status=publish --post_name=page-download --post_title='Page: Download' --porcelain --post_content='<!-- wp:wporg/modal {"href":"[download_link]","label":"Download WordPress [latest_version]"} --><!-- wp:paragraph --><p>Howdy!</p><!-- /wp:paragraph --><!-- /wp:wporg/modal -->'
    npx wp-env run cli wp post term set <template id> wp_theme twentytwentyfive
    npx wp-env run cli wp post create --post_type=page --post_status=publish --post_name=download --post_title=Download --porcelain
    ```

3. Open `http://localhost:8888/?page_id=<page id>`. On trunk the button reads "Download WordPress [latest_version]", on this branch "Download WordPress 7.1". The `aria-label` on the `role="dialog"` element changes the same way.

If you swap `render.php` between trunk and the branch with the env running, give opcache a couple of seconds before reloading, it served me the old file once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
