### PR TITLE
REST API: Cache the locale banner per language

### DIFF
--- a/mu-plugins/rest-api/endpoints/class-wporg-base-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-base-locale-banner-controller.php
@@ -53,6 +53,29 @@ abstract class Base_Locale_Banner_Controller extends \WP_REST_Controller {
 	abstract public function check_slug( $param );
 
 	/**
+	 * Wrap a result in a response that caches per language.
+	 *
+	 * The suggestion depends on the Accept-Language header, so the response
+	 * has to vary by it or a shared cache serves one visitor's language to
+	 * everyone requesting the same URL.
+	 *
+	 * @param mixed $data Response data.
+	 * @return \WP_REST_Response
+	 */
+	protected function prepare_response( $data ) {
+		$result = new \WP_REST_Response( $data );
+
+		$result->header( 'Vary', 'Accept-Language' );
+		$result->header( 'Expires', gmdate( 'r', time() + HOUR_IN_SECONDS ) );
+		$result->header( 'Cache-Control', 'max-age=' . HOUR_IN_SECONDS );
+
+		// nginx only honours a single Vary header, and this API is only used by the same origin.
+		remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
+
+		return $result;
+	}
+
+	/**
 	 * Send the response as plain text so it can be used as-is.
 	 */
 	public function send_plain_text( $result ) {

--- a/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-plugins-locale-banner-controller.php
@@ -71,7 +71,7 @@ class Plugins_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 
 		// Return more information if this is a debug request.
 		if ( ! empty( $request['debug'] ) ) {
-			return new \WP_REST_Response(
+			return $this->prepare_response(
 				array(
 					'currentLocale' => $current_locale,
 					'suggestions' => $suggest_locales,
@@ -82,7 +82,7 @@ class Plugins_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 
 		// The result should be a raw text response.
 		add_filter( 'rest_pre_echo_response', array( $this, 'send_plain_text' ) );
-		return new \WP_REST_Response( $suggest_string );
+		return $this->prepare_response( $suggest_string );
 	}
 
 	/**
@@ -178,7 +178,7 @@ class Plugins_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 
 		// Return more information if this is a debug request.
 		if ( ! empty( $request['debug'] ) ) {
-			return new \WP_REST_Response(
+			return $this->prepare_response(
 				array(
 					'currentLocale' => $current_locale,
 					'suggestions' => $suggest_locales,
@@ -189,6 +189,6 @@ class Plugins_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 
 		// The result should be a raw text response.
 		add_filter( 'rest_pre_echo_response', array( $this, 'send_plain_text' ) );
-		return new \WP_REST_Response( $suggest_string );
+		return $this->prepare_response( $suggest_string );
 	}
 }

--- a/mu-plugins/rest-api/endpoints/class-wporg-themes-locale-banner-controller.php
+++ b/mu-plugins/rest-api/endpoints/class-wporg-themes-locale-banner-controller.php
@@ -68,7 +68,7 @@ class Themes_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 
 		// Return more information if this is a debug request.
 		if ( ! empty( $request['debug'] ) ) {
-			return new \WP_REST_Response(
+			return $this->prepare_response(
 				array(
 					'currentLocale' => $current_locale,
 					'suggestions' => $suggest_locales,
@@ -79,7 +79,7 @@ class Themes_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 
 		// The result should be a raw text response.
 		add_filter( 'rest_pre_echo_response', array( $this, 'send_plain_text' ) );
-		return new \WP_REST_Response( $suggest_string );
+		return $this->prepare_response( $suggest_string );
 	}
 
 	/**
@@ -174,7 +174,7 @@ class Themes_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 
 		// Return more information if this is a debug request.
 		if ( ! empty( $request['debug'] ) ) {
-			return new \WP_REST_Response(
+			return $this->prepare_response(
 				array(
 					'currentLocale' => $current_locale,
 					'suggestions' => $suggest_locales,
@@ -185,6 +185,6 @@ class Themes_Locale_Banner_Controller extends Base_Locale_Banner_Controller {
 
 		// The result should be a raw text response.
 		add_filter( 'rest_pre_echo_response', array( $this, 'send_plain_text' ) );
-		return new \WP_REST_Response( $suggest_string );
+		return $this->prepare_response( $suggest_string );
 	}
 }


### PR DESCRIPTION
The locale banner endpoints send no cache headers, so the edge cache keys them by URL alone. Every visitor on a page requests the same URL, and whichever visitor first populates a cache node decides what everyone else on that node sees until the entry expires. On `wordpress.org/themes/` that is usually the empty English response, so the banner never renders.

### Why

Observed on the themes root banner URL with browser request headers, all within a few minutes:

| Request `Accept-Language` | Edge cache | Body |
|---|---|---|
| `en-US` (Safari, `debug=1`, never cached) | MISS | no suggestion, as expected |
| `en-US` (Safari, real banner URL) | HIT | Italian banner |
| `en-US` (curl, real banner URL) | HIT | German banner |
| `de-DE`, `fr-FR` | EXPIRED | correct language |

The plugin directory's own endpoint has declared `Vary: Accept-Language` with a one hour lifetime since 2020 and is unaffected. The themes endpoint lives here and only carries the network-wide `Vary: accept, content-type` plus core's `Vary: Origin`, neither of which includes the language header.

### Changes

- `Base_Locale_Banner_Controller::prepare_response()` wraps the result with `Vary: Accept-Language`, `Expires`, and `Cache-Control: max-age=3600`, and removes `rest_send_cors_headers` so nginx sees a single `Vary` header. This is the plugin directory's contract, applied to both the text and `debug` responses.
- Both the themes and the (unused) plugins controller return through it.

Response headers set on `WP_REST_Response` are sent with `header()` replace semantics, so the language `Vary` overrides the network-wide one.

### Testing

- `php -l` and `phpcs` on the three files report no new findings against trunk.
- Cached entries for the current URLs will age out on their own; purging the `wporg-themes/v1/locale-banner` path after deploy restores the banners immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
